### PR TITLE
feat: add sync-issues command for triage-state-only sync (#412)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ You may want to rerun the command with the extra `--debug` flag to get more trou
 | `structure` | Group extracted projects into organizations |
 | `mappings` | Generate entity mapping CSVs |
 | `migrate` | Push configuration and data to SonarQube Cloud |
+| `sync-issues` | Sync issue/hotspot triage state from SonarQube Server to an already-migrated SonarQube Cloud project |
 | `wizard` | Interactive guided migration (terminal) |
 | `gui` | Browser-based guided migration |
 | `report` | Generate a migration or maturity report |

--- a/docs/SYNC-ISSUES.md
+++ b/docs/SYNC-ISSUES.md
@@ -1,0 +1,201 @@
+# Using `sync-issues` — Sync Issue & Hotspot Triage State
+
+`sync-issues` is a **standalone**, **triage-state-only** command. It syncs the manual triage work done on SonarQube Server — issue status changes, resolutions, tags, severities, and comments, plus Security Hotspot review status and comments — onto the matching, already-migrated projects on SonarQube Cloud. It does not touch project configuration (quality gates, quality profiles, permissions, settings) and does not create projects: the target project must already exist on SonarQube Cloud.
+
+Use it when you need to (re-)apply triage state independently of a full migration, without re-running `migrate` or `transfer`.
+
+---
+
+## When to use it
+
+- After `migrate --skip_project_data_migration` — the migration created the project's configuration only; once a real SonarQube Cloud scan has populated the project with its own analysis (and its own issue/hotspot keys), run `sync-issues` to bring over the triage decisions made on SonarQube Server.
+- As a **periodic re-sync** — triage work continues on SonarQube Server after a migration (new false-positives marked, new comments added, tags updated); `sync-issues` can be run again and again to keep SonarQube Cloud's triage state current, without repeating a full migration.
+- When `migrate`/`transfer` already ran project-data import but you want to re-apply triage state on demand (for example, after catching up a backlog of manual reviews on the source).
+
+If you need to migrate configuration or issue/hotspot **history** (not just triage state) for the first time, see [MIGRATE.md](MIGRATE.md) or [TRANSFER.md](TRANSFER.md) instead — both already run this same sync as their final step.
+
+---
+
+## What it does
+
+`sync-issues` always runs its own lightweight extract from SonarQube Server — it does **not** require a prior `extract` run. The extract pulls only issues and Security Hotspots that carry a manual triage signal: a non-default status, a custom tag, a manually-set severity, or one or more comments. Findings with no triage signal are not extracted, since there is nothing to sync.
+
+For each extracted finding, the command:
+
+1. Resolves the SonarQube Cloud target project from the source project key (see [Target project resolution](#target-project-resolution) below).
+2. Looks up the corresponding issue or hotspot on the target project using the [matching algorithm](#matching-algorithm) below.
+3. When exactly one match qualifies, applies the source's status, resolution, tags, severity, and comments to the matched Cloud finding, and records the sync (see [Idempotency & traceability](#idempotency--traceability)).
+4. When no match or several ambiguous matches are found, skips that finding — it is not modified, and no error is raised for it individually.
+
+---
+
+## Project scope
+
+By default, `sync-issues` targets **every project visible on the source SonarQube Server token** — the sync fans out across the whole instance. Pass one or more `--project_key` flags to narrow it to specific projects:
+
+```bash
+sonar-migration-tool sync-issues \
+  --project_key my-project \
+  --project_key another-project \
+  ...
+```
+
+Projects whose organization has no SonarQube Cloud mapping (see [Target project resolution](#target-project-resolution)) are silently excluded; they are not created.
+
+---
+
+## Target project resolution
+
+`sync-issues` resolves each source project's target SonarQube Cloud key with the **same `project_key_pattern` convention** used by `migrate` and `transfer`:
+
+- The target organization for a project comes from `structure`'s `organizations.csv` mapping (server → organization), falling back to `--default_organization` when no per-server mapping is set.
+- The target project key is rendered from `--project_key_pattern` (default `<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>`), the same template used across the tool — see [Project key renaming strategy in ADVANCED-CONFIG.md](ADVANCED-CONFIG.md#project-key-renaming-strategy) for the full placeholder reference and validation rules.
+- `sync-issues` runs its own `extract` + `structure` pass internally (producing `organizations.csv` / `projects.csv` in `--export_dir`), so you don't need to run either command yourself first. It does not run `mappings` — the profile/gate/group/template/portfolio mapping CSVs it produces aren't needed for a triage-state-only sync.
+
+If a rendered target key does not exist on SonarQube Cloud, its findings are logged as lookup failures rather than synced (it was presumably never migrated, or was migrated under a different pattern — pass `--project_key_pattern` explicitly if your migration used a non-default one).
+
+---
+
+## Quick start
+
+### With CLI flags
+
+```bash
+# From source
+cd go && go run . sync-issues \
+  --source_url https://sonarqube.example.com \
+  --source_token sqp_xxx \
+  --target_token squ_xxx \
+  --default_organization my-org
+
+# Built binary
+sonar-migration-tool sync-issues \
+  --source_url https://sonarqube.example.com \
+  --source_token sqp_xxx \
+  --target_token squ_xxx \
+  --default_organization my-org
+```
+
+Omitting `--project_key` syncs every project visible to the source token.
+
+### With a config file
+
+```bash
+# From source
+cd go && go run . sync-issues -c config.json
+
+# Built binary
+sonar-migration-tool sync-issues -c config.json
+```
+
+`config.json` uses the **same unified shape** as `extract`, `migrate`, and `transfer` — one top-level block of shared defaults plus `source` and `target` sub-objects. See [ADVANCED-CONFIG.md](ADVANCED-CONFIG.md) for the full reference.
+
+```json
+{
+  "concurrency": 25,
+  "timeout": 60,
+  "export_directory": "./migration-files",
+  "source": {
+    "url": "https://sonarqube.example.com",
+    "token": "sqp_xxx",
+    "pem_file_path": "/path/to/cert.pem",
+    "key_file_path": "/path/to/cert.key",
+    "cert_password": "optional"
+  },
+  "target": {
+    "url": "https://sonarcloud.io/",
+    "token": "squ_xxx",
+    "default_organization": "my-org",
+    "project_key_pattern": "<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>"
+  }
+}
+```
+
+---
+
+## Flags
+
+| Flag | Config key | Description |
+|------|------------|--------------|
+| `-c, --config` | — | Path to a JSON configuration file (see [ADVANCED-CONFIG.md](ADVANCED-CONFIG.md)) |
+| `--source_url` | `source.url` | SonarQube Server URL |
+| `--source_token` | `source.token` | SonarQube Server token |
+| `--project_key` | `project_key` | Project key to sync. Repeatable. Omit to sync every project visible to the source token. |
+| `--target_url` | `target.url` | SonarQube Cloud URL (default: `https://sonarcloud.io/`) |
+| `--target_token` | `target.token` | SonarQube Cloud token |
+| `--default_organization` | `target.default_organization` | SonarQube Cloud organization key, used as a fallback when `organizations.csv` has no mapping for a source project |
+| `--project_key_pattern` | `target.project_key_pattern` | Template for target project keys, built from `<ORIGINAL_PROJECT_KEY>` and `<ORGANIZATION_KEY>` (default: `<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>`) |
+| `--export_dir` | `export_directory` | Working directory for intermediate files (default: `./migration-files/`) |
+| `--concurrency` | `concurrency` | Max concurrent HTTP requests (default: `25`) |
+| `--timeout` | `timeout` | HTTP request timeout in seconds |
+| `--pem_file_path` | `source.pem_file_path` | Client mTLS PEM file for the source server |
+| `--key_file_path` | `source.key_file_path` | Client mTLS key file for the source server |
+| `--cert_password` | `source.cert_password` | Password for the source server mTLS client certificate |
+| `--debug` | — | Verbose troubleshooting logs |
+
+CLI flags override values from the config file when both are provided.
+
+> **No `--skip_issue_sync` / `--skip_project_data_migration` flags.** Unlike `migrate` and `transfer`, `sync-issues` has nothing else to skip — syncing triage state is its entire job. There is no configuration or project-data import to opt out of.
+
+---
+
+## Matching algorithm
+
+Because the source code analyzed on SonarQube Server may differ slightly from the code analyzed on SonarQube Cloud (different scanner version, minor code drift, or line-shifting changes), `sync-issues` does not assume an exact line-number match between a source finding and its Cloud counterpart. Instead it uses a two-phase matcher, adapted from the same approach used by [sonar-tools' `findings.py`](https://github.com/okorach/sonar-tools/blob/593226eb1492c54d1bfa282eb7ed4ba5bb44cea3/sonar/findings.py#L421) (`strictly_identical_to` / `almost_identical_to`):
+
+### Phase 1 — exact match
+
+A candidate on the target project is an exact match when its **rule**, **file**, **line**, and **message** all match the source finding exactly.
+
+- If **exactly one** exact match is found, the sync proceeds.
+- If **several** exact matches are found, the finding is **skipped as ambiguous** — the tool cannot tell which target finding corresponds to the source one.
+
+### Phase 2 — approximate match
+
+When no exact match is found, the matcher falls back to a **scored approximate match** against every candidate on the same file (or, if the file itself doesn't match exactly, against the project's candidates more broadly). Each candidate earns points, up to a maximum of **7**, across:
+
+| Signal | Points |
+|---|---|
+| Message — exact match | full credit |
+| Message — fuzzy match (edit-distance similarity) below the exact threshold | partial credit |
+| File | credit if the file matches |
+| Line | credit if the line matches (or is within a small offset) |
+| Type / rule offset | credit if the rule or finding type matches |
+| Severity | credit if the severity matches |
+| Author | credit if the reporting author matches |
+
+A candidate must score **at least 6 out of 7** to qualify as an approximate match.
+
+- If **exactly one** candidate qualifies, the sync proceeds against that candidate.
+- If **zero** or **several** candidates qualify, the finding is **skipped** — no match is confident enough (or more than one is equally plausible) to sync safely.
+
+This means `sync-issues` never guesses when there's ambiguity: a skipped finding is left untouched on SonarQube Cloud, and can be revisited manually or on a later run once the ambiguity is resolved (e.g. after a newer scan narrows the candidate set).
+
+---
+
+## Idempotency & traceability
+
+Every finding that syncs successfully is marked the same way `migrate` and `transfer` already mark project-data-imported findings — this behavior is not new, `sync-issues` just makes it reachable without a full migration:
+
+- The synced Cloud issue or hotspot gets a **`metadata-synchronized`** tag, so re-running `sync-issues` (or a later `migrate`/`transfer`) can recognize it was already synced.
+- Comments copied from the source are prefixed **`[Migrated from …]`** so their origin is clear alongside any comments added natively on SonarQube Cloud.
+- A one-line **`Link to [Original issue]`** (for issues) or **`Link to [Original hotspot]`** (for hotspots) comment is added on the Cloud finding, linking back to the corresponding finding on SonarQube Server.
+
+Because of this, `sync-issues` is safe to run repeatedly — on a schedule, after every SonarQube Server triage session, or on demand — without duplicating comments or re-tagging findings that are already in sync.
+
+---
+
+## Output
+
+- **Intermediate files** — written to `--export_dir` (default `./migration-files/`): the extract data plus `organizations.csv` / `projects.csv` from the internal `structure` pass.
+- **Stdout** — a final summary of projects synced and issue/hotspot counts (actionable, synced, skipped), followed by `Sync complete.`.
+- Skipped projects (no resolvable target) and skipped findings (ambiguous or no match) are logged so you can review them; pass `--debug` for verbose per-finding detail.
+
+---
+
+## Troubleshooting
+
+- **Project skipped, no target found** — confirm the project was actually migrated, and that `--project_key_pattern` / `--default_organization` match what was used at migration time. See [Project key renaming strategy](ADVANCED-CONFIG.md#project-key-renaming-strategy).
+- **Finding skipped as ambiguous** — several candidates scored high enough on the same file; this is expected when a file contains multiple very similar findings (e.g. duplicated code blocks). Re-run after a fresh Cloud scan reduces line drift, or resolve the ambiguity manually on SonarQube Cloud.
+- **Token errors** — see the [Token permissions](MIGRATE.md#token-permissions) section in MIGRATE.md.
+- **Anything else** — [TROUBLESHOOTING.md](TROUBLESHOOTING.md) has the full list of common errors.

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -57,6 +57,7 @@ func addCommands() {
 		structureCmd,
 		mappingsCmd,
 		migrateCmd,
+		syncIssuesCmd,
 		predictiveReportCmd,
 		resetCmd,
 		analysisReportCmd,

--- a/go/cmd/sync_issues.go
+++ b/go/cmd/sync_issues.go
@@ -1,0 +1,267 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/extract"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
+	"github.com/spf13/cobra"
+)
+
+const flagProjectKeys = "project_key"
+
+var syncIssuesCmd = &cobra.Command{
+	Use:   "sync-issues",
+	Short: "Sync issue/hotspot triage state from " + sqServerName + " to " + scCloudName,
+	Long: `sync-issues synchronises issue and Security Hotspot triage state (status,
+comments, tags) from a ` + sqServerName + ` instance to already-migrated ` + scCloudName + `
+projects, without running a full migrate/transfer.
+
+Use it after a migrate/transfer run with --skip_project_data_migration, once
+a real ` + scCloudName + ` scan has populated the project's issues, or as a
+standalone periodic re-sync of triage state.
+
+It runs its own lightweight extract from the source (issues and hotspots
+carrying any manual triage signal: non-default status, custom tags, manual
+severity, or comments) — no prior extract is required.
+
+By default every project visible on the source is synced; pass one or more
+--project_key flags to narrow the scope. Target project keys are resolved
+via the same project_key_pattern + organizations.csv convention migrate/
+transfer use.
+
+Example (flags):
+  sonar-migration-tool sync-issues \
+    --source_url https://sonarqube.example.com \
+    --source_token sqp_xxx \
+    --target_token squ_xxx \
+    --default_organization my-org
+
+Example (config file):
+  sonar-migration-tool sync-issues -c config.json
+
+config.json uses the common unified shape (same loader as extract / migrate /
+transfer):
+  {
+    "export_directory": "./migration-files",
+    "concurrency": 10,
+    "timeout": 60,
+    "source": {
+      "url": "https://sonarqube.example.com",
+      "token": "sqp_xxx"
+    },
+    "target": {
+      "url": "https://sonarcloud.io/",
+      "token": "squ_xxx",
+      "default_organization": "my-org"
+    }
+  }
+
+CLI flags always take precedence over values from the config file.`,
+	RunE: runSyncIssuesCmd,
+}
+
+func init() {
+	f := syncIssuesCmd.Flags()
+	f.StringP(flagConfig, "c", "", "Path to JSON configuration file (common shape with source / target sections)")
+	f.String(flagSourceURL, "", sqServerName+" URL (maps to source.url)")
+	f.String(flagSourceToken, "", sqServerName+" token (maps to source.token)")
+	f.StringSlice(flagProjectKeys, nil, "Project key to sync (repeatable; omit to sync every project on the source)")
+	f.String(flagTargetURL, "", scCloudName+" URL (maps to target.url, default: https://sonarcloud.io/)")
+	f.String(flagTargetToken, "", scCloudName+" token (maps to target.token)")
+	f.String(flagDefaultOrg, "", scCloudName+" organization key (maps to target.default_organization)")
+	f.String(flagProjectKeyPattern, "", "Template used to resolve each project's already-migrated target key, built from <ORIGINAL_PROJECT_KEY> and <ORGANIZATION_KEY> (maps to target.project_key_pattern; default: <ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>) — must match the pattern used when the projects were created")
+	f.String(flagEnterpriseKey, "", scCloudName+" enterprise key (maps to target.enterprise_key, defaults to --"+flagDefaultOrg+")")
+	f.String(flagExportDir, "./migration-files/", "Working directory for intermediate files (maps to export_directory)")
+	f.Int(flagConcurrency, 0, "Max concurrent requests (default: 25) (maps to concurrency)")
+	f.Int(flagTimeout, 0, "HTTP request timeout in seconds (maps to timeout; default: 60)")
+	f.String(flagPEMFilePath, "", "Path to client mTLS PEM file for the source server (maps to source.pem_file_path)")
+	f.String(flagKeyFilePath, "", "Path to client mTLS key file for the source server (maps to source.key_file_path)")
+	f.String(flagCertPassword, "", "Password for the source server mTLS client certificate (maps to source.cert_password)")
+	// --debug is inherited from the persistent root flag; see cmd/root.go.
+}
+
+// syncIssuesConfig holds the resolved configuration after merging file and
+// flag values. Mirrors transferConfig, minus the skip-flags (this command's
+// entire job is the sync) and the mandatory single-project requirement.
+type syncIssuesConfig struct {
+	sourceURL           string
+	sourceToken         string
+	projectKeys         []string
+	targetURL           string
+	targetToken         string
+	defaultOrganization string
+	projectKeyPattern   string
+	enterpriseKey       string
+	exportDir           string
+	concurrency         int
+	timeout             int
+	pemFilePath         string
+	keyFilePath         string
+	certPassword        string
+	debug               bool
+}
+
+// loadSyncIssuesFileDefaults reads the shared --config file via the same
+// loaders extract / migrate use, so sync-issues accepts every supported
+// config shape.
+func loadSyncIssuesFileDefaults(path string) (syncIssuesConfig, error) {
+	var cfg syncIssuesConfig
+	extractCfg, err := extract.LoadExtractConfigFile(path)
+	if err != nil {
+		return cfg, err
+	}
+	migrateCfg, err := migrate.LoadMigrateConfigFile(path)
+	if err != nil {
+		return cfg, err
+	}
+
+	cfg.sourceURL = extractCfg.URL
+	cfg.sourceToken = extractCfg.Token
+	cfg.targetURL = migrateCfg.URL
+	cfg.targetToken = migrateCfg.Token
+	cfg.enterpriseKey = migrateCfg.EnterpriseKey
+	cfg.defaultOrganization = migrateCfg.DefaultOrganization
+	cfg.projectKeyPattern = migrateCfg.ProjectKeyPattern
+
+	cfg.exportDir = extractCfg.ExportDirectory
+	if cfg.exportDir == "" {
+		cfg.exportDir = migrateCfg.ExportDirectory
+	}
+
+	switch {
+	case extractCfg.Concurrency != 0:
+		cfg.concurrency = extractCfg.Concurrency
+	case migrateCfg.Concurrency != 0:
+		cfg.concurrency = migrateCfg.Concurrency
+	}
+
+	cfg.timeout = extractCfg.Timeout
+	cfg.pemFilePath = extractCfg.PEMFilePath
+	cfg.keyFilePath = extractCfg.KeyFilePath
+	cfg.certPassword = extractCfg.CertPassword
+
+	cfg.debug = migrateCfg.Debug
+	return cfg, nil
+}
+
+func resolveSyncIssuesConfig(cmd *cobra.Command) (syncIssuesConfig, error) {
+	var cfg syncIssuesConfig
+
+	configFile, _ := cmd.Flags().GetString(flagConfig)
+	if configFile != "" {
+		loaded, err := loadSyncIssuesFileDefaults(configFile)
+		if err != nil {
+			return syncIssuesConfig{}, err
+		}
+		cfg = loaded
+	}
+
+	applyFlagString(cmd, flagSourceURL, &cfg.sourceURL)
+	applyFlagString(cmd, flagSourceToken, &cfg.sourceToken)
+	if cmd.Flags().Changed(flagProjectKeys) {
+		cfg.projectKeys, _ = cmd.Flags().GetStringSlice(flagProjectKeys)
+	}
+	applyFlagString(cmd, flagTargetURL, &cfg.targetURL)
+	applyFlagString(cmd, flagTargetToken, &cfg.targetToken)
+	applyFlagString(cmd, flagDefaultOrg, &cfg.defaultOrganization)
+	applyFlagString(cmd, flagProjectKeyPattern, &cfg.projectKeyPattern)
+	applyFlagString(cmd, flagEnterpriseKey, &cfg.enterpriseKey)
+	applyFlagString(cmd, flagExportDir, &cfg.exportDir)
+	applyFlagInt(cmd, flagConcurrency, &cfg.concurrency)
+	applyFlagInt(cmd, flagTimeout, &cfg.timeout)
+	applyFlagString(cmd, flagPEMFilePath, &cfg.pemFilePath)
+	applyFlagString(cmd, flagKeyFilePath, &cfg.keyFilePath)
+	applyFlagString(cmd, flagCertPassword, &cfg.certPassword)
+	applyFlagBool(cmd, flagDebug, &cfg.debug)
+
+	if cfg.exportDir == "" {
+		cfg.exportDir = "./migration-files/"
+	}
+	if cfg.enterpriseKey == "" {
+		cfg.enterpriseKey = cfg.defaultOrganization
+	}
+
+	return cfg, nil
+}
+
+func validateSyncIssuesConfig(cfg syncIssuesConfig) error {
+	if cfg.sourceURL == "" || cfg.sourceToken == "" {
+		return fmt.Errorf("%s URL and token are required (--%s / --%s or source.url / source.token in config file)", sqServerName, flagSourceURL, flagSourceToken)
+	}
+	if cfg.targetToken == "" || cfg.defaultOrganization == "" {
+		return fmt.Errorf("%s token and organization key are required (--%s / --%s or target.token / target.default_organization in config file)", scCloudName, flagTargetToken, flagDefaultOrg)
+	}
+	return nil
+}
+
+func runSyncIssuesCmd(cmd *cobra.Command, _ []string) error {
+	defer common.LogCommandDuration(slog.Default(), "sync-issues", time.Now())
+
+	cfg, err := resolveSyncIssuesConfig(cmd)
+	if err != nil {
+		return err
+	}
+	if err := validateSyncIssuesConfig(cfg); err != nil {
+		return err
+	}
+
+	ctx := cmd.Context()
+
+	printPhase(1, 3, "Extracting from "+sqServerName+"...")
+	skipped, err := extract.RunExtract(ctx, extract.ExtractConfig{
+		URL:                cfg.sourceURL,
+		Token:              cfg.sourceToken,
+		ExportDirectory:    cfg.exportDir,
+		ProjectKeys:        cfg.projectKeys,
+		Concurrency:        cfg.concurrency,
+		Timeout:            cfg.timeout,
+		PEMFilePath:        cfg.pemFilePath,
+		KeyFilePath:        cfg.keyFilePath,
+		CertPassword:       cfg.certPassword,
+		IncludeProjectData: true,
+		Debug:              cfg.debug,
+	})
+	if err != nil {
+		return fmt.Errorf("extract failed: %w", err)
+	}
+	warnSkippedProjects(skipped)
+
+	printPhase(2, 3, "Building organization structure...")
+	if err := structure.RunStructure(cfg.exportDir, cfg.defaultOrganization); err != nil {
+		return fmt.Errorf("structure failed: %w", err)
+	}
+
+	printPhase(3, 3, "Syncing issues and hotspots to "+scCloudName+"...")
+	summary, err := migrate.RunSyncIssues(ctx, migrate.SyncIssuesConfig{
+		URL:                 cfg.targetURL,
+		Token:               cfg.targetToken,
+		EnterpriseKey:       cfg.enterpriseKey,
+		ExportDirectory:     cfg.exportDir,
+		Concurrency:         cfg.concurrency,
+		Timeout:             cfg.timeout,
+		ProjectKeyPattern:   cfg.projectKeyPattern,
+		DefaultOrganization: cfg.defaultOrganization,
+		ProjectKeys:         cfg.projectKeys,
+		Debug:               cfg.debug,
+	})
+	if err != nil {
+		return fmt.Errorf("sync-issues failed: %w", err)
+	}
+
+	fmt.Printf("Projects synced: %d\n", summary.ProjectsSynced)
+	fmt.Printf("Issues:   %d actionable, %d synced, %d skipped (ambiguous or not found)\n",
+		summary.IssuesActionable, summary.IssuesSynced, summary.IssuesLineMismatch+summary.IssuesNotFound)
+	fmt.Printf("Hotspots: %d actionable, %d synced, %d acknowledged->to_review, %d skipped (ambiguous or not found)\n",
+		summary.HotspotsActionable, summary.HotspotsSynced, summary.HotspotsAckDemoted, summary.HotspotsLineMismatch+summary.HotspotsNotFound)
+	fmt.Println("Sync complete.")
+	return nil
+}

--- a/go/cmd/sync_issues_test.go
+++ b/go/cmd/sync_issues_test.go
@@ -1,0 +1,226 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newSyncIssuesTestCmd mirrors syncIssuesCmd's flag set so
+// resolveSyncIssuesConfig can be exercised in isolation without invoking RunE.
+func newSyncIssuesTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "sync-issues"}
+	f := cmd.Flags()
+	f.StringP(flagConfig, "c", "", "")
+	f.String(flagSourceURL, "", "")
+	f.String(flagSourceToken, "", "")
+	f.StringSlice(flagProjectKeys, nil, "")
+	f.String(flagTargetURL, "", "")
+	f.String(flagTargetToken, "", "")
+	f.String(flagDefaultOrg, "", "")
+	f.String(flagProjectKeyPattern, "", "")
+	f.String(flagEnterpriseKey, "", "")
+	f.String(flagExportDir, "./migration-files/", "")
+	f.Int(flagConcurrency, 0, "")
+	f.Int(flagTimeout, 0, "")
+	f.String(flagPEMFilePath, "", "")
+	f.String(flagKeyFilePath, "", "")
+	f.String(flagCertPassword, "", "")
+	f.Bool(flagDebug, false, "")
+	return cmd
+}
+
+func writeSyncIssuesConfig(t *testing.T, contents string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "cfg.json")
+	if err := os.WriteFile(p, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// sync-issues reads the common unified source/target config shape just
+// like extract, migrate and transfer do — same loader, same field names.
+func TestResolveSyncIssuesConfig_UnifiedConfigShape(t *testing.T) {
+	path := writeSyncIssuesConfig(t, `{
+		"concurrency": 7,
+		"timeout": 42,
+		"export_directory": "/tmp/from-cfg",
+		"source": {
+			"url": "https://sq.example.com",
+			"token": "sq-token",
+			"pem_file_path": "/cert/pem",
+			"key_file_path": "/cert/key",
+			"cert_password": "p4ss"
+		},
+		"target": {
+			"url": "https://sonarcloud.io/",
+			"token": "sc-token",
+			"enterprise_key": "ent-key",
+			"default_organization": "my-org",
+			"project_key_pattern": "acme_<ORIGINAL_PROJECT_KEY>"
+		}
+	}`)
+
+	cmd := newSyncIssuesTestCmd()
+	if err := cmd.ParseFlags([]string{"-c", path}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := resolveSyncIssuesConfig(cmd)
+	if err != nil {
+		t.Fatalf("resolveSyncIssuesConfig: %v", err)
+	}
+
+	want := syncIssuesConfig{
+		sourceURL:           "https://sq.example.com",
+		sourceToken:         "sq-token",
+		targetURL:           "https://sonarcloud.io/",
+		targetToken:         "sc-token",
+		defaultOrganization: "my-org",
+		projectKeyPattern:   "acme_<ORIGINAL_PROJECT_KEY>",
+		enterpriseKey:       "ent-key",
+		exportDir:           "/tmp/from-cfg",
+		concurrency:         7,
+		timeout:             42,
+		pemFilePath:         "/cert/pem",
+		keyFilePath:         "/cert/key",
+		certPassword:        "p4ss",
+	}
+	if !reflect.DeepEqual(cfg, want) {
+		t.Errorf("got %+v\nwant %+v", cfg, want)
+	}
+}
+
+// CLI flags must take precedence over config-file values, matching the
+// contract documented for extract/migrate/transfer.
+func TestResolveSyncIssuesConfig_CLIOverridesConfig(t *testing.T) {
+	path := writeSyncIssuesConfig(t, `{
+		"source": {"url": "https://from-cfg", "token": "cfg-source"},
+		"target": {"token": "cfg-target", "default_organization": "cfg-org"}
+	}`)
+
+	cmd := newSyncIssuesTestCmd()
+	if err := cmd.ParseFlags([]string{
+		"-c", path,
+		"--source_url", "https://from-flag",
+		"--target_token", "flag-target",
+		"--default_organization", "flag-org",
+		"--project_key", "proj-a",
+		"--project_key", "proj-b",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := resolveSyncIssuesConfig(cmd)
+	if err != nil {
+		t.Fatalf("resolveSyncIssuesConfig: %v", err)
+	}
+
+	if cfg.sourceURL != "https://from-flag" {
+		t.Errorf("sourceURL: got %q, want %q", cfg.sourceURL, "https://from-flag")
+	}
+	if cfg.sourceToken != "cfg-source" {
+		t.Errorf("sourceToken (config-only field): got %q, want %q", cfg.sourceToken, "cfg-source")
+	}
+	if cfg.targetToken != "flag-target" {
+		t.Errorf("targetToken: got %q, want %q", cfg.targetToken, "flag-target")
+	}
+	if cfg.defaultOrganization != "flag-org" {
+		t.Errorf("defaultOrganization: got %q, want %q", cfg.defaultOrganization, "flag-org")
+	}
+	if want := []string{"proj-a", "proj-b"}; !reflect.DeepEqual(cfg.projectKeys, want) {
+		t.Errorf("projectKeys: got %v, want %v", cfg.projectKeys, want)
+	}
+}
+
+// project_key is optional for sync-issues (unlike transfer, which is
+// project-scoped by design) — omitting it must resolve cleanly to an empty
+// filter meaning "every project".
+func TestResolveSyncIssuesConfig_ProjectKeyOptional(t *testing.T) {
+	cmd := newSyncIssuesTestCmd()
+	if err := cmd.ParseFlags([]string{
+		"--source_url", "https://sq",
+		"--source_token", "tok",
+		"--target_token", "ct",
+		"--default_organization", "my-org",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := resolveSyncIssuesConfig(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.projectKeys) != 0 {
+		t.Errorf("projectKeys: got %v, want empty", cfg.projectKeys)
+	}
+}
+
+func TestResolveSyncIssuesConfig_EnterpriseKeyDefaultsToOrg(t *testing.T) {
+	cmd := newSyncIssuesTestCmd()
+	if err := cmd.ParseFlags([]string{
+		"--source_url", "https://sq",
+		"--source_token", "tok",
+		"--target_token", "ct",
+		"--default_organization", "my-org",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := resolveSyncIssuesConfig(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.enterpriseKey != "my-org" {
+		t.Errorf("enterpriseKey: got %q, want %q", cfg.enterpriseKey, "my-org")
+	}
+}
+
+// Validation must error if either side is missing credentials — but,
+// unlike transfer, must NOT require a project key (sync-issues defaults to
+// every project on the source).
+func TestValidateSyncIssuesConfig_MissingFields(t *testing.T) {
+	cases := []struct {
+		name   string
+		cfg    syncIssuesConfig
+		errSub string
+	}{
+		{
+			name:   "missing source",
+			cfg:    syncIssuesConfig{targetToken: "t", defaultOrganization: "o"},
+			errSub: "--" + flagSourceURL,
+		},
+		{
+			name:   "missing target",
+			cfg:    syncIssuesConfig{sourceURL: "u", sourceToken: "t"},
+			errSub: "--" + flagTargetToken,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateSyncIssuesConfig(c.cfg)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !contains(err.Error(), c.errSub) {
+				t.Errorf("error %q does not mention %q", err.Error(), c.errSub)
+			}
+		})
+	}
+}
+
+func TestValidateSyncIssuesConfig_HappyPathNoProjectKey(t *testing.T) {
+	cfg := syncIssuesConfig{
+		sourceURL: "https://sq", sourceToken: "t",
+		targetToken: "ct", defaultOrganization: "o",
+	}
+	if err := validateSyncIssuesConfig(cfg); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}

--- a/go/internal/migrate/issuesync_branch_test.go
+++ b/go/internal/migrate/issuesync_branch_test.go
@@ -87,3 +87,103 @@ func TestResolveAndSyncHotspotLookupError(t *testing.T) {
 		t.Fatalf("want syncOutcomeLookupError, got %v", got)
 	}
 }
+
+// No cloud candidates on the source's file means resolveAndSyncIssue
+// reports not_found rather than synced or an error.
+func TestResolveAndSyncIssueNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/issues/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"issues": []map[string]any{},
+			"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 0},
+		})
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
+
+	src := matchableIssue{Key: "s1", Rule: "java:S100", Component: "src-proj:src/app.go", Line: 10, Message: "Do not do this"}
+	got := resolveAndSyncIssue(context.Background(), e, "cloud-proj", "cloud-org", "", "src-proj", src, nil)
+	if got != syncOutcomeNotFound {
+		t.Fatalf("want syncOutcomeNotFound, got %v", got)
+	}
+}
+
+// Two cloud candidates that both exactly match the source's file, line, and
+// message are ambiguous — resolveAndSyncIssue must skip (line_mismatch)
+// rather than guess.
+func TestResolveAndSyncIssueLineMismatch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/issues/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"issues": []map[string]any{
+				{"key": "iss-1", "rule": "java:S100", "component": "cloud-proj:src/app.go", "line": 10, "message": "Do not do this"},
+				{"key": "iss-2", "rule": "java:S100", "component": "cloud-proj:src/app.go", "line": 10, "message": "Do not do this"},
+			},
+			"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 2},
+		})
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
+
+	src := matchableIssue{Key: "s1", Rule: "java:S100", Component: "src-proj:src/app.go", Line: 10, Message: "Do not do this"}
+	got := resolveAndSyncIssue(context.Background(), e, "cloud-proj", "cloud-org", "", "src-proj", src, nil)
+	if got != syncOutcomeLineMismatch {
+		t.Fatalf("want syncOutcomeLineMismatch, got %v", got)
+	}
+}
+
+// No cloud candidates on the source's file means resolveAndSyncHotspot
+// reports not_found rather than synced or an error.
+func TestResolveAndSyncHotspotNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/hotspots/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"hotspots": []map[string]any{},
+			"paging":   map[string]any{"pageIndex": 1, "pageSize": 500, "total": 0},
+		})
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
+
+	src := matchableHotspot{Key: "h1", RuleKey: "rk1", Component: "src-proj:src/app.go", Line: 10, Message: "Review this"}
+	got := resolveAndSyncHotspot(context.Background(), e, "cloud-proj", "cloud-org", "", "src-proj", src, nil)
+	if got != syncOutcomeNotFound {
+		t.Fatalf("want syncOutcomeNotFound, got %v", got)
+	}
+}
+
+// Two cloud candidates that both exactly match the source's file, line, and
+// message are ambiguous — resolveAndSyncHotspot must skip (line_mismatch)
+// rather than guess.
+func TestResolveAndSyncHotspotLineMismatch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/hotspots/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"hotspots": []map[string]any{
+				{"key": "hs-1", "ruleKey": "rk1", "component": "cloud-proj:src/app.go", "line": 10, "message": "Review this"},
+				{"key": "hs-2", "ruleKey": "rk1", "component": "cloud-proj:src/app.go", "line": 10, "message": "Review this"},
+			},
+			"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 2},
+		})
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
+
+	src := matchableHotspot{Key: "h1", RuleKey: "rk1", Component: "src-proj:src/app.go", Line: 10, Message: "Review this"}
+	got := resolveAndSyncHotspot(context.Background(), e, "cloud-proj", "cloud-org", "", "src-proj", src, nil)
+	if got != syncOutcomeLineMismatch {
+		t.Fatalf("want syncOutcomeLineMismatch, got %v", got)
+	}
+}

--- a/go/internal/migrate/matchscore.go
+++ b/go/internal/migrate/matchscore.go
@@ -1,0 +1,234 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+// This file implements the exact-then-approximate matching algorithm
+// requested by issue #412, adapted from sonar-tools' findings.py
+// (strictly_identical_to / almost_identical_to). The SonarQube API exposes
+// no line-content hash for issues or hotspots, so the exact-match test and
+// the approximate score are built entirely from fields the search APIs
+// already return: rule, file, line, message, type/offset, severity, and
+// author.
+
+// levenshteinWithin reports whether the edit distance between a and b is at
+// most maxDist. Plain O(len(a)*len(b)) DP — inputs here are short issue and
+// hotspot messages, and each call only runs across a small, already
+// file+rule-scoped candidate set, so no bounded/banded optimisation is
+// warranted.
+func levenshteinWithin(a, b string, maxDist int) bool {
+	if a == b {
+		return true
+	}
+	ra, rb := []rune(a), []rune(b)
+	if abs(len(ra)-len(rb)) > maxDist {
+		return false
+	}
+	prev := make([]int, len(rb)+1)
+	curr := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		curr[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(rb)] <= maxDist
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+func min3(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
+}
+
+// messageApproxDistance is the maximum edit distance for two messages to be
+// considered "similar" by the approximate scorer, mirroring sonar-tools'
+// Levenshtein.distance(...) <= 5 cutoff.
+const messageApproxDistance = 5
+
+// issueApproxMatchThreshold is the minimum score (out of a 7-point maximum,
+// see issueMatchScore) an approximate candidate must reach to qualify.
+// Mirrors sonar-tools' "need at least 7/8" ratio (~87.5%), adapted to the
+// smaller point scale used here since no hash-based tie-break is available.
+const issueApproxMatchThreshold = 6
+
+// issueMatchScore scores how well candidate matches source, mirroring
+// sonar-tools' almost_identical_to. Returns -1 when the rule differs — a
+// rule mismatch is a hard rejection, never a candidate. Otherwise the score
+// (0-7) accumulates: message exact (+2) or edit-distance-similar (+1); file
+// equal (+1); line equal (+1); type equal (+1); severity equal (+1); author
+// equal (+1).
+func issueMatchScore(source, candidate matchableIssue) int {
+	if source.Rule != candidate.Rule {
+		return -1
+	}
+	score := 0
+	switch {
+	case source.Message == candidate.Message:
+		score += 2
+	case levenshteinWithin(source.Message, candidate.Message, messageApproxDistance):
+		score++
+	}
+	if source.Component == candidate.Component {
+		score++
+	}
+	if source.Line == candidate.Line {
+		score++
+	}
+	if source.Type == candidate.Type {
+		score++
+	}
+	if source.Severity == candidate.Severity {
+		score++
+	}
+	if source.Author == candidate.Author {
+		score++
+	}
+	return score
+}
+
+// classifyIssueCandidatesByScore resolves a cloud counterpart for one
+// source issue from the per-file+rule candidate set returned by
+// /api/issues/search (issue #412).
+//
+// Phase 1 — exact match: file, line and message all equal (rule is already
+// guaranteed equal by the scoped Cloud search; a line-content hash, which
+// sonar-tools' strictly_identical_to also checks, is not exposed by the
+// SonarQube API and is therefore omitted). Exactly one exact match syncs;
+// several is reported as ambiguous.
+//
+// Phase 2 — approximate match: every candidate is scored via
+// issueMatchScore; those scoring >= issueApproxMatchThreshold qualify.
+// Zero qualifying candidates → not_found; exactly one → synced; several →
+// ambiguous (line_mismatch) — the literal decision tree from issue #412,
+// rather than sonar-tools' own smallest-line-gap tiebreak.
+func classifyIssueCandidatesByScore(candidates []matchableIssue, source matchableIssue) (matchableIssue, syncOutcome) {
+	var exact []matchableIssue
+	for _, c := range candidates {
+		if c.Component == source.Component && c.Line == source.Line && c.Message == source.Message {
+			exact = append(exact, c)
+		}
+	}
+	switch len(exact) {
+	case 0:
+		// Fall through to approximate scoring.
+	case 1:
+		return exact[0], syncOutcomeSynced
+	default:
+		return matchableIssue{}, syncOutcomeLineMismatch
+	}
+
+	var approx []matchableIssue
+	for _, c := range candidates {
+		if issueMatchScore(source, c) >= issueApproxMatchThreshold {
+			approx = append(approx, c)
+		}
+	}
+	switch len(approx) {
+	case 0:
+		return matchableIssue{}, syncOutcomeNotFound
+	case 1:
+		return approx[0], syncOutcomeSynced
+	default:
+		return matchableIssue{}, syncOutcomeLineMismatch
+	}
+}
+
+// hotspotApproxMatchThreshold mirrors issueApproxMatchThreshold for
+// hotspots (see hotspotMatchScore's 7-point scale).
+const hotspotApproxMatchThreshold = 6
+
+// hotspotMatchScore scores how well candidate matches source, the hotspot
+// counterpart of issueMatchScore. Returns -1 when both sides carry a
+// non-empty rule key that differs — an empty rule key on either side is
+// tolerated (preserving the pre-#412 "empty-rule fallback": some SonarQube
+// versions/endpoints omit ruleKey from hotspot search results entirely).
+// Otherwise the score (0-7) accumulates: message exact (+2) or
+// edit-distance-similar (+1); file equal (+1); line equal (+1); textRange
+// offset equal when both sides carry a real (>0) offset (+1);
+// vulnerabilityProbability equal (+1); author equal (+1).
+func hotspotMatchScore(source, candidate matchableHotspot) int {
+	if source.RuleKey != "" && candidate.RuleKey != "" && source.RuleKey != candidate.RuleKey {
+		return -1
+	}
+	score := 0
+	switch {
+	case source.Message == candidate.Message:
+		score += 2
+	case levenshteinWithin(source.Message, candidate.Message, messageApproxDistance):
+		score++
+	}
+	if source.Component == candidate.Component {
+		score++
+	}
+	if source.Line == candidate.Line {
+		score++
+	}
+	if source.Offset > 0 && candidate.Offset > 0 && source.Offset == candidate.Offset {
+		score++
+	}
+	if source.VulnerabilityProbability == candidate.VulnerabilityProbability {
+		score++
+	}
+	if source.Author == candidate.Author {
+		score++
+	}
+	return score
+}
+
+// classifyHotspotCandidatesByScore is the hotspot counterpart of
+// classifyIssueCandidatesByScore (issue #412), using file+line+message for
+// the exact-match phase and hotspotMatchScore for the approximate phase.
+func classifyHotspotCandidatesByScore(candidates []matchableHotspot, source matchableHotspot) (matchableHotspot, syncOutcome) {
+	var exact []matchableHotspot
+	for _, c := range candidates {
+		if (source.RuleKey == "" || c.RuleKey == "" || c.RuleKey == source.RuleKey) &&
+			c.Component == source.Component && c.Line == source.Line && c.Message == source.Message {
+			exact = append(exact, c)
+		}
+	}
+	switch len(exact) {
+	case 0:
+		// Fall through to approximate scoring.
+	case 1:
+		return exact[0], syncOutcomeSynced
+	default:
+		return matchableHotspot{}, syncOutcomeLineMismatch
+	}
+
+	var approx []matchableHotspot
+	for _, c := range candidates {
+		if hotspotMatchScore(source, c) >= hotspotApproxMatchThreshold {
+			approx = append(approx, c)
+		}
+	}
+	switch len(approx) {
+	case 0:
+		return matchableHotspot{}, syncOutcomeNotFound
+	case 1:
+		return approx[0], syncOutcomeSynced
+	default:
+		return matchableHotspot{}, syncOutcomeLineMismatch
+	}
+}

--- a/go/internal/migrate/matchscore.go
+++ b/go/internal/migrate/matchscore.go
@@ -90,7 +90,7 @@ func issueMatchScore(source, candidate matchableIssue) int {
 	case levenshteinWithin(source.Message, candidate.Message, messageApproxDistance):
 		score++
 	}
-	if source.Component == candidate.Component {
+	if stripProjectKeyPrefix(source.Component) == stripProjectKeyPrefix(candidate.Component) {
 		score++
 	}
 	if source.Line == candidate.Line {
@@ -126,7 +126,8 @@ func issueMatchScore(source, candidate matchableIssue) int {
 func classifyIssueCandidatesByScore(candidates []matchableIssue, source matchableIssue) (matchableIssue, syncOutcome) {
 	var exact []matchableIssue
 	for _, c := range candidates {
-		if c.Component == source.Component && c.Line == source.Line && c.Message == source.Message {
+		if stripProjectKeyPrefix(c.Component) == stripProjectKeyPrefix(source.Component) &&
+			c.Line == source.Line && c.Message == source.Message {
 			exact = append(exact, c)
 		}
 	}
@@ -179,7 +180,7 @@ func hotspotMatchScore(source, candidate matchableHotspot) int {
 	case levenshteinWithin(source.Message, candidate.Message, messageApproxDistance):
 		score++
 	}
-	if source.Component == candidate.Component {
+	if stripProjectKeyPrefix(source.Component) == stripProjectKeyPrefix(candidate.Component) {
 		score++
 	}
 	if source.Line == candidate.Line {
@@ -204,7 +205,8 @@ func classifyHotspotCandidatesByScore(candidates []matchableHotspot, source matc
 	var exact []matchableHotspot
 	for _, c := range candidates {
 		if (source.RuleKey == "" || c.RuleKey == "" || c.RuleKey == source.RuleKey) &&
-			c.Component == source.Component && c.Line == source.Line && c.Message == source.Message {
+			stripProjectKeyPrefix(c.Component) == stripProjectKeyPrefix(source.Component) &&
+			c.Line == source.Line && c.Message == source.Message {
 			exact = append(exact, c)
 		}
 	}

--- a/go/internal/migrate/sync_issues_standalone.go
+++ b/go/internal/migrate/sync_issues_standalone.go
@@ -1,0 +1,264 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync/atomic"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
+	sqapi "github.com/sonar-solutions/sq-api-go"
+	"github.com/sonar-solutions/sq-api-go/cloud"
+)
+
+// SyncIssuesConfig holds the parameters for a standalone sync-issues run
+// (issue #412). Unlike MigrateConfig, there is no project-creation or
+// configuration-provisioning here — every target project is assumed to
+// already exist in SonarQube Cloud (created by a prior migrate/transfer, or
+// scanned directly).
+type SyncIssuesConfig struct {
+	URL           string // SonarQube Cloud URL (default: https://sonarcloud.io/)
+	Token         string
+	EnterpriseKey string
+
+	ExportDirectory string
+	Concurrency     int
+	Timeout         int
+
+	// ProjectKeyPattern must match the pattern used when the target
+	// projects were created, so the rendered keys resolve to the same
+	// SonarQube Cloud projects. Defaults to DefaultProjectKeyPattern.
+	ProjectKeyPattern string
+
+	// DefaultOrganization is used as the SonarCloud org for every row in
+	// organizations.csv if none have a sonarcloud_org_key. See
+	// applyOrgMapping.
+	DefaultOrganization string
+
+	// ProjectKeys, when non-empty, restricts the sync to these source
+	// project keys. Empty means every project found in projects.csv.
+	ProjectKeys []string
+
+	Debug bool
+}
+
+func (cfg *SyncIssuesConfig) applyDefaults() {
+	if cfg.Concurrency <= 0 {
+		cfg.Concurrency = 25
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 60
+	}
+	if cfg.ExportDirectory == "" {
+		cfg.ExportDirectory = "./migration-files/"
+	}
+	if cfg.URL == "" {
+		cfg.URL = "https://sonarcloud.io/"
+	}
+	if strings.TrimSpace(cfg.ProjectKeyPattern) == "" {
+		cfg.ProjectKeyPattern = DefaultProjectKeyPattern
+	}
+	if cfg.URL != "" && cfg.URL[len(cfg.URL)-1] != '/' {
+		cfg.URL += "/"
+	}
+}
+
+// SyncIssuesSummary aggregates the per-project stats from every synced
+// project so the caller can print a run-wide total.
+type SyncIssuesSummary struct {
+	ProjectsSynced int
+
+	IssuesActionable     int64
+	IssuesSynced         int64
+	IssuesLineMismatch   int64
+	IssuesNotFound       int64
+	HotspotsActionable   int64
+	HotspotsSynced       int64
+	HotspotsLineMismatch int64
+	HotspotsNotFound     int64
+	HotspotsAckDemoted   int64
+}
+
+// syncTarget is the {source project, resolved Cloud project} tuple driving
+// one project's sync — the same shape the createProjects task output
+// carries (cloud_project_key, sonarcloud_org_key, server_url, key), built
+// here directly from projects.csv + organizations.csv instead of from a
+// migrate run's task store.
+type syncTarget struct {
+	Key             string // source (SonarQube Server) project key
+	ServerURL       string
+	CloudProjectKey string
+	OrgKey          string
+}
+
+// RunSyncIssues is the entry point for the standalone sync-issues command
+// (issue #412). It resolves every source project to its already-migrated
+// SonarQube Cloud counterpart via the same project_key_pattern +
+// organizations.csv convention `createProjects` uses, then runs the
+// existing issue/hotspot metadata sync (transitions, comments, tags,
+// back-links — unchanged) against each one directly, without going through
+// the migrate task planner/DAG.
+func RunSyncIssues(ctx context.Context, cfg SyncIssuesConfig) (SyncIssuesSummary, error) {
+	cfg.applyDefaults()
+
+	var summary SyncIssuesSummary
+
+	level := slog.LevelInfo
+	if cfg.Debug {
+		level = slog.LevelDebug
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+
+	if err := ValidateProjectKeyPattern(cfg.ProjectKeyPattern); err != nil {
+		return summary, common.NewExitError(2, fmt.Errorf("invalid project_key_pattern: %w", err))
+	}
+
+	appliedDefault, err := applyOrgMapping(cfg.ExportDirectory, cfg.DefaultOrganization, logger)
+	if err != nil {
+		return summary, err
+	}
+
+	cloudURL := cfg.URL
+	clientOpts := []sqapi.Option{sqapi.WithTimeout(cfg.Timeout)}
+	if cfg.Debug {
+		clientOpts = append(clientOpts, sqapi.WithDebugLogger(common.NewHTTPDebugLogger(logger)))
+	}
+	cloudClient := sqapi.NewCloudClient(cloudURL, cfg.Token, clientOpts...)
+	cc := cloud.New(cloudClient)
+	raw := common.NewRawClient(cloudClient.HTTPClient(), cloudClient.BaseURL())
+
+	if err := validateOrgsExist(ctx, cc.Organizations, cfg.ExportDirectory, cfg.EnterpriseKey, cfg.DefaultOrganization, appliedDefault); err != nil {
+		return summary, err
+	}
+	if err := validatePatternOrgCollision(ctx, cc.Organizations, cfg.ProjectKeyPattern); err != nil {
+		return summary, err
+	}
+
+	mapping, err := structure.GetUniqueExtracts(cfg.ExportDirectory)
+	if err != nil {
+		return summary, fmt.Errorf("scanning extracts: %w", err)
+	}
+
+	targets, err := resolveSyncTargets(cfg.ExportDirectory, cfg.ProjectKeyPattern, cfg.ProjectKeys)
+	if err != nil {
+		return summary, err
+	}
+	if len(targets) == 0 {
+		logger.Warn("sync-issues: no matching projects found in projects.csv")
+		return summary, nil
+	}
+
+	e := &Executor{
+		Cloud:             cc,
+		Raw:               raw,
+		ExportDir:         cfg.ExportDirectory,
+		Mapping:           mapping,
+		Sem:               make(chan struct{}, cfg.Concurrency),
+		ProjectKeyPattern: cfg.ProjectKeyPattern,
+		Logger:            logger,
+	}
+
+	ruleDefaults := loadRuleTagDefaults(e)
+	counter := NewTaskCounter("syncIssues")
+
+	var issuesActionable, issuesSynced, issuesMismatch, issuesNotFound atomic.Int64
+	var hotspotsActionable, hotspotsSynced, hotspotsMismatch, hotspotsNotFound, hotspotsAck atomic.Int64
+
+	runProjectSyncLoop(ctx, e, targets, "sync-issues: projects", 5,
+		func(gctx context.Context, t syncTarget) {
+			logger.Info("sync-issues: syncing project", "source_key", t.Key, "cloud_project_key", t.CloudProjectKey, "org", t.OrgKey)
+
+			iStats := syncProjectIssues(gctx, e, t.CloudProjectKey, t.OrgKey, t.ServerURL, t.Key, counter, ruleDefaults)
+			issuesActionable.Add(iStats.Actionable)
+			issuesSynced.Add(iStats.A)
+			issuesMismatch.Add(iStats.B)
+			issuesNotFound.Add(iStats.C)
+
+			hResult := syncProjectHotspots(gctx, e, syncHotspotInput{
+				CloudKey:  t.CloudProjectKey,
+				OrgKey:    t.OrgKey,
+				ServerURL: t.ServerURL,
+				ServerKey: t.Key,
+			})
+			hotspotsActionable.Add(hResult.Stats.Actionable)
+			hotspotsSynced.Add(hResult.Stats.A)
+			hotspotsMismatch.Add(hResult.Stats.B)
+			hotspotsNotFound.Add(hResult.Stats.C)
+			hotspotsAck.Add(hResult.Stats.AckDemoted)
+		})
+
+	summary = SyncIssuesSummary{
+		ProjectsSynced:       len(targets),
+		IssuesActionable:     issuesActionable.Load(),
+		IssuesSynced:         issuesSynced.Load(),
+		IssuesLineMismatch:   issuesMismatch.Load(),
+		IssuesNotFound:       issuesNotFound.Load(),
+		HotspotsActionable:   hotspotsActionable.Load(),
+		HotspotsSynced:       hotspotsSynced.Load(),
+		HotspotsLineMismatch: hotspotsMismatch.Load(),
+		HotspotsNotFound:     hotspotsNotFound.Load(),
+		HotspotsAckDemoted:   hotspotsAck.Load(),
+	}
+	logger.Info("sync-issues: run complete",
+		"projects", summary.ProjectsSynced,
+		"issues_synced", summary.IssuesSynced, "issues_skipped", summary.IssuesLineMismatch+summary.IssuesNotFound,
+		"hotspots_synced", summary.HotspotsSynced, "hotspots_skipped", summary.HotspotsLineMismatch+summary.HotspotsNotFound,
+	)
+	return summary, nil
+}
+
+// resolveSyncTargets reads projects.csv + organizations.csv from exportDir
+// and computes each project's target SonarQube Cloud project key, exactly
+// mirroring what the createProjects task does (tasks_create.go:68) so
+// sync-issues resolves to the SAME already-migrated Cloud project.
+// Projects whose org is unmapped (shouldSkipOrg) or that aren't in
+// projectKeys (when non-empty) are excluded.
+func resolveSyncTargets(exportDir, pattern string, projectKeys []string) ([]syncTarget, error) {
+	rows, err := structure.LoadCSV(exportDir, "projects.csv")
+	if err != nil {
+		return nil, fmt.Errorf("loading projects.csv: %w", err)
+	}
+	orgLookup, err := buildOrgKeyLookup(exportDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading organizations.csv: %w", err)
+	}
+
+	var wanted map[string]bool
+	if len(projectKeys) > 0 {
+		wanted = make(map[string]bool, len(projectKeys))
+		for _, k := range projectKeys {
+			wanted[k] = true
+		}
+	}
+
+	var targets []syncTarget
+	for _, row := range rows {
+		key, _ := row["key"].(string)
+		if key == "" {
+			continue
+		}
+		if wanted != nil && !wanted[key] {
+			continue
+		}
+		serverURL, _ := row["server_url"].(string)
+		sourceOrgKey, _ := row["sonarqube_org_key"].(string)
+		orgKey := orgLookup[sourceOrgKey]
+		if shouldSkipOrg(orgKey) {
+			continue
+		}
+		targets = append(targets, syncTarget{
+			Key:             key,
+			ServerURL:       serverURL,
+			CloudProjectKey: RenderProjectKey(pattern, key, orgKey),
+			OrgKey:          orgKey,
+		})
+	}
+	return targets, nil
+}

--- a/go/internal/migrate/sync_issues_standalone_test.go
+++ b/go/internal/migrate/sync_issues_standalone_test.go
@@ -1,0 +1,115 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// writeSyncTargetCSVs writes minimal projects.csv / organizations.csv
+// fixtures into dir — only the columns resolveSyncTargets actually reads.
+func writeSyncTargetCSVs(t *testing.T, dir, projectsCSV, orgsCSV string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "projects.csv"), []byte(projectsCSV), 0o644); err != nil {
+		t.Fatalf("write projects.csv: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "organizations.csv"), []byte(orgsCSV), 0o644); err != nil {
+		t.Fatalf("write organizations.csv: %v", err)
+	}
+}
+
+func TestResolveSyncTargets(t *testing.T) {
+	orgsCSV := "sonarqube_org_key,sonarcloud_org_key\n" +
+		"src-org,my-cloud-org\n" +
+		"unmapped-org,\n"
+
+	tests := []struct {
+		name        string
+		projectsCSV string
+		pattern     string
+		projectKeys []string
+		want        []syncTarget
+	}{
+		{
+			name: "renders cloud key from default pattern",
+			projectsCSV: "key,server_url,sonarqube_org_key\n" +
+				"proj-a,https://sqs.example.com,src-org\n",
+			pattern: DefaultProjectKeyPattern,
+			want: []syncTarget{
+				{Key: "proj-a", ServerURL: "https://sqs.example.com", CloudProjectKey: "my-cloud-org_proj-a", OrgKey: "my-cloud-org"},
+			},
+		},
+		{
+			name: "custom pattern",
+			projectsCSV: "key,server_url,sonarqube_org_key\n" +
+				"proj-a,https://sqs.example.com,src-org\n",
+			pattern: "acme_<ORIGINAL_PROJECT_KEY>",
+			want: []syncTarget{
+				{Key: "proj-a", ServerURL: "https://sqs.example.com", CloudProjectKey: "acme_proj-a", OrgKey: "my-cloud-org"},
+			},
+		},
+		{
+			name: "unmapped org is skipped",
+			projectsCSV: "key,server_url,sonarqube_org_key\n" +
+				"proj-a,https://sqs.example.com,src-org\n" +
+				"proj-b,https://sqs.example.com,unmapped-org\n",
+			pattern: DefaultProjectKeyPattern,
+			want: []syncTarget{
+				{Key: "proj-a", ServerURL: "https://sqs.example.com", CloudProjectKey: "my-cloud-org_proj-a", OrgKey: "my-cloud-org"},
+			},
+		},
+		{
+			name: "unknown org key (not in organizations.csv) is skipped",
+			projectsCSV: "key,server_url,sonarqube_org_key\n" +
+				"proj-a,https://sqs.example.com,src-org\n" +
+				"proj-c,https://sqs.example.com,never-heard-of-it\n",
+			pattern: DefaultProjectKeyPattern,
+			want: []syncTarget{
+				{Key: "proj-a", ServerURL: "https://sqs.example.com", CloudProjectKey: "my-cloud-org_proj-a", OrgKey: "my-cloud-org"},
+			},
+		},
+		{
+			name: "projectKeys filter narrows to the requested project",
+			projectsCSV: "key,server_url,sonarqube_org_key\n" +
+				"proj-a,https://sqs.example.com,src-org\n" +
+				"proj-b,https://sqs.example.com,src-org\n",
+			pattern:     DefaultProjectKeyPattern,
+			projectKeys: []string{"proj-b"},
+			want: []syncTarget{
+				{Key: "proj-b", ServerURL: "https://sqs.example.com", CloudProjectKey: "my-cloud-org_proj-b", OrgKey: "my-cloud-org"},
+			},
+		},
+		{
+			name:        "empty projects.csv — no targets",
+			projectsCSV: "key,server_url,sonarqube_org_key\n",
+			pattern:     DefaultProjectKeyPattern,
+			want:        nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeSyncTargetCSVs(t, dir, tc.projectsCSV, orgsCSV)
+
+			got, err := resolveSyncTargets(dir, tc.pattern, tc.projectKeys)
+			if err != nil {
+				t.Fatalf("resolveSyncTargets: %v", err)
+			}
+			sort.Slice(got, func(i, j int) bool { return got[i].Key < got[j].Key })
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d targets, want %d: %+v", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("target[%d] = %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/go/internal/migrate/sync_issues_standalone_test.go
+++ b/go/internal/migrate/sync_issues_standalone_test.go
@@ -5,11 +5,61 @@
 package migrate
 
 import (
+	"context"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sort"
 	"testing"
 )
+
+func TestApplyDefaults(t *testing.T) {
+	cfg := SyncIssuesConfig{}
+	cfg.applyDefaults()
+
+	if cfg.Concurrency != 25 {
+		t.Errorf("Concurrency = %d, want 25", cfg.Concurrency)
+	}
+	if cfg.Timeout != 60 {
+		t.Errorf("Timeout = %d, want 60", cfg.Timeout)
+	}
+	if cfg.ExportDirectory != "./migration-files/" {
+		t.Errorf("ExportDirectory = %q, want ./migration-files/", cfg.ExportDirectory)
+	}
+	if cfg.URL != "https://sonarcloud.io/" {
+		t.Errorf("URL = %q, want https://sonarcloud.io/", cfg.URL)
+	}
+	if cfg.ProjectKeyPattern != DefaultProjectKeyPattern {
+		t.Errorf("ProjectKeyPattern = %q, want %q", cfg.ProjectKeyPattern, DefaultProjectKeyPattern)
+	}
+}
+
+func TestApplyDefaultsPreservesExplicitValuesAndAddsTrailingSlash(t *testing.T) {
+	cfg := SyncIssuesConfig{
+		Concurrency:       3,
+		Timeout:           5,
+		ExportDirectory:   "/tmp/custom",
+		URL:               "https://sqc.example.com",
+		ProjectKeyPattern: "acme_<ORIGINAL_PROJECT_KEY>",
+	}
+	cfg.applyDefaults()
+
+	if cfg.Concurrency != 3 {
+		t.Errorf("Concurrency = %d, want 3 (explicit value preserved)", cfg.Concurrency)
+	}
+	if cfg.Timeout != 5 {
+		t.Errorf("Timeout = %d, want 5 (explicit value preserved)", cfg.Timeout)
+	}
+	if cfg.ExportDirectory != "/tmp/custom" {
+		t.Errorf("ExportDirectory = %q, want /tmp/custom (explicit value preserved)", cfg.ExportDirectory)
+	}
+	if cfg.URL != "https://sqc.example.com/" {
+		t.Errorf("URL = %q, want trailing slash appended", cfg.URL)
+	}
+	if cfg.ProjectKeyPattern != "acme_<ORIGINAL_PROJECT_KEY>" {
+		t.Errorf("ProjectKeyPattern = %q, want explicit value preserved", cfg.ProjectKeyPattern)
+	}
+}
 
 // writeSyncTargetCSVs writes minimal projects.csv / organizations.csv
 // fixtures into dir — only the columns resolveSyncTargets actually reads.
@@ -90,6 +140,16 @@ func TestResolveSyncTargets(t *testing.T) {
 			pattern:     DefaultProjectKeyPattern,
 			want:        nil,
 		},
+		{
+			name: "row with empty key is skipped",
+			projectsCSV: "key,server_url,sonarqube_org_key\n" +
+				",https://sqs.example.com,src-org\n" +
+				"proj-a,https://sqs.example.com,src-org\n",
+			pattern: DefaultProjectKeyPattern,
+			want: []syncTarget{
+				{Key: "proj-a", ServerURL: "https://sqs.example.com", CloudProjectKey: "my-cloud-org_proj-a", OrgKey: "my-cloud-org"},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -111,5 +171,149 @@ func TestResolveSyncTargets(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestResolveSyncTargetsLoadProjectsCSVError(t *testing.T) {
+	dir := t.TempDir()
+	// Malformed CSV (inconsistent field count) makes the reader return an
+	// error rather than the "missing file" nil,nil case.
+	if err := os.WriteFile(filepath.Join(dir, "projects.csv"), []byte("key,server_url\nproj-a\n"), 0o644); err != nil {
+		t.Fatalf("write projects.csv: %v", err)
+	}
+
+	if _, err := resolveSyncTargets(dir, DefaultProjectKeyPattern, nil); err == nil {
+		t.Fatal("resolveSyncTargets: want error for malformed projects.csv, got nil")
+	}
+}
+
+func TestResolveSyncTargetsLoadOrganizationsCSVError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "projects.csv"), []byte("key,server_url,sonarqube_org_key\nproj-a,https://sqs.example.com,src-org\n"), 0o644); err != nil {
+		t.Fatalf("write projects.csv: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "organizations.csv"), []byte("sonarqube_org_key,sonarcloud_org_key\nsrc-org\n"), 0o644); err != nil {
+		t.Fatalf("write organizations.csv: %v", err)
+	}
+
+	if _, err := resolveSyncTargets(dir, DefaultProjectKeyPattern, nil); err == nil {
+		t.Fatal("resolveSyncTargets: want error for malformed organizations.csv, got nil")
+	}
+}
+
+// newSyncIssuesTestServer builds a minimal Cloud mock server sufficient for
+// RunSyncIssues's own control flow: organization lookups (validateOrgsExist
+// / validatePatternOrgCollision) succeed for any key. No issues/hotspots
+// endpoints are needed because the test fixtures below carry no source
+// issue/hotspot extract data, so syncProjectIssues/syncProjectHotspots
+// return immediately without making any further Cloud calls.
+func newSyncIssuesTestServer() *httptest.Server {
+	return newMockCloudServer()
+}
+
+// writeSyncIssuesFixture wires the minimal on-disk state RunSyncIssues
+// needs: a mapped organizations.csv, a single-project projects.csv pointing
+// at testServerURL, and an extract-01/extract.json so GetUniqueExtracts
+// resolves testServerURL -> extract-01.
+func writeSyncIssuesFixture(t *testing.T, dir string) {
+	t.Helper()
+	writeSyncTargetCSVs(t, dir,
+		"key,server_url,sonarqube_org_key\n"+
+			"proj-a,"+testServerURL+",src-org\n",
+		"sonarqube_org_key,sonarcloud_org_key\n"+
+			"src-org,my-cloud-org\n")
+	writeJSON(filepath.Join(dir, "extract-01", "extract.json"),
+		map[string]any{"url": testServerURL, "edition": "enterprise"})
+}
+
+func TestRunSyncIssuesHappyPath(t *testing.T) {
+	cloudSrv := newSyncIssuesTestServer()
+	defer cloudSrv.Close()
+
+	dir := t.TempDir()
+	writeSyncIssuesFixture(t, dir)
+
+	cfg := SyncIssuesConfig{
+		URL:             cloudSrv.URL,
+		Token:           "test-token",
+		ExportDirectory: dir,
+		Concurrency:     5,
+		Timeout:         10,
+	}
+
+	summary, err := RunSyncIssues(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RunSyncIssues: %v", err)
+	}
+	if summary.ProjectsSynced != 1 {
+		t.Errorf("ProjectsSynced = %d, want 1", summary.ProjectsSynced)
+	}
+	if summary.IssuesSynced != 0 || summary.HotspotsSynced != 0 {
+		t.Errorf("expected no synced issues/hotspots (no source extract data), got %+v", summary)
+	}
+}
+
+func TestRunSyncIssuesInvalidProjectKeyPattern(t *testing.T) {
+	cloudSrv := newSyncIssuesTestServer()
+	defer cloudSrv.Close()
+
+	dir := t.TempDir()
+	writeSyncIssuesFixture(t, dir)
+
+	cfg := SyncIssuesConfig{
+		URL:               cloudSrv.URL,
+		Token:             "test-token",
+		ExportDirectory:   dir,
+		ProjectKeyPattern: "no-placeholders-here",
+	}
+
+	if _, err := RunSyncIssues(context.Background(), cfg); err == nil {
+		t.Fatal("RunSyncIssues: want error for invalid project_key_pattern, got nil")
+	}
+}
+
+func TestRunSyncIssuesMissingOrgMapping(t *testing.T) {
+	cloudSrv := newSyncIssuesTestServer()
+	defer cloudSrv.Close()
+
+	dir := t.TempDir()
+	// organizations.csv deliberately absent and no DefaultOrganization —
+	// applyOrgMapping must reject the run (#279).
+	if err := os.WriteFile(filepath.Join(dir, "projects.csv"),
+		[]byte("key,server_url,sonarqube_org_key\nproj-a,"+testServerURL+",src-org\n"), 0o644); err != nil {
+		t.Fatalf("write projects.csv: %v", err)
+	}
+
+	cfg := SyncIssuesConfig{
+		URL:             cloudSrv.URL,
+		Token:           "test-token",
+		ExportDirectory: dir,
+	}
+
+	if _, err := RunSyncIssues(context.Background(), cfg); err == nil {
+		t.Fatal("RunSyncIssues: want error for missing organization mapping, got nil")
+	}
+}
+
+func TestRunSyncIssuesNoMatchingTargets(t *testing.T) {
+	cloudSrv := newSyncIssuesTestServer()
+	defer cloudSrv.Close()
+
+	dir := t.TempDir()
+	writeSyncIssuesFixture(t, dir)
+
+	cfg := SyncIssuesConfig{
+		URL:             cloudSrv.URL,
+		Token:           "test-token",
+		ExportDirectory: dir,
+		ProjectKeys:     []string{"does-not-exist"},
+	}
+
+	summary, err := RunSyncIssues(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("RunSyncIssues: %v", err)
+	}
+	if summary.ProjectsSynced != 0 {
+		t.Errorf("ProjectsSynced = %d, want 0 when no project matches the filter", summary.ProjectsSynced)
 	}
 }

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -59,6 +59,13 @@ type matchableHotspot struct {
 	// extracted from (enriched into the extract record). Used to build a
 	// branch-correct back-link to the original hotspot (#321).
 	Branch string
+
+	// Message, Author and VulnerabilityProbability feed the approximate-
+	// match scorer (matchscore.go, issue #412) — they play no role in the
+	// status / comment sync logic below.
+	Message                  string
+	Author                   string
+	VulnerabilityProbability string
 }
 
 // hotspotComment captures a single comment attached to a hotspot.
@@ -368,8 +375,8 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 }
 
 // resolveAndSyncHotspot searches Cloud for hotspots in the source
-// hotspot's file, then resolves by (ruleKey, line). Returns the case
-// a/b/c/lookup outcome.
+// hotspot's file, then resolves via the scored matcher (matchscore.go,
+// issue #412). Returns the case a/b/c/lookup outcome.
 func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, baseURL, sourceKey string, src matchableHotspot, counter *TaskCounter) syncOutcome {
 	// Strip "projectKey:" and any trailing "moduleKey:" segments so the bare
 	// file path can be used in the cloud search. Multi-module (monorepo)
@@ -386,7 +393,7 @@ func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, b
 			"project", cloudKey, "source_key", src.Key, "file", filePath, "branch", src.Branch)
 		return syncOutcomeLookupError
 	}
-	target, outcome := classifyHotspotCandidatesByLine(candidates, src.RuleKey, src.Line, src.Offset)
+	target, outcome := classifyHotspotCandidatesByScore(candidates, src)
 	switch outcome {
 	case syncOutcomeSynced:
 		pair := hotspotPair{source: src, cloud: target}
@@ -406,109 +413,15 @@ func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, b
 			outcome = syncOutcomeAckDemoted
 		}
 	case syncOutcomeNotFound:
-		e.Logger.Debug("syncHotspotMetadata: no cloud counterpart on source line", "source_key", src.Key, "rule", src.RuleKey, "file", filePath, "line", src.Line)
+		e.Logger.Debug("syncHotspotMetadata: no cloud counterpart matched", "source_key", src.Key, "rule", src.RuleKey, "file", filePath, "line", src.Line)
 	case syncOutcomeLineMismatch:
 		keys := make([]string, 0)
 		for _, c := range candidates {
-			if c.Line == src.Line && (c.RuleKey == "" || c.RuleKey == src.RuleKey) {
-				keys = append(keys, c.Key)
-			}
+			keys = append(keys, c.Key)
 		}
-		e.Logger.Debug("syncHotspotMetadata: multiple cloud counterparts on source line, skipping", "source_key", src.Key, "rule", src.RuleKey, "file", filePath, "line", src.Line, "candidates", keys)
+		e.Logger.Debug("syncHotspotMetadata: multiple cloud counterparts matched, skipping", "source_key", src.Key, "rule", src.RuleKey, "file", filePath, "line", src.Line, "candidates", keys)
 	}
 	return outcome
-}
-
-// classifyHotspotCandidatesByLine resolves a cloud counterpart for one
-// source hotspot from the per-file candidate set returned by
-// /api/hotspots/search?files=<filePath>.
-//
-// Three-phase match (#392 + follow-up):
-//
-//  1. PRECISE — (ruleKey, line, offset) match. textRange.startOffset
-//     disambiguates two hotspots of the same rule firing on different
-//     columns of the same line (e.g. `sys.argv[1]` and `sys.argv[2]`).
-//     Without it, those collapse to syncOutcomeLineMismatch and stay
-//     TO_REVIEW. Skipped when either side has Offset == 0 (older API
-//     shapes that omit textRange).
-//
-//  2. RULE+LINE — (ruleKey, line) match. The common case: rule
-//     populated on both sides, no column ambiguity needed. Restores
-//     the pre-offset behaviour that already covered 25 of the 31
-//     SAFE hotspots in the live run.
-//
-//  3. EMPTY-RULE FALLBACK — line-only against cloud candidates whose
-//     ruleKey is empty. The 2026-06-09 audit recorded a case where
-//     every cloud hotspot parsed with RuleKey == "" (per-version /
-//     per-endpoint omission); without this fallback the entire
-//     project's REVIEWED hotspots stay TO_REVIEW. Candidates with a
-//     non-empty ruleKey that doesn't match the source are deliberately
-//     NOT considered here — they're a different rule firing on the
-//     same line.
-//
-// Returns syncOutcomeSynced when exactly one candidate qualifies,
-// syncOutcomeLineMismatch when several do (caller skips rather than
-// guess), and syncOutcomeNotFound when none do.
-func classifyHotspotCandidatesByLine(candidates []matchableHotspot, sourceRule string, sourceLine, sourceOffset int) (matchableHotspot, syncOutcome) {
-	// Phase 1: precise (ruleKey, line, offset). Both sides must carry
-	// a non-zero offset for this phase to be considered.
-	if sourceOffset > 0 {
-		var pick matchableHotspot
-		matches := 0
-		for _, c := range candidates {
-			if c.RuleKey == sourceRule && c.Line == sourceLine && c.Offset > 0 && c.Offset == sourceOffset {
-				matches++
-				if matches == 1 {
-					pick = c
-				}
-			}
-		}
-		if matches == 1 {
-			return pick, syncOutcomeSynced
-		}
-		// matches == 0 (offset not present or no exact column hit) →
-		// fall through to phase 2. matches > 1 means duplicate offsets
-		// on the cloud (extremely unusual) — also fall through and let
-		// phase 2's rule+line check resolve to line_mismatch.
-	}
-
-	// Phase 2: (ruleKey, line) match.
-	var pick matchableHotspot
-	matches := 0
-	for _, c := range candidates {
-		if c.RuleKey == sourceRule && c.Line == sourceLine {
-			matches++
-			if matches == 1 {
-				pick = c
-			}
-		}
-	}
-	if matches > 0 {
-		if matches == 1 {
-			return pick, syncOutcomeSynced
-		}
-		return matchableHotspot{}, syncOutcomeLineMismatch
-	}
-
-	// Phase 3: cloud candidates with no ruleKey are eligible for a
-	// line-only fallback.
-	matches = 0
-	for _, c := range candidates {
-		if c.RuleKey == "" && c.Line == sourceLine {
-			matches++
-			if matches == 1 {
-				pick = c
-			}
-		}
-	}
-	switch matches {
-	case 0:
-		return matchableHotspot{}, syncOutcomeNotFound
-	case 1:
-		return pick, syncOutcomeSynced
-	default:
-		return matchableHotspot{}, syncOutcomeLineMismatch
-	}
 }
 
 // findCloudHotspotCandidates queries /api/hotspots/search?files=…
@@ -842,7 +755,10 @@ func parseMatchableHotspot(data json.RawMessage) matchableHotspot {
 		Comments:   comments,
 		// Present on source-side records (enriched at extract time);
 		// absent/empty on cloud candidates, which don't need it.
-		Branch: extractField(data, "branch"),
+		Branch:                   extractField(data, "branch"),
+		Message:                  extractField(data, "message"),
+		Author:                   extractField(data, "author"),
+		VulnerabilityProbability: extractField(data, "vulnerabilityProbability"),
 	}
 }
 

--- a/go/internal/migrate/tasks_hotspotsync_test.go
+++ b/go/internal/migrate/tasks_hotspotsync_test.go
@@ -55,176 +55,123 @@ func TestHotspotHasManualChanges(t *testing.T) {
 	}
 }
 
-// #392: the hotspot classifier is three-phase:
-//
-//  1. Precise (ruleKey, line, offset) — disambiguates co-located
-//     hotspots of the same rule on different columns (sys.argv[1] and
-//     sys.argv[2] on a single line). Only considered when both sides
-//     carry a non-zero offset.
-//  2. (ruleKey, line) — covers the common case where rule is enough.
-//  3. Empty-ruleKey line-only — fallback for the 2026-06-09 audit
-//     case where the cloud response omits ruleKey.
-func TestClassifyHotspotCandidatesByLine(t *testing.T) {
-	cand := func(key, rule string, line, offset int) matchableHotspot {
-		return matchableHotspot{Key: key, RuleKey: rule, Line: line, Offset: offset}
+// #412: hotspotMatchScore — a non-empty rule mismatch is a hard reject;
+// an empty ruleKey on either side is tolerated (preserving the pre-#412
+// empty-rule fallback), and the score otherwise accumulates across
+// message/file/line/offset/vulnerabilityProbability/author.
+func TestHotspotMatchScore(t *testing.T) {
+	base := matchableHotspot{
+		RuleKey: "python:S4823", Component: "a.py", Line: 35, Offset: 17,
+		Message: "Make sure this is safe", VulnerabilityProbability: "HIGH", Author: "alice",
 	}
+
 	tests := []struct {
-		name         string
-		candidates   []matchableHotspot
-		sourceRule   string
-		sourceLine   int
-		sourceOffset int
-		wantKey      string
-		wantOutcome  syncOutcome
+		name      string
+		candidate matchableHotspot
+		want      int
 	}{
-		// --- Phase 1: precise (rule, line, offset) ---
+		{"non-empty rule mismatch rejects", withHotspotRule(base, "python:S9999"), -1},
+		{"identical — max score", base, 7},
+		{"candidate empty ruleKey — tolerated, still scored", withHotspotRule(base, ""), 7},
 		{
-			// Live scenario from #392 follow-up: two cloud hotspots of
-			// the same rule on the same line, different startOffsets.
-			// Without offset they collapse to line_mismatch; with it,
-			// each source resolves cleanly to its column-matched peer.
-			name: "co-located cloud hotspots disambiguated by offset",
-			candidates: []matchableHotspot{
-				cand("h-MF", "python:S4823", 35, 35),
-				cand("h-MG", "python:S4823", 35, 17),
-			},
-			sourceRule:   "python:S4823",
-			sourceLine:   35,
-			sourceOffset: 17,
-			wantKey:      "h-MG",
-			wantOutcome:  syncOutcomeSynced,
+			"source has offset, candidate offset missing — no offset point",
+			withHotspotOffset(base, 0),
+			6,
 		},
 		{
-			// Same call shape, source on the OTHER column.
-			name: "co-located cloud hotspots — pick by offset 35",
-			candidates: []matchableHotspot{
-				cand("h-MF", "python:S4823", 35, 35),
-				cand("h-MG", "python:S4823", 35, 17),
-			},
-			sourceRule:   "python:S4823",
-			sourceLine:   35,
-			sourceOffset: 35,
-			wantKey:      "h-MF",
-			wantOutcome:  syncOutcomeSynced,
-		},
-
-		// --- Phase 2: (rule, line) match (offset unavailable / zero) ---
-		{
-			name:         "exact rule + line match — synced (offset absent)",
-			candidates:   []matchableHotspot{cand("h-1", "javasecurity:S1", 42, 0)},
-			sourceRule:   "javasecurity:S1",
-			sourceLine:   42,
-			sourceOffset: 0,
-			wantKey:      "h-1",
-			wantOutcome:  syncOutcomeSynced,
-		},
-		{
-			name: "rule disambiguates among same-line candidates (#392 regression guard)",
-			candidates: []matchableHotspot{
-				cand("h-1", "javasecurity:S1", 42, 0),
-				cand("h-2", "javasecurity:S2", 42, 0),
-			},
-			sourceRule:   "javasecurity:S2",
-			sourceLine:   42,
-			sourceOffset: 0,
-			wantKey:      "h-2",
-			wantOutcome:  syncOutcomeSynced,
-		},
-		{
-			name: "two same-rule same-line candidates with NO offset — line_mismatch",
-			candidates: []matchableHotspot{
-				cand("h-1", "javasecurity:S1", 42, 0),
-				cand("h-2", "javasecurity:S1", 42, 0),
-			},
-			sourceRule:   "javasecurity:S1",
-			sourceLine:   42,
-			sourceOffset: 0,
-			wantOutcome:  syncOutcomeLineMismatch,
-		},
-		{
-			// Source has offset but cloud doesn't — phase 1 yields
-			// nothing, phase 2 falls back and picks the single
-			// rule+line match.
-			name: "source has offset, cloud doesn't — phase 2 still resolves",
-			candidates: []matchableHotspot{
-				cand("h-1", "javasecurity:S1", 42, 0),
-			},
-			sourceRule:   "javasecurity:S1",
-			sourceLine:   42,
-			sourceOffset: 17,
-			wantKey:      "h-1",
-			wantOutcome:  syncOutcomeSynced,
-		},
-
-		// --- Phase 3: empty-ruleKey fallback ---
-		{
-			name:         "empty-ruleKey candidate falls back to line-only — synced",
-			candidates:   []matchableHotspot{cand("h-1", "", 42, 0)},
-			sourceRule:   "javasecurity:S1",
-			sourceLine:   42,
-			sourceOffset: 0,
-			wantKey:      "h-1",
-			wantOutcome:  syncOutcomeSynced,
-		},
-		{
-			name: "two empty-ruleKey candidates on the same line — line_mismatch",
-			candidates: []matchableHotspot{
-				cand("h-1", "", 42, 0),
-				cand("h-2", "", 42, 0),
-			},
-			sourceRule:   "javasecurity:S1",
-			sourceLine:   42,
-			sourceOffset: 0,
-			wantOutcome:  syncOutcomeLineMismatch,
-		},
-		{
-			// Non-empty cloud rule that doesn't match the source's rule
-			// must NOT be picked by phase 3.
-			name: "non-matching cloud rule on the line — not picked by fallback",
-			candidates: []matchableHotspot{
-				cand("h-1", "javasecurity:S2", 42, 0),
-			},
-			sourceRule:   "javasecurity:S1",
-			sourceLine:   42,
-			sourceOffset: 0,
-			wantOutcome:  syncOutcomeNotFound,
-		},
-		{
-			// Earlier phase wins: a precise rule+line match must not
-			// be undone by an empty-rule candidate on the same line.
-			name: "phase 2 match wins over phase 3 candidate on same line",
-			candidates: []matchableHotspot{
-				cand("h-1", "javasecurity:S1", 42, 0),
-				cand("h-2", "", 42, 0),
-			},
-			sourceRule:   "javasecurity:S1",
-			sourceLine:   42,
-			sourceOffset: 0,
-			wantKey:      "h-1",
-			wantOutcome:  syncOutcomeSynced,
-		},
-
-		// --- General negatives ---
-		{
-			name:         "no candidate on the source line — not_found",
-			candidates:   []matchableHotspot{cand("h-1", "javasecurity:S1", 40, 0)},
-			sourceRule:   "javasecurity:S1",
-			sourceLine:   42,
-			sourceOffset: 0,
-			wantOutcome:  syncOutcomeNotFound,
-		},
-		{
-			name:         "empty candidate set — not_found",
-			candidates:   nil,
-			sourceRule:   "javasecurity:S1",
-			sourceLine:   42,
-			sourceOffset: 0,
-			wantOutcome:  syncOutcomeNotFound,
+			"very different message, else equal",
+			withHotspotMessage(base, "An entirely unrelated finding description"),
+			5,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, outcome := classifyHotspotCandidatesByLine(tc.candidates, tc.sourceRule, tc.sourceLine, tc.sourceOffset)
+			if got := hotspotMatchScore(base, tc.candidate); got != tc.want {
+				t.Errorf("hotspotMatchScore = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func withHotspotRule(h matchableHotspot, rule string) matchableHotspot   { h.RuleKey = rule; return h }
+func withHotspotOffset(h matchableHotspot, offset int) matchableHotspot  { h.Offset = offset; return h }
+func withHotspotMessage(h matchableHotspot, msg string) matchableHotspot { h.Message = msg; return h }
+
+// #412: classifyHotspotCandidatesByScore — exact match (rule-compatible +
+// file + line + message) wins when unique; otherwise the approximate score
+// must clear hotspotApproxMatchThreshold and uniquely qualify.
+func TestClassifyHotspotCandidatesByScore(t *testing.T) {
+	source := matchableHotspot{
+		RuleKey: "python:S4823", Component: "a.py", Line: 35, Offset: 17,
+		Message: "Make sure this is safe", VulnerabilityProbability: "HIGH", Author: "alice",
+	}
+	exactMatch := source
+	exactMatch.Key = "h-exact"
+
+	approxMatch := matchableHotspot{
+		Key: "h-approx", RuleKey: "python:S4823", Component: "a.py", Line: 35, Offset: 17,
+		Message: "Make sure this stays safe", VulnerabilityProbability: "HIGH", Author: "alice",
+	} // message similar (+1), file+line+offset+vulnProb+author (+5) = 6
+
+	belowThreshold := matchableHotspot{
+		Key: "h-low", RuleKey: "python:S4823", Component: "b.py", Line: 99, Offset: 0,
+		Message: "unrelated", VulnerabilityProbability: "LOW", Author: "bob",
+	}
+
+	// Preserves the pre-#412 empty-ruleKey fallback: some SQ
+	// versions/endpoints omit ruleKey from hotspot search results.
+	emptyRuleExact := source
+	emptyRuleExact.Key = "h-empty-rule"
+	emptyRuleExact.RuleKey = ""
+
+	tests := []struct {
+		name        string
+		candidates  []matchableHotspot
+		wantKey     string
+		wantOutcome syncOutcome
+	}{
+		{
+			name:        "unique exact match — synced",
+			candidates:  []matchableHotspot{belowThreshold, exactMatch},
+			wantKey:     "h-exact",
+			wantOutcome: syncOutcomeSynced,
+		},
+		{
+			name:        "two exact matches — ambiguous",
+			candidates:  []matchableHotspot{exactMatch, {Key: "h-exact-2", RuleKey: "python:S4823", Component: "a.py", Line: 35, Message: "Make sure this is safe"}},
+			wantOutcome: syncOutcomeLineMismatch,
+		},
+		{
+			name:        "no exact, unique approximate match — synced",
+			candidates:  []matchableHotspot{belowThreshold, approxMatch},
+			wantKey:     "h-approx",
+			wantOutcome: syncOutcomeSynced,
+		},
+		{
+			name:        "no exact, two qualifying approximate matches — ambiguous",
+			candidates:  []matchableHotspot{approxMatch, {Key: "h-approx-2", RuleKey: "python:S4823", Component: "a.py", Line: 35, Offset: 17, Message: "Make sure this stays safe", VulnerabilityProbability: "HIGH", Author: "alice"}},
+			wantOutcome: syncOutcomeLineMismatch,
+		},
+		{
+			name:        "no candidate clears the threshold — not_found",
+			candidates:  []matchableHotspot{belowThreshold},
+			wantOutcome: syncOutcomeNotFound,
+		},
+		{
+			name:        "empty-ruleKey candidate still matches exactly (fallback preserved)",
+			candidates:  []matchableHotspot{emptyRuleExact},
+			wantKey:     "h-empty-rule",
+			wantOutcome: syncOutcomeSynced,
+		},
+		{
+			name:        "empty candidate set — not_found",
+			candidates:  nil,
+			wantOutcome: syncOutcomeNotFound,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, outcome := classifyHotspotCandidatesByScore(tc.candidates, source)
 			if outcome != tc.wantOutcome {
 				t.Errorf("outcome = %v, want %v", outcome, tc.wantOutcome)
 			}
@@ -244,7 +191,7 @@ func TestMapHotspotResolution(t *testing.T) {
 	}{
 		{"SAFE", "SAFE"},
 		{"FIXED", "FIXED"},
-		{"safe", "SAFE"},  // case-insensitive
+		{"safe", "SAFE"},   // case-insensitive
 		{"fixed", "FIXED"}, // case-insensitive
 		{"ACKNOWLEDGED", ""},
 		{"acknowledged", ""},
@@ -312,12 +259,12 @@ func TestSyncOneHotspotAddsSourceLink(t *testing.T) {
 // (TO_REVIEW is also the cloud default). Comments still propagate.
 func TestSyncOneHotspotAcknowledgedResetsToToReview(t *testing.T) {
 	var (
-		mu             sync.Mutex
-		changeStatus   string
-		changeResol    string
-		changeHotspot  string
-		changeCalls    int
-		commentCalls   int
+		mu            sync.Mutex
+		changeStatus  string
+		changeResol   string
+		changeHotspot string
+		changeCalls   int
+		commentCalls  int
 	)
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/hotspots/change_status", func(w http.ResponseWriter, r *http.Request) {
@@ -376,9 +323,9 @@ func TestSyncOneHotspotAcknowledgedResetsToToReview(t *testing.T) {
 // status and merges the results.
 func TestFindCloudHotspotCandidatesQueriesBothStatuses(t *testing.T) {
 	var (
-		mu          sync.Mutex
-		seenStatus  []string
-		seenBranch  []string
+		mu         sync.Mutex
+		seenStatus []string
+		seenBranch []string
 	)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/hotspots/search", func(w http.ResponseWriter, r *http.Request) {

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -87,6 +87,14 @@ type matchableIssue struct {
 	ManualSeverity bool
 	Branch         string
 	Transitions    []string
+
+	// Message, Type, Severity and Author feed the approximate-match scorer
+	// (matchscore.go, issue #412) — they play no role in the transition /
+	// comment / tag sync logic below.
+	Message  string
+	Type     string
+	Severity string
+	Author   string
 }
 
 // issueComment is a normalised comment attached to a matchableIssue.
@@ -600,48 +608,20 @@ func resolveAndSyncIssue(ctx context.Context, e *Executor, cloudKey, orgKey, bas
 			"project", cloudKey, "source_key", src.Key, "rule", src.Rule, "file", filePath, "branch", src.Branch)
 		return syncOutcomeLookupError
 	}
-	target, outcome := classifyIssueCandidatesByLine(candidates, src.Line)
+	target, outcome := classifyIssueCandidatesByScore(candidates, src)
 	switch outcome {
 	case syncOutcomeSynced:
 		syncOnePair(ctx, e, issuePair{source: src, cloud: target}, baseURL, projectKey, counter)
 	case syncOutcomeNotFound:
-		e.Logger.Debug("syncIssueMetadata: no cloud counterpart on source line", "source_key", src.Key, "rule", src.Rule, "file", filePath, "line", src.Line)
+		e.Logger.Debug("syncIssueMetadata: no cloud counterpart matched", "source_key", src.Key, "rule", src.Rule, "file", filePath, "line", src.Line)
 	case syncOutcomeLineMismatch:
 		keys := make([]string, 0)
 		for _, c := range candidates {
-			if c.Line == src.Line {
-				keys = append(keys, c.Key)
-			}
+			keys = append(keys, c.Key)
 		}
-		e.Logger.Debug("syncIssueMetadata: multiple cloud counterparts on source line, skipping", "source_key", src.Key, "rule", src.Rule, "file", filePath, "line", src.Line, "candidates", keys)
+		e.Logger.Debug("syncIssueMetadata: multiple cloud counterparts matched, skipping", "source_key", src.Key, "rule", src.Rule, "file", filePath, "line", src.Line, "candidates", keys)
 	}
 	return outcome
-}
-
-// classifyIssueCandidatesByLine implements the case a/b/c decision
-// from #356: among candidates returned by /api/issues/search, pick
-// the one on the source's line. 1 → synced, 0 → not_found, n>1 →
-// line_mismatch. Factored out so the per-pair logic is unit testable
-// without HTTP mocking.
-func classifyIssueCandidatesByLine(candidates []matchableIssue, sourceLine int) (matchableIssue, syncOutcome) {
-	var pick matchableIssue
-	matches := 0
-	for _, c := range candidates {
-		if c.Line == sourceLine {
-			matches++
-			if matches == 1 {
-				pick = c
-			}
-		}
-	}
-	switch matches {
-	case 0:
-		return matchableIssue{}, syncOutcomeNotFound
-	case 1:
-		return pick, syncOutcomeSynced
-	default:
-		return matchableIssue{}, syncOutcomeLineMismatch
-	}
 }
 
 // findCloudIssueCandidates queries /api/issues/search for cloud issues
@@ -1059,6 +1039,10 @@ func loadMatchableIssues(e *Executor, serverURL, serverKey string, ruleDefaults 
 			Assignee:       extractField(item.Data, "assignee"),
 			ManualSeverity: extractBool(item.Data, "manualSeverity"),
 			Branch:         extractField(item.Data, "branch"),
+			Message:        extractField(item.Data, "message"),
+			Type:           extractField(item.Data, "type"),
+			Severity:       extractField(item.Data, "severity"),
+			Author:         extractField(item.Data, "author"),
 		})
 	}
 
@@ -1096,6 +1080,10 @@ func apiIssueToMatchable(ai sqtypes.Issue) matchableIssue {
 		Comments:    comments,
 		Assignee:    ai.Assignee,
 		Transitions: ai.Transitions,
+		Message:     ai.Message,
+		Type:        ai.Type,
+		Severity:    ai.Severity,
+		Author:      ai.Author,
 	}
 }
 

--- a/go/internal/migrate/tasks_issuesync_test.go
+++ b/go/internal/migrate/tasks_issuesync_test.go
@@ -5,7 +5,10 @@
 package migrate
 
 import (
+	"path/filepath"
 	"testing"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 )
 
 func TestIsAlreadyMigratedIssueComment(t *testing.T) {
@@ -549,5 +552,30 @@ func TestClassifyActionableReasonsIssueStatus(t *testing.T) {
 	}
 	if b.customTags != 1 {
 		t.Errorf("customTags: want 1, got %d", b.customTags)
+	}
+}
+
+// #412: loadMatchableIssues carries message/type/severity/author through
+// from the extract into matchableIssue — the approximate-match scorer
+// (matchscore.go) needs them.
+func TestLoadMatchableIssuesCarriesScorerFields(t *testing.T) {
+	dir := t.TempDir()
+	extractDir := filepath.Join(dir, "extract-01")
+	writeJSONL(filepath.Join(extractDir, "getProjectIssuesFull"), []map[string]any{
+		{
+			"key": "iss-1", "rule": "java:S100", "component": "proj-a:src/app.go", "line": 10,
+			"status": "OPEN", "projectKey": "proj-a",
+			"message": "Do not do this", "type": "BUG", "severity": "MAJOR", "author": "dev@example.com",
+		},
+	})
+
+	e := &Executor{ExportDir: dir, Mapping: structure.ExtractMapping{testServerURL: "extract-01"}}
+	got := loadMatchableIssues(e, testServerURL, "proj-a", loadRuleTagDefaults(e))
+	if len(got) != 1 {
+		t.Fatalf("loadMatchableIssues: got %d issues, want 1", len(got))
+	}
+	iss := got[0]
+	if iss.Message != "Do not do this" || iss.Type != "BUG" || iss.Severity != "MAJOR" || iss.Author != "dev@example.com" {
+		t.Errorf("loadMatchableIssues: scorer fields not carried through, got %+v", iss)
 	}
 }

--- a/go/internal/migrate/tasks_issuesync_test.go
+++ b/go/internal/migrate/tasks_issuesync_test.go
@@ -10,16 +10,16 @@ import (
 
 func TestIsAlreadyMigratedIssueComment(t *testing.T) {
 	tests := []struct {
-		name         string
-		body         string
+		name          string
+		body          string
 		cloudComments []issueComment
-		want         bool
+		want          bool
 	}{
 		{
-			name: "no cloud comments",
-			body: "some comment text",
+			name:          "no cloud comments",
+			body:          "some comment text",
 			cloudComments: nil,
-			want: false,
+			want:          false,
 		},
 		{
 			name: "cloud comment contains prefix and body",
@@ -150,7 +150,7 @@ func TestRuleTagDefaultsUserTagsOnly(t *testing.T) {
 		bySrv: map[string]map[string]map[string]struct{}{
 			"https://server1": {
 				"java:S1481": setOf("unused", "convention"),
-				"java:S2095":  setOf("cwe", "denial-of-service", "security"),
+				"java:S2095": setOf("cwe", "denial-of-service", "security"),
 			},
 		},
 	}
@@ -163,37 +163,37 @@ func TestRuleTagDefaultsUserTagsOnly(t *testing.T) {
 		want      []string
 	}{
 		{
-			name: "all tags are rule defaults — returns empty",
+			name:      "all tags are rule defaults — returns empty",
 			serverURL: "https://server1", ruleKey: "java:S1481",
 			allTags: []string{"unused", "convention"},
 			want:    []string{},
 		},
 		{
-			name: "rule defaults stripped, user tags retained",
+			name:      "rule defaults stripped, user tags retained",
 			serverURL: "https://server1", ruleKey: "java:S2095",
 			allTags: []string{"cwe", "denial-of-service", "security", "flagged-by-team", "needs-investigation"},
 			want:    []string{"flagged-by-team", "needs-investigation"},
 		},
 		{
-			name: "rule not indexed — fallback returns input unchanged",
+			name:      "rule not indexed — fallback returns input unchanged",
 			serverURL: "https://server1", ruleKey: "kotlin:S100",
 			allTags: []string{"convention"},
 			want:    []string{"convention"},
 		},
 		{
-			name: "server not indexed — fallback returns input unchanged",
+			name:      "server not indexed — fallback returns input unchanged",
 			serverURL: "https://other-server", ruleKey: "java:S1481",
 			allTags: []string{"unused"},
 			want:    []string{"unused"},
 		},
 		{
-			name: "empty input — returns empty",
+			name:      "empty input — returns empty",
 			serverURL: "https://server1", ruleKey: "java:S1481",
 			allTags: nil,
 			want:    nil,
 		},
 		{
-			name: "user tags only (no rule defaults present)",
+			name:      "user tags only (no rule defaults present)",
 			serverURL: "https://server1", ruleKey: "java:S1481",
 			allTags: []string{"team-quarantine"},
 			want:    []string{"team-quarantine"},
@@ -279,14 +279,14 @@ func TestStripProjectKeyPrefix(t *testing.T) {
 func TestClassifyActionableReasonsAndBranches(t *testing.T) {
 	comment := issueComment{Login: "u", Markdown: "noted"}
 	issues := []matchableIssue{
-		{Status: "ACCEPTED", Branch: "main"},                                                       // accepted
-		{Status: "RESOLVED", Resolution: "FALSE-POSITIVE", Branch: "main"},                          // accepted_or_fp (via resolution)
-		{Status: "FALSE_POSITIVE", Branch: "develop"},                                               // accepted_or_fp (modern enum)
-		{Status: "OPEN", Tags: []string{"flagged"}, Branch: "develop"},                              // custom_tags
-		{Status: "OPEN", ManualSeverity: true, Branch: "feat-1"},                                    // manual_severity
-		{Status: "OPEN", Comments: []issueComment{comment}, Branch: "feat-2"},                       // comments
-		{Status: "ACCEPTED", Tags: []string{"audited"}, Branch: "main"},                             // accepted + tags (counted in both)
-		{Status: "ACCEPTED", Comments: []issueComment{comment}, ManualSeverity: true, Branch: ""},   // accepted + manualSeverity + comments
+		{Status: "ACCEPTED", Branch: "main"},                                                      // accepted
+		{Status: "RESOLVED", Resolution: "FALSE-POSITIVE", Branch: "main"},                        // accepted_or_fp (via resolution)
+		{Status: "FALSE_POSITIVE", Branch: "develop"},                                             // accepted_or_fp (modern enum)
+		{Status: "OPEN", Tags: []string{"flagged"}, Branch: "develop"},                            // custom_tags
+		{Status: "OPEN", ManualSeverity: true, Branch: "feat-1"},                                  // manual_severity
+		{Status: "OPEN", Comments: []issueComment{comment}, Branch: "feat-2"},                     // comments
+		{Status: "ACCEPTED", Tags: []string{"audited"}, Branch: "main"},                           // accepted + tags (counted in both)
+		{Status: "ACCEPTED", Comments: []issueComment{comment}, ManualSeverity: true, Branch: ""}, // accepted + manualSeverity + comments
 	}
 	b := classifyActionableReasons(issues)
 	if want := 5; b.acceptedOrFP != want {
@@ -307,64 +307,113 @@ func TestClassifyActionableReasonsAndBranches(t *testing.T) {
 	}
 }
 
-// #356: case a/b/c classification — exactly the semantics from the
-// issue. 1 cloud counterpart on the source line → synced (a); 0
-// counterparts on the line → not_found (c); 2+ on the same line →
-// line_mismatch (b). Off-line candidates are ignored.
-func TestClassifyIssueCandidatesByLine(t *testing.T) {
-	cand := func(key string, line int) matchableIssue {
-		return matchableIssue{Key: key, Line: line}
+// #412: issueMatchScore — rule mismatch is a hard reject; otherwise the
+// score accumulates across message/file/line/type/severity/author.
+func TestIssueMatchScore(t *testing.T) {
+	base := matchableIssue{
+		Rule: "java:S1", Component: "a.java", Line: 10,
+		Message: "Fix this issue please", Type: "CODE_SMELL", Severity: "MAJOR", Author: "alice",
 	}
+
+	tests := []struct {
+		name      string
+		candidate matchableIssue
+		want      int
+	}{
+		{"rule mismatch rejects", withRule(base, "java:S2"), -1},
+		{"identical — max score", base, 7},
+		{
+			"similar message (edit distance <=5), all else equal",
+			withMessage(base, "Fix this issue pls"),
+			6,
+		},
+		{
+			"very different message, all else equal",
+			withMessage(base, "Completely unrelated wording here"),
+			5,
+		},
+		{
+			"only rule+line equal, everything else different",
+			matchableIssue{Rule: "java:S1", Component: "b.java", Line: 10, Message: "zzz", Type: "BUG", Severity: "MINOR", Author: "bob"},
+			1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := issueMatchScore(base, tc.candidate); got != tc.want {
+				t.Errorf("issueMatchScore = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func withRule(m matchableIssue, rule string) matchableIssue   { m.Rule = rule; return m }
+func withMessage(m matchableIssue, msg string) matchableIssue { m.Message = msg; return m }
+
+// #412: classifyIssueCandidatesByScore — exact match (file+line+message)
+// wins when unique; otherwise fall back to the approximate score, which
+// must clear issueApproxMatchThreshold and be uniquely qualifying.
+func TestClassifyIssueCandidatesByScore(t *testing.T) {
+	source := matchableIssue{
+		Rule: "java:S1", Component: "a.java", Line: 42,
+		Message: "Fix this issue please", Type: "CODE_SMELL", Severity: "MAJOR", Author: "alice",
+	}
+	exactMatch := source
+	exactMatch.Key = "cloud-exact"
+
+	approxMatch := matchableIssue{
+		Key: "cloud-approx", Rule: "java:S1", Component: "a.java", Line: 42,
+		Message: "Fix this issue pls", Type: "CODE_SMELL", Severity: "MAJOR", Author: "alice",
+	} // score 6: message similar(+1) + file+line+type+severity+author(+5)
+
+	belowThreshold := matchableIssue{
+		Key: "cloud-low", Rule: "java:S1", Component: "b.java", Line: 99,
+		Message: "totally different text", Type: "BUG", Severity: "MINOR", Author: "bob",
+	}
+
 	tests := []struct {
 		name        string
 		candidates  []matchableIssue
-		sourceLine  int
 		wantKey     string
 		wantOutcome syncOutcome
 	}{
 		{
-			name:        "exactly one match on line — synced (a)",
-			candidates:  []matchableIssue{cand("cloud-1", 42)},
-			sourceLine:  42,
-			wantKey:     "cloud-1",
+			name:        "unique exact match — synced",
+			candidates:  []matchableIssue{belowThreshold, exactMatch},
+			wantKey:     "cloud-exact",
 			wantOutcome: syncOutcomeSynced,
 		},
 		{
-			name:        "one match among off-line candidates — synced (a)",
-			candidates:  []matchableIssue{cand("cloud-a", 40), cand("cloud-b", 42), cand("cloud-c", 44)},
-			sourceLine:  42,
-			wantKey:     "cloud-b",
+			name:        "two exact matches — ambiguous",
+			candidates:  []matchableIssue{exactMatch, {Key: "cloud-exact-2", Rule: "java:S1", Component: "a.java", Line: 42, Message: "Fix this issue please"}},
+			wantOutcome: syncOutcomeLineMismatch,
+		},
+		{
+			name:        "no exact, unique approximate match — synced",
+			candidates:  []matchableIssue{belowThreshold, approxMatch},
+			wantKey:     "cloud-approx",
 			wantOutcome: syncOutcomeSynced,
 		},
 		{
-			name:        "two matches on same line — line_mismatch (b)",
-			candidates:  []matchableIssue{cand("cloud-a", 42), cand("cloud-b", 42)},
-			sourceLine:  42,
+			name:        "no exact, two qualifying approximate matches — ambiguous",
+			candidates:  []matchableIssue{approxMatch, {Key: "cloud-approx-2", Rule: "java:S1", Component: "a.java", Line: 42, Message: "Fix this issue pls", Type: "CODE_SMELL", Severity: "MAJOR", Author: "alice"}},
 			wantOutcome: syncOutcomeLineMismatch,
 		},
 		{
-			name:        "three matches on same line, one off-line — line_mismatch (b)",
-			candidates:  []matchableIssue{cand("cloud-a", 42), cand("cloud-b", 42), cand("cloud-c", 42), cand("cloud-d", 99)},
-			sourceLine:  42,
-			wantOutcome: syncOutcomeLineMismatch,
-		},
-		{
-			name:        "no matches on line, candidates elsewhere — not_found (c)",
-			candidates:  []matchableIssue{cand("cloud-a", 40), cand("cloud-b", 44)},
-			sourceLine:  42,
+			name:        "no candidate clears the threshold — not_found",
+			candidates:  []matchableIssue{belowThreshold},
 			wantOutcome: syncOutcomeNotFound,
 		},
 		{
-			name:        "empty candidates — not_found (c)",
+			name:        "empty candidates — not_found",
 			candidates:  nil,
-			sourceLine:  42,
 			wantOutcome: syncOutcomeNotFound,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, outcome := classifyIssueCandidatesByLine(tc.candidates, tc.sourceLine)
+			got, outcome := classifyIssueCandidatesByScore(tc.candidates, source)
 			if outcome != tc.wantOutcome {
 				t.Errorf("outcome = %v, want %v", outcome, tc.wantOutcome)
 			}

--- a/migrate.sh
+++ b/migrate.sh
@@ -36,13 +36,13 @@ fi
 CONFIG_FILE="config-${CONFIG}.json"
 
 if [[ "${DO_EXTRACT}" = true ]]; then
-  ./sonar-migration-tool extract --config "${CONFIG_FILE}"
-  ./sonar-migration-tool structure --config "${CONFIG_FILE}"
-  ./sonar-migration-tool mappings --config "${CONFIG_FILE}"
+  sonar-migration-tool extract --config "${CONFIG_FILE}"
+  sonar-migration-tool structure --config "${CONFIG_FILE}"
+  sonar-migration-tool mappings --config "${CONFIG_FILE}"
 
   cp organizations-${CONFIG}.csv migration-files-${CONFIG}/organizations.csv
 fi
 
 if [[ "${DO_MIGRATE}" = true ]]; then
-  ./sonar-migration-tool migrate --config "${CONFIG_FILE}"
+  sonar-migration-tool migrate --config "${CONFIG_FILE}"
 fi

--- a/transfer.sh
+++ b/transfer.sh
@@ -13,11 +13,14 @@ usage() {
   exit 1
 }
 
-while getopts "c:hp:o:" opt; do
+DEBUG=""
+
+while getopts "c:hp:o:v" opt; do
   case "${opt}" in
     c) CONFIG="${OPTARG}" ;;
     p) PK="${OPTARG}" ;;
     o) ORG="${OPTARG}" ;;
+    v) DEBUG="--debug" ;;
     h) usage ;;
     *) usage ;;
   esac
@@ -37,4 +40,4 @@ fi
 
 CONFIG_FILE="config-${CONFIG}.json"
 
-./sonar-migration-tool transfer --config "${CONFIG_FILE}" --project_key $PK --default_organization $ORG --debug
+sonar-migration-tool transfer --config "${CONFIG_FILE}" --project_key $PK --default_organization $ORG $DEBUG


### PR DESCRIPTION
## Summary
- Adds a new `sync-issues` command that syncs issue/hotspot triage state (status, resolution, tags, severity, comments) from SonarQube Server to already-migrated SonarQube Cloud projects, without requiring a full `migrate`/`transfer` run. It performs its own lightweight extract internally.
- Replaces the line-only candidate matcher (`classifyIssueCandidatesByLine` / `classifyHotspotCandidatesByLine`) with a scored exact-then-approximate matcher (`matchscore.go`), adapted from sonar-tools findings.py (`strictly_identical_to` / `almost_identical_to`), to disambiguate multiple cloud candidates on the same source line using rule, message, severity, type/offset, and author.
- Adds `docs/SYNC-ISSUES.md` documenting usage, project scope, target resolution, and the matching algorithm.
- Minor doc/script updates: README command table entry, `-v/--debug` flag on `transfer.sh`.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual run of `sonar-migration-tool sync-issues` against a real SonarQube Server + Cloud pair
