### PR TITLE
fix: align release versioning to semver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,12 +284,26 @@ jobs:
     runs-on: sonar-xs
     permissions:
       contents: write
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
     steps:
-      - name: Set release tag
+      - uses: actions/checkout@v6
+
+      - name: Set release version and tag
         id: release
         run: |
-          TAG="v$(date -u +%Y.%m.%d)-${GITHUB_RUN_NUMBER}"
+          RAW_VERSION="$(grep -oE 'const Version = "[^"]+"' go/internal/version/version.go | cut -d'"' -f2)"
+          VERSION="${RAW_VERSION#v}"
+          VERSION="${VERSION%%-*}"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version '${RAW_VERSION}' in go/internal/version/version.go is not major.minor.patch"
+            exit 1
+          fi
+          TAG="v${VERSION}.${GITHUB_RUN_NUMBER}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${VERSION}"
           echo "Release tag: ${TAG}"
 
       - name: Download all binaries
@@ -319,3 +333,51 @@ jobs:
           target_commitish: ${{ github.sha }}
           generate_release_notes: true
           files: dist/sonar-migration-tool-*
+
+  # Open a PR bumping go/internal/version/version.go to a tentative next
+  # version so the released version is never left stale. The PR is a
+  # starting point only: a human picks the real next major/minor/patch
+  # before merging.
+  bump-version:
+    name: Open Next-Version Bump PR
+    needs: publish
+    if: success()
+    runs-on: sonar-xs
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Bump version.go and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASED_VERSION: ${{ needs.publish.outputs.version }}
+          RELEASED_TAG: ${{ needs.publish.outputs.tag }}
+        run: |
+          set -euo pipefail
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$RELEASED_VERSION"
+          NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-SNAPSHOT"
+          BRANCH="chore/bump-version-${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+          sed -i.bak -E "s/const Version = \"[^\"]+\"/const Version = \"v${NEXT_VERSION}\"/" go/internal/version/version.go
+          rm -f go/internal/version/version.go.bak
+
+          if git diff --quiet -- go/internal/version/version.go; then
+            echo "::error::Expected go/internal/version/version.go to change but it did not"
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git commit -am "chore: bump version to v${NEXT_VERSION}"
+          git push origin "$BRANCH"
+
+          PR_BODY="$(printf 'Automated follow-up to release `%s`.\n\nThis bumps `go/internal/version/version.go` to a tentative next version (`v%s`) by incrementing the patch number.\n\n**Please review and adjust the major/minor/patch as appropriate for what'"'"'s actually planned next before merging.**' "$RELEASED_TAG" "$NEXT_VERSION")"
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: bump version to v${NEXT_VERSION}" \
+            --body "$PR_BODY"


### PR DESCRIPTION
## Summary
- Release version is now read from the Version constant in go/internal/version/version.go (stripping any v prefix and -SUFFIX like -SNAPSHOT), instead of a date stamp.
- Release tag is now v<major.minor.patch>.<GITHUB_RUN_NUMBER>.
- The publish job fails fast if the version string is not valid major.minor.patch.
- New bump-version job runs after publish and opens a PR against main that bumps version.go to a tentative next patch version (-SNAPSHOT), for a human to adjust before merging.

Fixes #500

## Test plan
- [x] go build ./... and go run . --version confirm the current version string still builds and prints correctly
- [x] YAML syntax validated (python3 -c "import yaml; yaml.safe_load(...)")
- [x] Version-extraction/tag/bump bash logic simulated locally against several sample version.go contents, including a malformed one (correctly rejected)
- [x] Not verified via an actual workflow_dispatch run, since that would cut a real release - needs a first real run to confirm end-to-end (tag creation, PR auto-open with correct permissions)

Generated with Claude Code