### PR TITLE
fix: truncate user list to first 10 in permission limitation notes

### DIFF
--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -239,6 +239,26 @@ func collectLimitations(runDir, exportDir string, mapping structure.ExtractMappi
 	return out
 }
 
+// maxListedLimitationUsers caps how many logins are spelled out in a
+// user-permission limitation note (#475) — instances with thousands
+// of users but only a handful holding the affected permissions were
+// producing an unreadably long PDF report.
+const maxListedLimitationUsers = 10
+
+// formatLimitationUserList renders logins for a user-permission
+// limitation note (#475): all of them when there are at most
+// maxListedLimitationUsers, otherwise only the first
+// maxListedLimitationUsers plus a count of the rest.
+func formatLimitationUserList(logins []string) string {
+	if len(logins) <= maxListedLimitationUsers {
+		return strings.Join(logins, ", ")
+	}
+	return fmt.Sprintf("first %d: %s (and %d more)",
+		maxListedLimitationUsers,
+		strings.Join(logins[:maxListedLimitationUsers], ", "),
+		len(logins)-maxListedLimitationUsers)
+}
+
 // collectUserPermissionLimitations covers #230 Y3 and Y4. SonarQube
 // Cloud does not expose a way to grant permissions to individual
 // users via API — only to groups — so any SQS user permission on a
@@ -286,12 +306,12 @@ func collectUserPermissionLimitations(exportDir string, mapping structure.Extrac
 		sort.Strings(combined)
 		notes = append(notes, fmt.Sprintf(
 			"SonarQube Cloud does not support user permissions via API. The following %d user(s) had permissions on SonarQube Server permission templates and were not migrated: %s.",
-			len(combined), strings.Join(combined, ", ")))
+			len(combined), formatLimitationUserList(combined)))
 	}
 	if globalLogins := collect("getUserPermissions"); len(globalLogins) > 0 {
 		notes = append(notes, fmt.Sprintf(
 			"SonarQube Cloud does not support user permissions via API. The following %d user(s) had global SonarQube Server permissions and were not migrated: %s.",
-			len(globalLogins), strings.Join(globalLogins, ", ")))
+			len(globalLogins), formatLimitationUserList(globalLogins)))
 	}
 	return notes
 }

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -6,6 +6,7 @@ package summary
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1384,6 +1385,130 @@ func TestCollectSummaryNoApplicationsLimitation(t *testing.T) {
 		if strings.Contains(msg, "Applications") {
 			t.Errorf("Limitations must NOT mention applications when none extracted, got %q", msg)
 		}
+	}
+}
+
+// #475: formatLimitationUserList must list every login when there are
+// at most maxListedLimitationUsers, and truncate to the first
+// maxListedLimitationUsers plus a remainder count otherwise — a
+// migration with thousands of users but only a handful holding the
+// affected permissions was producing an unreadably long PDF report.
+func TestFormatLimitationUserList(t *testing.T) {
+	tests := []struct {
+		name   string
+		logins []string
+		want   string
+	}{
+		{
+			name:   "empty",
+			logins: nil,
+			want:   "",
+		},
+		{
+			name:   "below limit lists everyone",
+			logins: []string{"alice", "bob", "carol", "dave"},
+			want:   "alice, bob, carol, dave",
+		},
+		{
+			name: "exactly at limit lists everyone",
+			logins: []string{
+				"u01", "u02", "u03", "u04", "u05", "u06", "u07", "u08", "u09", "u10",
+			},
+			want: "u01, u02, u03, u04, u05, u06, u07, u08, u09, u10",
+		},
+		{
+			name: "above limit truncates with remainder count",
+			logins: []string{
+				"u01", "u02", "u03", "u04", "u05", "u06", "u07", "u08", "u09", "u10", "u11", "u12",
+			},
+			want: "first 10: u01, u02, u03, u04, u05, u06, u07, u08, u09, u10 (and 2 more)",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatLimitationUserList(tc.logins)
+			if got != tc.want {
+				t.Errorf("formatLimitationUserList(%v) = %q, want %q", tc.logins, got, tc.want)
+			}
+		})
+	}
+}
+
+// #475: the global-permissions limitation note must truncate to the
+// first 10 logins plus a count of the rest when more than 10 users
+// held global SonarQube Server permissions.
+func TestCollectSummaryGlobalPermissionsLimitationTruncatesAt10(t *testing.T) {
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, "run1")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	extractDir := filepath.Join(dir, "extract-01")
+	writeExtractMeta(t, extractDir, "https://sq.example.com")
+	var items []map[string]any
+	for i := 1; i <= 12; i++ {
+		items = append(items, map[string]any{"login": fmt.Sprintf("user%02d", i)})
+	}
+	writeTaskJSONL(t, extractDir, "getUserPermissions", items)
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	var msg string
+	for _, l := range summary.Limitations {
+		if strings.Contains(l, "had global SonarQube Server permissions") {
+			msg = l
+			break
+		}
+	}
+	if msg == "" {
+		t.Fatalf("expected a global-permissions limitation note, got %v", summary.Limitations)
+	}
+	if !strings.Contains(msg, "12 user(s)") {
+		t.Errorf("expected total count of 12, got %q", msg)
+	}
+	if !strings.Contains(msg, "first 10: user01, user02, user03, user04, user05, user06, user07, user08, user09, user10 (and 2 more)") {
+		t.Errorf("expected truncated list of first 10 with remainder count, got %q", msg)
+	}
+	if strings.Contains(msg, "user11") || strings.Contains(msg, "user12") {
+		t.Errorf("expected users beyond the first 10 to be omitted, got %q", msg)
+	}
+}
+
+// #475: when at most 10 users held global SonarQube Server
+// permissions, every login must still be listed explicitly.
+func TestCollectSummaryGlobalPermissionsLimitationListsAllBelow10(t *testing.T) {
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, "run1")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	extractDir := filepath.Join(dir, "extract-01")
+	writeExtractMeta(t, extractDir, "https://sq.example.com")
+	writeTaskJSONL(t, extractDir, "getUserPermissions", []map[string]any{
+		{"login": "alice"}, {"login": "bob"}, {"login": "carol"}, {"login": "dave"},
+	})
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	var msg string
+	for _, l := range summary.Limitations {
+		if strings.Contains(l, "had global SonarQube Server permissions") {
+			msg = l
+			break
+		}
+	}
+	if msg == "" {
+		t.Fatalf("expected a global-permissions limitation note, got %v", summary.Limitations)
+	}
+	if !strings.Contains(msg, "4 user(s) had global SonarQube Server permissions and were not migrated: alice, bob, carol, dave.") {
+		t.Errorf("expected all 4 logins listed explicitly, got %q", msg)
+	}
+	if strings.Contains(msg, "first 10") || strings.Contains(msg, "more)") {
+		t.Errorf("must not truncate when at or below the limit, got %q", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The Migration Limitations section of the PDF report listed every user with unmigrated global/permission-template SonarQube Server permissions, regardless of count. On instances with thousands of users, this made the report unreadably verbose even though usually only a handful of users hold those permissions.
- Added a formatLimitationUserList helper (10-user cap) and wired it into both the global-permissions and permission-template limitation messages in collectUserPermissionLimitations.
- <=10 affected users: unchanged behavior, all logins listed.
- >10 affected users: only the first 10 are listed explicitly, followed by a count of the rest, e.g. "first 10: u1, ..., u10 (and 2 more)".

Fixes #475

## Test plan
- [x] New table test for formatLimitationUserList covering empty / below-limit / exactly-at-limit / above-limit cases
- [x] New end-to-end CollectSummary test with 12 users confirming truncation and the remainder count, and that users beyond the first 10 are omitted
- [x] New end-to-end CollectSummary test with 4 users confirming all are still listed explicitly
- [x] go test ./... passes across the whole module
- [x] go build ./..., gofmt, go vet clean on the changed files
- [x] SonarQube Agentic Analysis (DEEP) run on both changed files; only pre-existing Cognitive Complexity findings unrelated to this change were reported

Generated with Claude Code