### PR TITLE
fix: bump actions off deprecated Node.js 20 runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: '1.25'
       - name: Run Go library tests with coverage
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: '1.25'
       - name: Build binary
@@ -276,7 +276,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: '1.25'
       - name: Run Go library tests with coverage
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: '1.25'
       - name: Build binary
@@ -227,7 +227,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
@@ -326,7 +326,7 @@ jobs:
           path: dist/
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.release.outputs.tag }}
           name: ${{ steps.release.outputs.tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: '1.25'
 


### PR DESCRIPTION
## Summary
- GitHub Actions now forces actions/setup-go@v5, actions/setup-java@v4, and softprops/action-gh-release@v2 onto Node 24 with a deprecation warning on every run, since all three still target the deprecated Node.js 20 runtime.
- Bumped actions/setup-go@v5 to v7 (test.yml, build.yml x2, release.yml x2).
- Bumped actions/setup-java@v4 to v5 (build.yml, release.yml).
- Bumped softprops/action-gh-release@v2 to v3 (release.yml).
- Verified via GitHub API that every other action in the workflows (actions/checkout@v6, the SHA-pinned download-artifact/upload-artifact, and all SonarSource/* actions) is already on Node 24 or is a composite action, so no change was needed there.

Fixes #509

## Test plan
- [x] Confirmed via each action.yml (runs.using field) that setup-go@v5, setup-java@v4, and action-gh-release@v2 target node20, and that v7/v5/v3 target node24
- [x] Reviewed release notes for all three major-version bumps; each is primarily a Node 20 to 24 runtime bump with no breaking input or behavior changes
- [x] YAML syntax validated on all three modified workflow files
- [x] SonarQube Agentic Analysis (DEEP) run on all three files; only pre-existing, unrelated SHA-pinning findings on other actions were reported

Generated with Claude Code