### PR TITLE
fix: exclude favicon, font, and image files from SonarCloud scan

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,6 @@ sonar.go.coverage.reportPaths=lib/sq-api-go/coverage.sonar.out,go/coverage.sonar
 sonar.sources=lib/sq-api-go,go/cmd,go/internal,go/main.go
 sonar.tests=go/internal
 sonar.test.inclusions=**/*_test.go
-sonar.exclusions=**/*.pb.go,go/internal/gui/frontend/**
+sonar.exclusions=**/*.pb.go,go/internal/gui/frontend/**,**/*.ico,**/*.ttf
 sonar.coverage.exclusions=**/*_test.go,**/cli_prompter.go,**/*.pb.go,go/cmd/**
 sonar.cpd.exclusions=**/*_test.go

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,6 @@ sonar.go.coverage.reportPaths=lib/sq-api-go/coverage.sonar.out,go/coverage.sonar
 sonar.sources=lib/sq-api-go,go/cmd,go/internal,go/main.go
 sonar.tests=go/internal
 sonar.test.inclusions=**/*_test.go
-sonar.exclusions=**/*.pb.go,go/internal/gui/frontend/**,**/*.ico,**/*.ttf
+sonar.exclusions=**/*.pb.go,go/internal/gui/frontend/**,**/*.ico,**/*.ttf,**/*.png
 sonar.coverage.exclusions=**/*_test.go,**/cli_prompter.go,**/*.pb.go,go/cmd/**
 sonar.cpd.exclusions=**/*_test.go


### PR DESCRIPTION
## Summary
- Scanner logs and the SonarCloud analysis overview both warned about "Invalid character encountered ... for encoding UTF-8" for several binary assets analyzed as source text: go/internal/gui/static/favicon.ico, the six bundled .ttf fonts under go/internal/report/summary/fonts/, and two .png images under go/internal/report/summary/images/ (sonar-logo-footer.png, sonar-logo-header.png).
- Added **/*.ico, **/*.ttf, and **/*.png to sonar.exclusions in sonar-project.properties. The .ico/.ttf exclusions match the exact change requested in the issue; .png was added afterward since it hit the identical warning and was already visible in the same log the issue quotes.

Fixes #511

## Test plan
- [x] Confirmed via find that every file named in the issue warning log (favicon.ico, 6 .ttf fonts, 2 .png images) matches the new exclusion patterns
- [x] SonarQube Agentic Analysis (DEEP) run on the modified file after each change; clean, no issues

Generated with Claude Code