### PR TITLE
fix: pass sonar.projectVersion dynamically to the scanner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,9 +49,19 @@ jobs:
         with:
           secrets: |
             development/kv/data/sonarcloud token | SONAR_TOKEN;
+      - name: Compute project version
+        if: env.SONAR_ANALYSIS_ENABLED == 'true'
+        id: project_version
+        run: |
+          RAW_VERSION="$(grep -oE 'const Version = "[^"]+"' go/internal/version/version.go | cut -d'"' -f2)"
+          VERSION="${RAW_VERSION#v}"
+          VERSION="${VERSION%%-*}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       - name: SonarQube Scan
         if: env.SONAR_ANALYSIS_ENABLED == 'true'
         uses: SonarSource/sonarqube-scan-action@v8
+        with:
+          args: -Dsonar.projectVersion=${{ steps.project_version.outputs.version }}
         env:
           # `|| '{}'` is load-bearing: GitHub evaluates a step's `env` expressions
           # even when its `if` is false, so when "Fetch Vault secrets" is skipped

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,17 @@ jobs:
         with:
           secrets: |
             development/kv/data/sonarcloud token | SONAR_TOKEN;
+      - name: Compute project version
+        id: project_version
+        run: |
+          RAW_VERSION="$(grep -oE 'const Version = "[^"]+"' go/internal/version/version.go | cut -d'"' -f2)"
+          VERSION="${RAW_VERSION#v}"
+          VERSION="${VERSION%%-*}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v8
+        with:
+          args: -Dsonar.projectVersion=${{ steps.project_version.outputs.version }}
         env:
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,18 @@ jobs:
           secrets: |
             development/kv/data/sonarcloud token | SONAR_TOKEN;
 
+      - name: Compute project version
+        id: project_version
+        run: |
+          RAW_VERSION="$(grep -oE 'const Version = "[^"]+"' go/internal/version/version.go | cut -d'"' -f2)"
+          VERSION="${RAW_VERSION#v}"
+          VERSION="${VERSION%%-*}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: SonarQube Cloud Scan
         uses: SonarSource/sonarqube-scan-action@v8
+        with:
+          args: -Dsonar.projectVersion=${{ steps.project_version.outputs.version }}
         env:
           # Reference the token from Vault
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- The SonarQube Cloud scan never set sonar.projectVersion, so the dashboard showed the version as not provided, and new code period management was effectively broken.
- Added a Compute project version step to each scan-running job in test.yml, build.yml, and release.yml. It extracts the Version constant from go/internal/version/version.go, strips the leading v and any SUFFIX such as SNAPSHOT, and exposes the bare major.minor.patch as a step output, reusing the same extraction logic already established in the release.yml publish job from #500.
- Wired that output into the SonarQube Scan step via the sonarqube-scan-action args input, passing sonar.projectVersion equal to the computed version.
- In build.yml the new step respects the existing SONAR_ANALYSIS_ENABLED fork-PR guard so it does not run when the scan itself is skipped.

Fixes #513

## Test plan
- [x] Simulated the extraction logic locally against the current version.go, v1.1.0-SNAPSHOT, confirmed it yields 1.1.0
- [x] YAML syntax validated on all three modified workflow files
- [x] SonarQube Agentic Analysis DEEP run on all three files; only pre-existing, unrelated SHA-pinning findings on other actions were reported
- [ ] Not verified via an actual workflow run against SonarCloud since that would require a real scan; the next run on main should show the version populated

Generated with Claude Code