### PR TITLE
GUI progress bar with ETA for extract/migrate (#519)

### DIFF
--- a/go/internal/common/progress_tracker.go
+++ b/go/internal/common/progress_tracker.go
@@ -121,6 +121,8 @@ type Tracker struct {
 	mu        sync.Mutex
 	completed map[string]bool
 
+	onUpdate func(percent float64, eta time.Duration, known bool)
+
 	stopOnce sync.Once
 	stopCh   chan struct{}
 	doneCh   chan struct{}
@@ -159,6 +161,19 @@ func (t *Tracker) Registry() *ProgressRegistry {
 	return t.registry
 }
 
+// OnUpdate registers fn to be called with the same (percent, eta, known)
+// values as each log line — from the periodic ticker (#520) and from
+// LogFinal's closing 100% snapshot. Used by the GUI (#519) to drive a
+// progress bar without touching CLI behavior: callers that never call
+// OnUpdate get no extra work, and a nil receiver is a no-op so it's safe
+// to call unconditionally on a Tracker built from an unset config field.
+func (t *Tracker) OnUpdate(fn func(percent float64, eta time.Duration, known bool)) {
+	if t == nil {
+		return
+	}
+	t.onUpdate = fn
+}
+
 // MarkTaskComplete records that a task's Run function has returned
 // successfully — it now counts as 100% of its category's per-task share
 // regardless of whether it had a registered item-level logger. A nil
@@ -174,8 +189,17 @@ func (t *Tracker) MarkTaskComplete(name string) {
 }
 
 // Start launches a goroutine that logs the overall progress/ETA line every
-// interval until ctx is done or Stop is called.
+// interval until ctx is done or Stop is called. It also immediately pushes
+// one snapshot through OnUpdate (log-free) so a GUI progress bar appears
+// at 0% right away instead of staying hidden for the first interval — or,
+// on a run shorter than interval, staying hidden until LogFinal (#519).
+// The #520 log cadence itself is untouched: the first log line still
+// waits for the first real tick.
 func (t *Tracker) Start(ctx context.Context, interval time.Duration) {
+	if t.onUpdate != nil {
+		percent, eta, known := t.snapshot()
+		t.onUpdate(percent, eta, known)
+	}
 	go func() {
 		defer close(t.doneCh)
 		ticker := time.NewTicker(interval)
@@ -209,11 +233,14 @@ func (t *Tracker) logOnce() {
 		etaStr = FormatHMS(eta)
 	}
 	t.logger.Info(fmt.Sprintf("-----> Overall progress: %d%% - ETA: %s", int(percent), etaStr))
+	if t.onUpdate != nil {
+		t.onUpdate(percent, eta, known)
+	}
 }
 
 // LogFinal emits the closing "-----> Overall progress: 100% - ETA: 00:00:00"
 // line. Call it once, explicitly, right after a run finishes all phases
-// successfully — unlike logOnce (driven by the 30s ticker, and derived from
+// successfully — unlike logOnce (driven by the periodic ticker, and derived from
 // the live snapshot), this always reports exactly 100%/00:00:00 rather than
 // whatever the last snapshot happened to compute, so operators get an
 // unambiguous "done" line even if the run completed between ticks. Do not
@@ -223,6 +250,9 @@ func (t *Tracker) LogFinal() {
 		return
 	}
 	t.logger.Info(fmt.Sprintf("-----> Overall progress: 100%% - ETA: %s", FormatHMS(0)))
+	if t.onUpdate != nil {
+		t.onUpdate(100, 0, true)
+	}
 }
 
 // snapshot computes the current overall percentage (0-100) and ETA. known

--- a/go/internal/common/progress_tracker_test.go
+++ b/go/internal/common/progress_tracker_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"math"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -214,6 +215,115 @@ func TestTrackerLogFinal(t *testing.T) {
 func TestTrackerLogFinalNilSafe(t *testing.T) {
 	var tr *Tracker
 	tr.LogFinal() // must not panic
+}
+
+// OnUpdate's callback (#519) must fire with the same values as the log
+// line on every tick, so a GUI progress bar stays in sync with the #520
+// log output without re-deriving the snapshot itself.
+func TestTrackerOnUpdateFiresFromTicker(t *testing.T) {
+	logger := testLogger()
+
+	plan := [][]string{{"general-1", "config-1"}}
+	tr := NewTracker(logger, plan, categorizeByPrefix, DefaultCategoryWeights)
+	registerPartial(tr, "config-1", 1, 2) // non-zero progress so ETA becomes known
+
+	type update struct {
+		percent float64
+		eta     time.Duration
+		known   bool
+	}
+	var mu sync.Mutex
+	var got []update
+	tr.OnUpdate(func(percent float64, eta time.Duration, known bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		got = append(got, update{percent, eta, known})
+	})
+
+	tr.Start(context.Background(), 10*time.Millisecond)
+	time.Sleep(35 * time.Millisecond)
+	tr.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) == 0 {
+		t.Fatal("expected at least one OnUpdate call")
+	}
+	for _, u := range got {
+		if !u.known {
+			t.Errorf("update %+v: known = false, want true (progress > 0)", u)
+		}
+		if u.percent <= 0 {
+			t.Errorf("update %+v: percent <= 0, want > 0", u)
+		}
+	}
+}
+
+// Start must push one OnUpdate snapshot immediately, without waiting for
+// the first tick — time.NewTicker only fires after a full interval, so
+// without this a GUI progress bar would stay hidden for the whole
+// interval, or (on a run shorter than interval) never show anything
+// before LogFinal's single closing call. Uses a long interval so only
+// the immediate call, never a real tick, could produce a result (#519).
+func TestTrackerOnUpdateFiresImmediatelyOnStart(t *testing.T) {
+	plan := [][]string{{"general-1", "config-1"}}
+	tr := NewTracker(testLogger(), plan, categorizeByPrefix, DefaultCategoryWeights)
+	registerPartial(tr, "config-1", 1, 2)
+
+	var mu sync.Mutex
+	var calls int
+	tr.OnUpdate(func(percent float64, eta time.Duration, known bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+	})
+
+	tr.Start(context.Background(), time.Hour)
+	defer tr.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Errorf("calls = %d, want exactly 1 (the immediate snapshot, no tick could have fired)", calls)
+	}
+}
+
+// LogFinal must push the fixed 100%/0s closing snapshot through OnUpdate
+// too, so the GUI snaps its bar to "done" immediately rather than waiting
+// for the next tick.
+func TestTrackerOnUpdateFiresFromLogFinal(t *testing.T) {
+	plan := [][]string{{"general-1", "config-1"}}
+	tr := NewTracker(testLogger(), plan, categorizeByPrefix, DefaultCategoryWeights)
+	registerPartial(tr, "config-1", 1, 2)
+
+	var gotPercent float64
+	var gotETA time.Duration
+	var gotKnown bool
+	tr.OnUpdate(func(percent float64, eta time.Duration, known bool) {
+		gotPercent, gotETA, gotKnown = percent, eta, known
+	})
+
+	tr.LogFinal()
+
+	if gotPercent != 100 {
+		t.Errorf("percent = %v, want 100", gotPercent)
+	}
+	if gotETA != 0 {
+		t.Errorf("eta = %v, want 0", gotETA)
+	}
+	if !gotKnown {
+		t.Error("known = false, want true")
+	}
+}
+
+// OnUpdate must be a no-op on a nil *Tracker, same nil-safety contract as
+// the rest of the type (production call sites set it unconditionally via
+// e.Progress.OnUpdate(cfg.ProgressCallback) even when Progress is unset).
+func TestTrackerOnUpdateNilSafe(t *testing.T) {
+	var tr *Tracker
+	tr.OnUpdate(func(percent float64, eta time.Duration, known bool) {
+		t.Error("callback must never be invoked via a nil Tracker")
+	}) // must not panic
 }
 
 // Registry/MarkTaskComplete must be safe to call on a nil *Tracker so

--- a/go/internal/extract/extract.go
+++ b/go/internal/extract/extract.go
@@ -51,6 +51,11 @@ type ExtractConfig struct {
 	// requested projects are fetched and all downstream per-project tasks
 	// naturally scope to the same set.
 	ProjectKeys []string
+	// ProgressCallback, when set, is invoked with the same run-wide
+	// percent/ETA snapshot as the #520 log line, on every tick and once
+	// more at completion. Nil for CLI callers (go/cmd/extract.go); the
+	// GUI wizard sets it to drive a progress bar (#519).
+	ProgressCallback func(percent float64, eta time.Duration, known bool)
 }
 
 // Executor is the runtime context passed to every task function.
@@ -140,10 +145,11 @@ func RunExtract(ctx context.Context, cfg ExtractConfig) ([]string, error) {
 	executor.ProjectKeys = cfg.ProjectKeys
 	executor.SkipIssueSync = cfg.SkipIssueSync
 
-	// Overall progress/ETA logging (#520) — every 30s for the duration of
+	// Overall progress/ETA logging (#520) — every 10s for the duration of
 	// the run, stopped once phases finish (success or error).
 	executor.Progress = common.NewTracker(executor.Logger, plan, CategorizeTask, common.DefaultCategoryWeights)
-	executor.Progress.Start(ctx, 30*time.Second)
+	executor.Progress.OnUpdate(cfg.ProgressCallback)
+	executor.Progress.Start(ctx, 10*time.Second)
 	defer executor.Progress.Stop()
 
 	if err := executePhases(ctx, executor, plan, registry, store); err != nil {

--- a/go/internal/gui/protocol.go
+++ b/go/internal/gui/protocol.go
@@ -15,15 +15,16 @@ const (
 	TypePromptConfirmReview = "prompt_confirm_review"
 	TypePromptChoice        = "prompt_choice"
 
-	TypeDisplayWelcome        = "display_welcome"
-	TypeDisplayPhaseProgress  = "display_phase_progress"
-	TypeDisplayMessage        = "display_message"
-	TypeDisplayError          = "display_error"
-	TypeDisplayWarning        = "display_warning"
-	TypeDisplaySuccess        = "display_success"
-	TypeDisplaySummary        = "display_summary"
-	TypeDisplayResumeInfo     = "display_resume_info"
-	TypeDisplayWizardComplete = "display_wizard_complete"
+	TypeDisplayWelcome         = "display_welcome"
+	TypeDisplayPhaseProgress   = "display_phase_progress"
+	TypeDisplayOverallProgress = "display_overall_progress"
+	TypeDisplayMessage         = "display_message"
+	TypeDisplayError           = "display_error"
+	TypeDisplayWarning         = "display_warning"
+	TypeDisplaySuccess         = "display_success"
+	TypeDisplaySummary         = "display_summary"
+	TypeDisplayResumeInfo      = "display_resume_info"
+	TypeDisplayWizardComplete  = "display_wizard_complete"
 
 	TypeWizardStarted  = "wizard_started"
 	TypeWizardFinished = "wizard_finished"
@@ -44,24 +45,32 @@ type KVPair struct {
 
 // ServerMessage is sent from the Go server to the browser.
 type ServerMessage struct {
-	Type      string   `json:"type"`
-	ID        string   `json:"id,omitempty"`
-	Message   string   `json:"message,omitempty"`
-	Validate  bool     `json:"validate,omitempty"`
-	Default   any      `json:"default,omitempty"`
-	Title     string   `json:"title,omitempty"`
-	Details   []KVPair `json:"details,omitempty"`
-	Phase     string   `json:"phase,omitempty"`
-	Index     int      `json:"index,omitempty"`
-	Total     int      `json:"total,omitempty"`
-	Name      string   `json:"name,omitempty"`
-	Stats     []KVPair `json:"stats,omitempty"`
-	SourceURL string   `json:"source_url,omitempty"`
-	TargetURL string   `json:"target_url,omitempty"`
-	ExtractID string   `json:"extract_id,omitempty"`
+	Type        string   `json:"type"`
+	ID          string   `json:"id,omitempty"`
+	Message     string   `json:"message,omitempty"`
+	Validate    bool     `json:"validate,omitempty"`
+	Default     any      `json:"default,omitempty"`
+	Title       string   `json:"title,omitempty"`
+	Details     []KVPair `json:"details,omitempty"`
+	Phase       string   `json:"phase,omitempty"`
+	Index       int      `json:"index,omitempty"`
+	Total       int      `json:"total,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Stats       []KVPair `json:"stats,omitempty"`
+	SourceURL   string   `json:"source_url,omitempty"`
+	TargetURL   string   `json:"target_url,omitempty"`
+	ExtractID   string   `json:"extract_id,omitempty"`
 	Error       *string  `json:"error"`
 	BackEnabled bool     `json:"back_enabled,omitempty"`
 	Options     []string `json:"options,omitempty"`
+
+	// Percent / EtaSeconds / Known carry the #520 run-wide progress
+	// snapshot for display_overall_progress (#519). No omitempty on
+	// Percent/Known: a legitimate 0% / not-yet-known message must
+	// still serialize.
+	Percent    float64 `json:"percent"`
+	EtaSeconds int     `json:"eta_seconds,omitempty"`
+	Known      bool    `json:"known"`
 }
 
 // ClientMessage is sent from the browser to the Go server.

--- a/go/internal/gui/protocol.go
+++ b/go/internal/gui/protocol.go
@@ -65,11 +65,12 @@ type ServerMessage struct {
 	Options     []string `json:"options,omitempty"`
 
 	// Percent / EtaSeconds / Known carry the #520 run-wide progress
-	// snapshot for display_overall_progress (#519). No omitempty on
-	// Percent/Known: a legitimate 0% / not-yet-known message must
-	// still serialize.
+	// snapshot for display_overall_progress (#519). No omitempty on any
+	// of the three: a legitimate 0% / 0-second ETA (e.g. LogFinal's
+	// 100%/0s closing snapshot) / not-yet-known message must still
+	// serialize, or the JS side sees `undefined` and renders "~NaN min".
 	Percent    float64 `json:"percent"`
-	EtaSeconds int     `json:"eta_seconds,omitempty"`
+	EtaSeconds int     `json:"eta_seconds"`
 	Known      bool    `json:"known"`
 }
 

--- a/go/internal/gui/templates/base.html
+++ b/go/internal/gui/templates/base.html
@@ -19,7 +19,7 @@
 		<div id="header-inner" class="header-inner">
 			<div id="header-left" class="header-left">
 				<span id="header-title" class="header-title">SonarQube Server To Cloud Migration</span>
-				<span id="header-experimental" class="header-experimental" title="The GUI is experimental and may change or have rough edges.">Experimental</span>
+				<span id="header-experimental" class="header-experimental" title="The GUI is in beta and may change or have rough edges.">Beta</span>
 				<nav id="header-nav" class="header-nav">
 					<a id="nav-wizard" href="/" {{if eq .ActiveNav "wizard"}}class="active"{{end}}>Wizard</a>
 					<a id="nav-history" href="/history" {{if eq .ActiveNav "history"}}class="active"{{end}}>History</a>

--- a/go/internal/gui/templates/wizard.html
+++ b/go/internal/gui/templates/wizard.html
@@ -32,6 +32,10 @@
 				<span class="spinner"></span>
 				<span id="processing-text">Processing...</span>
 			</div>
+			<div id="overall-progress" class="overall-progress hidden">
+				<div class="progress-track"><div id="overall-progress-fill" class="progress-fill"></div></div>
+				<span id="overall-progress-eta" class="progress-eta"></span>
+			</div>
 		</div>
 
 		<div id="event-log-card" class="card mt-2">
@@ -53,6 +57,31 @@
 	animation: spin 0.8s linear infinite;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
+
+.overall-progress {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin-top: 0.5rem;
+}
+.progress-track {
+	flex: 1;
+	height: 8px;
+	border-radius: 4px;
+	background: var(--color-border);
+	overflow: hidden;
+}
+.progress-fill {
+	height: 100%;
+	width: 0%;
+	background: var(--color-primary);
+	transition: width 0.3s ease-out;
+}
+.progress-eta {
+	font-size: 0.8rem;
+	color: var(--color-text-muted, #888);
+	white-space: nowrap;
+}
 
 .prompt .input-row {
 	display: flex;
@@ -213,6 +242,9 @@ var Wizard = (function() {
 		case 'display_phase_progress':
 			onPhaseProgress(msg);
 			break;
+		case 'display_overall_progress':
+			onOverallProgress(msg);
+			break;
 		case 'display_message':
 			showProcessing(msg.message);
 			addLogEntry(msg.message, msg.type);
@@ -289,6 +321,25 @@ var Wizard = (function() {
 		const text = `Phase ${msg.index}/${msg.total}: ${msg.name}`;
 		showProcessing(text);
 		addLogEntry(text, 'display_phase_progress');
+	}
+
+	function onOverallProgress(msg) {
+		const box = document.getElementById('overall-progress');
+		const fill = document.getElementById('overall-progress-fill');
+		const eta = document.getElementById('overall-progress-eta');
+		box.classList.remove(HIDDEN);
+		fill.style.width = `${msg.percent}%`;
+		eta.textContent = msg.known ? `ETA: ${formatETA(msg.eta_seconds)}` : 'ETA: calculating...';
+	}
+
+	// Below 2 minutes, "~1 min"/"~0 min" reads as imprecise or done-ish
+	// when it isn't — show exact seconds instead. At/above 2 minutes,
+	// round to the nearest minute per issue #519.
+	function formatETA(seconds) {
+		if (seconds < 120) {
+			return `${Math.round(seconds)}s`;
+		}
+		return `~${Math.round(seconds / 60)} min`;
 	}
 
 	// --- Phase input capture ---
@@ -795,6 +846,10 @@ var Wizard = (function() {
 		const proc = document.getElementById('processing');
 		proc.classList.add(HIDDEN);
 		proc.style.display = 'none';
+
+		const progress = document.getElementById('overall-progress');
+		progress.classList.add(HIDDEN);
+		document.getElementById('overall-progress-fill').style.width = '0%';
 	}
 
 	function hidePrompt() {

--- a/go/internal/gui/templates/wizard.html
+++ b/go/internal/gui/templates/wizard.html
@@ -122,6 +122,8 @@ var Wizard = (function() {
 	const HIDDEN = 'hidden';
 	const ID_PROMPT_AREA = 'prompt-area';
 	const ID_PROMPT_INPUT = 'prompt-input';
+	// Below this, an ETA reads clearer as exact seconds than as "~0 min" (#519).
+	const ETA_SECONDS_AS_TEXT_THRESHOLD = 120;
 
 	const EYE_SVG = `<svg xmlns="http://www.w3.org/2000/svg"
 		viewBox="0 0 24 24" fill="currentColor"><path
@@ -336,10 +338,11 @@ var Wizard = (function() {
 	// when it isn't — show exact seconds instead. At/above 2 minutes,
 	// round to the nearest minute per issue #519.
 	function formatETA(seconds) {
-		if (seconds < 120) {
-			return `${Math.round(seconds)}s`;
+		const s = seconds || 0; // defend against a missing/undefined eta_seconds
+		if (s < ETA_SECONDS_AS_TEXT_THRESHOLD) {
+			return `${Math.round(s)}s`;
 		}
-		return `~${Math.round(seconds / 60)} min`;
+		return `~${Math.round(s / 60)} min`;
 	}
 
 	// --- Phase input capture ---

--- a/go/internal/gui/web_prompter.go
+++ b/go/internal/gui/web_prompter.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/wizard"
 )
@@ -157,6 +158,15 @@ func (wp *WebPrompter) DisplayPhaseProgress(phase wizard.WizardPhase) {
 		Index: wizard.PhaseIndex(phase),
 		Total: wizard.PhaseCount(),
 		Name:  wizard.PhaseDisplayName(phase),
+	})
+}
+
+func (wp *WebPrompter) DisplayOverallProgress(percent float64, eta time.Duration, known bool) {
+	wp.sendFn(ServerMessage{
+		Type:       TypeDisplayOverallProgress,
+		Percent:    percent,
+		EtaSeconds: int(eta.Seconds()),
+		Known:      known,
 	})
 }
 

--- a/go/internal/gui/web_prompter_test.go
+++ b/go/internal/gui/web_prompter_test.go
@@ -6,6 +6,8 @@ package gui
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -337,6 +339,26 @@ func TestDisplayOverallProgressUnknownETA(t *testing.T) {
 	}
 	if msg.Known {
 		t.Error("known: got true, want false")
+	}
+}
+
+// A 0-second ETA (LogFinal's 100%/0s closing snapshot, or any tick that
+// rounds down to 0s while known) must still serialize eta_seconds — an
+// omitted field arrives as `undefined` in JS and renders "ETA: ~NaN min".
+func TestDisplayOverallProgressZeroETASerializes(t *testing.T) {
+	sendFn, snapshot := collectMessages()
+	ctx := context.Background()
+	wp := NewWebPrompter(ctx, sendFn)
+
+	wp.DisplayOverallProgress(100, 0, true)
+	msg := snapshot()[0]
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"eta_seconds":0`) {
+		t.Errorf("expected eta_seconds:0 in serialized message, got: %s", data)
 	}
 }
 

--- a/go/internal/gui/web_prompter_test.go
+++ b/go/internal/gui/web_prompter_test.go
@@ -302,6 +302,44 @@ func TestDisplayPhaseProgressFields(t *testing.T) {
 	}
 }
 
+func TestDisplayOverallProgressFields(t *testing.T) {
+	sendFn, snapshot := collectMessages()
+	ctx := context.Background()
+	wp := NewWebPrompter(ctx, sendFn)
+
+	wp.DisplayOverallProgress(42, 12*time.Minute, true)
+	msg := snapshot()[0]
+
+	if msg.Type != TypeDisplayOverallProgress {
+		t.Errorf("type: got %q", msg.Type)
+	}
+	if msg.Percent != 42 {
+		t.Errorf("percent: got %v, want 42", msg.Percent)
+	}
+	if msg.EtaSeconds != 720 {
+		t.Errorf("eta_seconds: got %d, want 720", msg.EtaSeconds)
+	}
+	if !msg.Known {
+		t.Error("known: got false, want true")
+	}
+}
+
+func TestDisplayOverallProgressUnknownETA(t *testing.T) {
+	sendFn, snapshot := collectMessages()
+	ctx := context.Background()
+	wp := NewWebPrompter(ctx, sendFn)
+
+	wp.DisplayOverallProgress(0, 0, false)
+	msg := snapshot()[0]
+
+	if msg.Percent != 0 {
+		t.Errorf("percent: got %v, want 0", msg.Percent)
+	}
+	if msg.Known {
+		t.Error("known: got true, want false")
+	}
+}
+
 func TestDisplayResumeInfoWithNilPointers(t *testing.T) {
 	sendFn, snapshot := collectMessages()
 	ctx := context.Background()

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -134,27 +134,127 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 	base := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
 	logger := slog.New(newEventHandler(base, collector))
 
-	// Validate the project-key renaming pattern syntax before anything
-	// else — a malformed pattern is a config error the operator must fix
-	// (issue #138). The org-prefix collision guard runs later once the
-	// Cloud client exists.
-	if err := ValidateProjectKeyPattern(cfg.ProjectKeyPattern); err != nil {
-		return "", common.NewExitError(2, fmt.Errorf("invalid project_key_pattern: %w", err))
-	}
-
-	// Validate the SQC org mapping and apply --default_organization
-	// fallback if requested (issues #279 + #281). Done before any API
-	// client setup so the failure or warning surfaces immediately.
-	appliedDefault, err := applyOrgMapping(cfg.ExportDirectory, cfg.DefaultOrganization, logger)
+	appliedDefault, err := validateMigrateConfig(cfg, logger)
 	if err != nil {
 		return "", err
 	}
 
+	clients := newMigrateClients(cfg, logger)
+
+	// Verify every SQC organization the migration will touch exists and
+	// is visible to the token, and that the project-key pattern doesn't
+	// collide with one (issues #283, #138). Done early so a config error
+	// aborts the run before any extract data is touched.
+	if err := validateMigrateOrgs(ctx, clients.Cloud, cfg, appliedDefault); err != nil {
+		return "", err
+	}
+
+	mp, err := prepareMigratePlan(cfg, logger)
+	if err != nil {
+		return "", err
+	}
+	runIDOut = mp.RunID
+
+	// Best-effort run artifacts: written on every exit path (success or
+	// error) without altering retErr or panicking.
+	defer func() {
+		tm.CompletedAt = time.Now()
+		writeMigrateRunArtifacts(mp.RunDir, tm, retErr, cfg.ProjectKeyPattern, collector, logger)
+		// End-of-command timing line (#311) — paired with the per-task
+		// lines from runPhase so operators get a complete duration view.
+		common.LogCommandDuration(logger, "migrate", tm.StartedAt)
+	}()
+
+	defer writeRateLimitArtifact(mp.RunDir, clients.RateLimitTracker, logger)
+
+	// Filter completed tasks for resumability.
+	store := common.NewDataStore(mp.RunDir)
+	phases := filterCompleted(mp.Plan, store)
+
+	executor := &Executor{
+		Cloud:                clients.Cloud,
+		CloudAPI:             clients.CloudAPI,
+		Raw:                  clients.Raw,
+		RawAPI:               clients.RawAPI,
+		Extract:              nil, // Will be set per-task based on extract mapping
+		Store:                store,
+		CloudURL:             clients.CloudURL,
+		APIURL:               clients.APIURL,
+		EntKey:               cfg.EnterpriseKey,
+		Edition:              mp.Edition,
+		ExportDir:            cfg.ExportDirectory,
+		Mapping:              mp.Mapping,
+		Sem:                  make(chan struct{}, cfg.Concurrency),
+		ExcludeBranches:      cfg.ExcludeBranches,
+		UnsupportedLanguages: cfg.UnsupportedLanguages,
+		ProjectKeyPattern:    cfg.ProjectKeyPattern,
+		Logger:               logger,
+	}
+
+	// Overall progress/ETA logging (#520) — every 10s for the duration of
+	// the run, stopped once phases finish (success or error).
+	executor.Progress = common.NewTracker(logger, phases, CategorizeTask, common.DefaultCategoryWeights)
+	executor.Progress.OnUpdate(cfg.ProgressCallback)
+	executor.Progress.Start(ctx, 10*time.Second)
+	defer executor.Progress.Stop()
+
+	// Execute phases.
+	for i, phase := range phases {
+		logger.Info("starting phase", "phase", i+1, "tasks", len(phase))
+		if err := runPhase(ctx, executor, phase, mp.Registry, i+1, tm); err != nil {
+			return runIDOut, fmt.Errorf("phase %d: %w", i+1, err)
+		}
+		for _, taskName := range phase {
+			store.MarkComplete(taskName)
+		}
+	}
+	executor.Progress.LogFinal()
+
+	fmt.Printf("%s v%s - Migration Complete: %s\n", version.ToolName, version.Version, runIDOut)
+	return runIDOut, nil
+}
+
+// validateMigrateConfig validates the project-key renaming pattern syntax
+// and the SQC org mapping, applying the --default_organization fallback if
+// requested (issues #138, #279, #281). Both checks run before any API
+// client setup so a config error surfaces immediately.
+func validateMigrateConfig(cfg MigrateConfig, logger *slog.Logger) (appliedDefault bool, err error) {
+	if err := ValidateProjectKeyPattern(cfg.ProjectKeyPattern); err != nil {
+		return false, common.NewExitError(2, fmt.Errorf("invalid project_key_pattern: %w", err))
+	}
+	return applyOrgMapping(cfg.ExportDirectory, cfg.DefaultOrganization, logger)
+}
+
+// validateMigrateOrgs verifies every SQC organization the migration will
+// touch exists and is visible to the token (issue #283), and that the
+// project-key pattern's static prefix — used in place of
+// <ORGANIZATION_KEY> — doesn't collide with a real org (issue #138).
+func validateMigrateOrgs(ctx context.Context, cc *cloud.Client, cfg MigrateConfig, appliedDefault bool) error {
+	if err := validateOrgsExist(ctx, cc.Organizations, cfg.ExportDirectory, cfg.EnterpriseKey, cfg.DefaultOrganization, appliedDefault); err != nil {
+		return err
+	}
+	return validatePatternOrgCollision(ctx, cc.Organizations, cfg.ProjectKeyPattern)
+}
+
+// migrateClients bundles the Cloud API clients, raw readers, and
+// rate-limit tracker a migrate run wires together before executing tasks.
+type migrateClients struct {
+	Cloud            *cloud.Client
+	CloudAPI         *cloud.Client
+	Raw              *common.RawClient
+	RawAPI           *common.RawClient
+	CloudURL         string
+	APIURL           string
+	RateLimitTracker *RateLimitTracker
+}
+
+// newMigrateClients builds the standard and enterprise Cloud API clients
+// for a migrate run, wiring retry, rate-limit, and (when cfg.Debug is set)
+// full HTTP request/response logging into each one.
+func newMigrateClients(cfg MigrateConfig, logger *slog.Logger) *migrateClients {
 	cloudURL := cfg.URL
 	apiURL := strings.Replace(cloudURL, "https://", "https://api.", 1)
 
-	// Create Cloud clients with retry logging — and, when --debug is set,
-	// full HTTP request/response logging.
 	retryLog := func(method, url string, status, attempt, total int) {
 		logger.Warn("retrying request",
 			"method", method, "endpoint", url,
@@ -191,35 +291,38 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 	}
 	cloudClient := sqapi.NewCloudClient(cloudURL, cfg.Token, clientOpts...)
 	apiClient := sqapi.NewCloudClient(apiURL, cfg.Token, clientOpts...)
-	cc := cloud.New(cloudClient)
-	apiCC := cloud.New(apiClient)
 
-	// Verify every SQC organization the migration will touch exists and
-	// is visible to the token (issue #283). Done early so a typo aborts
-	// the run before any extract data is touched.
-	if err := validateOrgsExist(ctx, cc.Organizations, cfg.ExportDirectory, cfg.EnterpriseKey, cfg.DefaultOrganization, appliedDefault); err != nil {
-		return "", err
+	return &migrateClients{
+		Cloud:            cloud.New(cloudClient),
+		CloudAPI:         cloud.New(apiClient),
+		Raw:              common.NewRawClient(cloudClient.HTTPClient(), cloudClient.BaseURL()),
+		RawAPI:           common.NewRawClient(apiClient.HTTPClient(), apiClient.BaseURL()),
+		CloudURL:         cloudClient.BaseURL(),
+		APIURL:           apiClient.BaseURL(),
+		RateLimitTracker: rateLimitTracker,
 	}
+}
 
-	// When the key pattern carries a static prefix instead of <ORGANIZATION_KEY>,
-	// that prefix is shared by every project and could be mistaken for an
-	// organization-scoped key. Abort if it collides with a real SQC org
-	// (issue #138).
-	if err := validatePatternOrgCollision(ctx, cc.Organizations, cfg.ProjectKeyPattern); err != nil {
-		return "", err
-	}
+// migratePlan bundles the resolved extract mapping, task registry, and
+// dependency-resolved phase plan a migrate run executes.
+type migratePlan struct {
+	Mapping  structure.ExtractMapping
+	Edition  common.Edition
+	RunID    string
+	RunDir   string
+	Registry map[string]*TaskDef
+	Plan     [][]string
+}
 
-	// Create RawClients for read operations.
-	raw := common.NewRawClient(cloudClient.HTTPClient(), cloudClient.BaseURL())
-	rawAPI := common.NewRawClient(apiClient.HTTPClient(), apiClient.BaseURL())
-
-	// Resolve extract mapping.
+// prepareMigratePlan resolves the extract mapping, creates the run
+// directory, and builds the dependency-resolved phase plan for the
+// requested target tasks — persisting the plan metadata for a fresh run.
+func prepareMigratePlan(cfg MigrateConfig, logger *slog.Logger) (*migratePlan, error) {
 	mapping, err := structure.GetUniqueExtracts(cfg.ExportDirectory)
 	if err != nil {
-		return "", fmt.Errorf("scanning extracts: %w", err)
+		return nil, fmt.Errorf("scanning extracts: %w", err)
 	}
 
-	// Determine edition.
 	edition := common.Edition(cfg.Edition)
 
 	// Generate or resume run ID.
@@ -230,43 +333,10 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 	}
 	runDir := filepath.Join(cfg.ExportDirectory, runID)
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
-		return "", fmt.Errorf("creating run dir: %w", err)
+		return nil, fmt.Errorf("creating run dir: %w", err)
 	}
-	runIDOut = runID
 
-	// Best-effort run artifacts: written on every exit path (success or
-	// error) without altering retErr or panicking.
-	defer func() {
-		tm.CompletedAt = time.Now()
-		meta := RunMeta{
-			StartedAt:         tm.StartedAt,
-			CompletedAt:       tm.CompletedAt,
-			OverallStatus:     computeStatus(retErr, tm),
-			Phases:            tm.phasesSnapshot(),
-			Tasks:             tm.tasksSnapshot(),
-			ProjectKeyPattern: cfg.ProjectKeyPattern,
-		}
-		if b, err := json.MarshalIndent(meta, "", "  "); err == nil {
-			_ = os.WriteFile(filepath.Join(runDir, "run_meta.json"), b, 0o644)
-		}
-		if err := writeRunEvents(runDir, collector); err != nil {
-			logger.Warn("writing run events", "err", err)
-		}
-		// End-of-command timing line (#311) — paired with the per-task
-		// lines from runPhase so operators get a complete duration view.
-		common.LogCommandDuration(logger, "migrate", tm.StartedAt)
-	}()
-
-	defer func() {
-		if writeErr := rateLimitTracker.WriteJSON(filepath.Join(runDir, RateLimitEventsFile)); writeErr != nil {
-			logger.Warn("failed to write rate-limit events artefact", "err", writeErr)
-		}
-	}()
-
-	// Build task registry and plan.
-	allDefs := RegisterAll()
-	registry := BuildMigrateRegistry(allDefs)
-	registry = FilterByEdition(registry, edition)
+	registry := FilterByEdition(BuildMigrateRegistry(RegisterAll()), edition)
 
 	// Project-data migration covers importProjectData + the trailing
 	// issue/hotspot sync pair. Skipping it necessarily skips the
@@ -290,66 +360,57 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 	targets := MigrateTargetTasks(registry, cfg.TargetTask, cfg.SkipProfiles, cfg.IncludeProjectData, cfg.SkipIssueSync, cfg.SkipProjectDataMigration, cfg.TargetTasks)
 	taskSet := ResolveDependencies(targets, registry)
 	if taskSet == nil {
-		return "", fmt.Errorf("cannot resolve dependencies for target tasks")
+		return nil, fmt.Errorf("cannot resolve dependencies for target tasks")
 	}
 
 	plan, err := PlanPhases(taskSet, registry)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	// Write or load plan metadata.
+	// Write plan metadata for a fresh run.
 	if createPlan {
-		if err := writeMigrateMeta(runDir, plan, runID, edition, cloudURL, targets, registry); err != nil {
-			return "", err
+		if err := writeMigrateMeta(runDir, plan, runID, edition, cfg.URL, targets, registry); err != nil {
+			return nil, err
 		}
 	}
 
-	// Filter completed tasks for resumability.
-	store := common.NewDataStore(runDir)
-	plan = filterCompleted(plan, store)
+	return &migratePlan{
+		Mapping:  mapping,
+		Edition:  edition,
+		RunID:    runID,
+		RunDir:   runDir,
+		Registry: registry,
+		Plan:     plan,
+	}, nil
+}
 
-	executor := &Executor{
-		Cloud:                cc,
-		CloudAPI:             apiCC,
-		Raw:                  raw,
-		RawAPI:               rawAPI,
-		Extract:              nil, // Will be set per-task based on extract mapping
-		Store:                store,
-		CloudURL:             cloudClient.BaseURL(),
-		APIURL:               apiClient.BaseURL(),
-		EntKey:               cfg.EnterpriseKey,
-		Edition:              edition,
-		ExportDir:            cfg.ExportDirectory,
-		Mapping:              mapping,
-		Sem:                  make(chan struct{}, cfg.Concurrency),
-		ExcludeBranches:      cfg.ExcludeBranches,
-		UnsupportedLanguages: cfg.UnsupportedLanguages,
-		ProjectKeyPattern:    cfg.ProjectKeyPattern,
-		Logger:               logger,
+// writeMigrateRunArtifacts best-effort persists run_meta.json and the
+// collected run-events log on every exit path (success or error) without
+// altering retErr or panicking.
+func writeMigrateRunArtifacts(runDir string, tm *RunTimings, retErr error, keyPattern string, collector *eventCollector, logger *slog.Logger) {
+	meta := RunMeta{
+		StartedAt:         tm.StartedAt,
+		CompletedAt:       tm.CompletedAt,
+		OverallStatus:     computeStatus(retErr, tm),
+		Phases:            tm.phasesSnapshot(),
+		Tasks:             tm.tasksSnapshot(),
+		ProjectKeyPattern: keyPattern,
 	}
-
-	// Overall progress/ETA logging (#520) — every 10s for the duration of
-	// the run, stopped once phases finish (success or error).
-	executor.Progress = common.NewTracker(logger, plan, CategorizeTask, common.DefaultCategoryWeights)
-	executor.Progress.OnUpdate(cfg.ProgressCallback)
-	executor.Progress.Start(ctx, 10*time.Second)
-	defer executor.Progress.Stop()
-
-	// Execute phases.
-	for i, phase := range plan {
-		logger.Info("starting phase", "phase", i+1, "tasks", len(phase))
-		if err := runPhase(ctx, executor, phase, registry, i+1, tm); err != nil {
-			return runIDOut, fmt.Errorf("phase %d: %w", i+1, err)
-		}
-		for _, taskName := range phase {
-			store.MarkComplete(taskName)
-		}
+	if b, err := json.MarshalIndent(meta, "", "  "); err == nil {
+		_ = os.WriteFile(filepath.Join(runDir, "run_meta.json"), b, 0o644)
 	}
-	executor.Progress.LogFinal()
+	if err := writeRunEvents(runDir, collector); err != nil {
+		logger.Warn("writing run events", "err", err)
+	}
+}
 
-	fmt.Printf("%s v%s - Migration Complete: %s\n", version.ToolName, version.Version, runID)
-	return runID, nil
+// writeRateLimitArtifact best-effort persists the rate-limit events
+// collected during the run, for later PDF reporting.
+func writeRateLimitArtifact(runDir string, tracker *RateLimitTracker, logger *slog.Logger) {
+	if writeErr := tracker.WriteJSON(filepath.Join(runDir, RateLimitEventsFile)); writeErr != nil {
+		logger.Warn("failed to write rate-limit events artefact", "err", writeErr)
+	}
 }
 
 func runPhase(ctx context.Context, e *Executor, taskNames []string, registry map[string]*TaskDef, phaseIdx int, tm *RunTimings) error {

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -72,6 +72,12 @@ type MigrateConfig struct {
 	// SonarQube Cloud project key from the source key, the org key, and
 	// the enterprise key. Defaults to DefaultProjectKeyPattern. Issue #138.
 	ProjectKeyPattern string
+
+	// ProgressCallback, when set, is invoked with the same run-wide
+	// percent/ETA snapshot as the #520 log line, on every tick and once
+	// more at completion. Nil for CLI callers (go/cmd/migrate.go); the
+	// GUI wizard sets it to drive a progress bar (#519).
+	ProgressCallback func(percent float64, eta time.Duration, known bool)
 }
 
 // Executor is the runtime context passed to every migrate task function.
@@ -323,10 +329,11 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 		Logger:               logger,
 	}
 
-	// Overall progress/ETA logging (#520) — every 30s for the duration of
+	// Overall progress/ETA logging (#520) — every 10s for the duration of
 	// the run, stopped once phases finish (success or error).
 	executor.Progress = common.NewTracker(logger, plan, CategorizeTask, common.DefaultCategoryWeights)
-	executor.Progress.Start(ctx, 30*time.Second)
+	executor.Progress.OnUpdate(cfg.ProgressCallback)
+	executor.Progress.Start(ctx, 10*time.Second)
 	defer executor.Progress.Stop()
 
 	// Execute phases.

--- a/go/internal/wizard/cli_prompter.go
+++ b/go/internal/wizard/cli_prompter.go
@@ -7,6 +7,7 @@ package wizard
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 )
@@ -107,6 +108,12 @@ func (p *CLIPrompter) SetBackEnabled(bool) { /* no-op for CLI */ }
 func (p *CLIPrompter) DisplayWelcome() {
 	fmt.Println(welcomeBanner)
 }
+
+// DisplayOverallProgress is a no-op for the CLI: terminal users already
+// see the #520 "-----> Overall progress" line on stderr from the
+// extract/migrate logger itself, so a second rendering here would just
+// be duplicate/competing output (#519 is scoped to the GUI).
+func (p *CLIPrompter) DisplayOverallProgress(percent float64, eta time.Duration, known bool) {}
 
 func (p *CLIPrompter) DisplayPhaseProgress(phase WizardPhase) {
 	idx := PhaseIndex(phase)

--- a/go/internal/wizard/cli_prompter.go
+++ b/go/internal/wizard/cli_prompter.go
@@ -109,11 +109,12 @@ func (p *CLIPrompter) DisplayWelcome() {
 	fmt.Println(welcomeBanner)
 }
 
-// DisplayOverallProgress is a no-op for the CLI: terminal users already
-// see the #520 "-----> Overall progress" line on stderr from the
-// extract/migrate logger itself, so a second rendering here would just
-// be duplicate/competing output (#519 is scoped to the GUI).
-func (p *CLIPrompter) DisplayOverallProgress(percent float64, eta time.Duration, known bool) {}
+// DisplayOverallProgress is a no-op for the CLI (#519 is scoped to the GUI).
+func (p *CLIPrompter) DisplayOverallProgress(percent float64, eta time.Duration, known bool) {
+	// Terminal users already see the #520 "-----> Overall progress" line
+	// on stderr from the extract/migrate logger itself, so a second
+	// rendering here would just be duplicate/competing output.
+}
 
 func (p *CLIPrompter) DisplayPhaseProgress(phase WizardPhase) {
 	idx := PhaseIndex(phase)

--- a/go/internal/wizard/phases.go
+++ b/go/internal/wizard/phases.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/analysis"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/extract"
@@ -20,10 +21,14 @@ import (
 
 // Package-level function vars for external commands. Tests override these.
 var (
-	runExtractFn = func(ctx context.Context, cfg extract.ExtractConfig) ([]string, error) { return extract.RunExtract(ctx, cfg) }
+	runExtractFn = func(ctx context.Context, cfg extract.ExtractConfig) ([]string, error) {
+		return extract.RunExtract(ctx, cfg)
+	}
 	runStructureFn = func(exportDir string) error { return structure.RunStructure(exportDir) }
 	runMappingsFn  = func(exportDir string) error { return structure.RunMappings(exportDir) }
-	runMigrateFn = func(ctx context.Context, cfg migrate.MigrateConfig) (string, error) { return migrate.RunMigrate(ctx, cfg) }
+	runMigrateFn   = func(ctx context.Context, cfg migrate.MigrateConfig) (string, error) {
+		return migrate.RunMigrate(ctx, cfg)
+	}
 )
 
 // CSV file names used across phases.
@@ -112,6 +117,9 @@ func runExtractWithRetry(ctx context.Context, p Prompter, state *WizardState, ex
 			KeyFilePath:        cert.keyFile,
 			CertPassword:       cert.password,
 			IncludeProjectData: true,
+			ProgressCallback: func(percent float64, eta time.Duration, known bool) {
+				p.DisplayOverallProgress(percent, eta, known)
+			},
 		}
 
 		skipped, err := runExtractFn(ctx, cfg)
@@ -441,6 +449,9 @@ func runMigrateWithRetry(ctx context.Context, p Prompter, state *WizardState, ex
 			URL:                ptrStr(state.TargetURL),
 			ExportDirectory:    exportDir,
 			IncludeProjectData: true,
+			ProgressCallback: func(percent float64, eta time.Duration, known bool) {
+				p.DisplayOverallProgress(percent, eta, known)
+			},
 		}
 
 		resultID, err := runMigrateFn(ctx, cfg)
@@ -485,4 +496,3 @@ func generateAnalysisReport(p Prompter, exportDir, runID string) {
 	p.DisplayMessage(fmt.Sprintf("PDF summary report: %s", pdfPath))
 	p.DisplayMessage(fmt.Sprintf("Markdown summary report: %s", mdPath))
 }
-

--- a/go/internal/wizard/phases.go
+++ b/go/internal/wizard/phases.go
@@ -105,11 +105,10 @@ func runExtractWithRetry(ctx context.Context, p Prompter, state *WizardState, ex
 			CertPassword:             cert.password,
 			IncludeProjectData:       includeProjectData,
 			SkipProjectDataMigration: !includeProjectData,
-			SkipIssueSync:            !includeIssueSync,			IncludeProjectData: true,
+			SkipIssueSync:            !includeIssueSync,
 			ProgressCallback: func(percent float64, eta time.Duration, known bool) {
 				p.DisplayOverallProgress(percent, eta, known)
 			},
-
 		}
 
 		skipped, err := runExtractFn(ctx, cfg)
@@ -414,7 +413,7 @@ func runMigrateWithRetry(ctx context.Context, p Prompter, state *WizardState, ex
 			IncludeProjectData:       includeProjectData,
 			SkipProjectDataMigration: !includeProjectData,
 			SkipIssueSync:            !includeIssueSync,
-      ProgressCallback: func(percent float64, eta time.Duration, known bool) {
+			ProgressCallback: func(percent float64, eta time.Duration, known bool) {
 				p.DisplayOverallProgress(percent, eta, known)
 			},
 		}

--- a/go/internal/wizard/phases_test.go
+++ b/go/internal/wizard/phases_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/extract"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
@@ -16,9 +17,9 @@ import (
 )
 
 const (
-	testSQServerURL  = "https://sq.example.com/"
-	testCloudOrgKey  = "cloud-1"
-	testEntKey       = "my-enterprise"
+	testSQServerURL   = "https://sq.example.com/"
+	testCloudOrgKey   = "cloud-1"
+	testEntKey        = "my-enterprise"
 	errPromptExtract  = "promptExtractCredentials: %v"
 	errExpectComplete = "expected COMPLETE, got %s"
 )
@@ -236,6 +237,36 @@ func TestRunExtractWithRetrySuccess(t *testing.T) {
 	}
 }
 
+func TestRunExtractWithRetrySetsProgressCallback(t *testing.T) {
+	var captured extract.ExtractConfig
+	origFn := runExtractFn
+	runExtractFn = func(_ context.Context, cfg extract.ExtractConfig) ([]string, error) {
+		captured = cfg
+		return nil, nil
+	}
+	defer func() { runExtractFn = origFn }()
+
+	dir := t.TempDir()
+	state := &WizardState{}
+	p := &MockPrompter{}
+
+	if _, err := runExtractWithRetry(context.Background(), p, state, dir, testSQServerURL, "token"); err != nil {
+		t.Fatalf("runExtractWithRetry: %v", err)
+	}
+	if captured.ProgressCallback == nil {
+		t.Fatal("expected ProgressCallback to be set")
+	}
+
+	captured.ProgressCallback(42, 12*time.Minute, true)
+	if len(p.OverallProgressCalls) != 1 {
+		t.Fatalf("expected 1 DisplayOverallProgress call, got %d", len(p.OverallProgressCalls))
+	}
+	got := p.OverallProgressCalls[0]
+	if got.Percent != 42 || got.Eta != 12*time.Minute || !got.Known {
+		t.Errorf("got %+v, want {42 12m true}", got)
+	}
+}
+
 func TestRunExtractWithRetrySSLError(t *testing.T) {
 	callCount := 0
 	origFn := runExtractFn
@@ -343,7 +374,7 @@ func TestPhaseMigrateSuccess(t *testing.T) {
 	}
 	p := &MockPrompter{
 		ConfirmResponses:  []bool{true},      // proceed with migration
-		PasswordResponses: []string{"token"},  // cloud token
+		PasswordResponses: []string{"token"}, // cloud token
 	}
 
 	err := phaseMigrate(context.Background(), p, state, dir)
@@ -391,6 +422,36 @@ func TestRunMigrateWithRetrySuccess(t *testing.T) {
 	}
 }
 
+func TestRunMigrateWithRetrySetsProgressCallback(t *testing.T) {
+	var captured migrate.MigrateConfig
+	origFn := runMigrateFn
+	runMigrateFn = func(_ context.Context, cfg migrate.MigrateConfig) (string, error) {
+		captured = cfg
+		return "test-run-01", nil
+	}
+	defer func() { runMigrateFn = origFn }()
+
+	dir := t.TempDir()
+	state := &WizardState{TargetURL: strPtr(testSQCloudURL), EnterpriseKey: strPtr(testEntKey)}
+	p := &MockPrompter{}
+
+	if err := runMigrateWithRetry(context.Background(), p, state, dir, "token"); err != nil {
+		t.Fatalf("runMigrateWithRetry: %v", err)
+	}
+	if captured.ProgressCallback == nil {
+		t.Fatal("expected ProgressCallback to be set")
+	}
+
+	captured.ProgressCallback(100, 0, true)
+	if len(p.OverallProgressCalls) != 1 {
+		t.Fatalf("expected 1 DisplayOverallProgress call, got %d", len(p.OverallProgressCalls))
+	}
+	got := p.OverallProgressCalls[0]
+	if got.Percent != 100 || got.Eta != 0 || !got.Known {
+		t.Errorf("got %+v, want {100 0 true}", got)
+	}
+}
+
 // --- Full wizard run with mocked commands ---
 
 func TestRunFullWizardMocked(t *testing.T) {
@@ -419,8 +480,8 @@ func TestRunFullWizardMocked(t *testing.T) {
 	p := &MockPrompter{
 		URLResponses: []string{testSQServerURL, testSQCloudURL},
 		TextResponses: []string{
-			testEntKey,   // enterprise key
-			"cloud-org",  // cloud org key for org-1
+			testEntKey,  // enterprise key
+			"cloud-org", // cloud org key for org-1
 		},
 		PasswordResponses: []string{
 			"server-token", // extract token

--- a/go/internal/wizard/phases_test.go
+++ b/go/internal/wizard/phases_test.go
@@ -227,8 +227,22 @@ func TestRunExtractWithRetrySuccess(t *testing.T) {
 }
 
 func TestRunExtractWithRetrySetsProgressCallback(t *testing.T) {
-  state := &WizardState{}
-  if captured.ProgressCallback == nil {
+	var captured extract.ExtractConfig
+	origFn := runExtractFn
+	runExtractFn = func(_ context.Context, cfg extract.ExtractConfig) ([]string, error) {
+		captured = cfg
+		return nil, nil
+	}
+	defer func() { runExtractFn = origFn }()
+
+	dir := t.TempDir()
+	state := &WizardState{}
+	p := &MockPrompter{}
+
+	if _, err := runExtractWithRetry(context.Background(), p, state, dir, testSQServerURL, "token"); err != nil {
+		t.Fatalf("runExtractWithRetry: %v", err)
+	}
+	if captured.ProgressCallback == nil {
 		t.Fatal("expected ProgressCallback to be set")
 	}
 
@@ -239,18 +253,7 @@ func TestRunExtractWithRetrySetsProgressCallback(t *testing.T) {
 	got := p.OverallProgressCalls[0]
 	if got.Percent != 42 || got.Eta != 12*time.Minute || !got.Known {
 		t.Errorf("got %+v, want {42 12m true}", got)
-  }
-  if captured.ProgressCallback == nil {
-		t.Fatal("expected ProgressCallback to be set")
 	}
-
-	captured.ProgressCallback(42, 12*time.Minute, true)
-	if len(p.OverallProgressCalls) != 1 {
-		t.Fatalf("expected 1 DisplayOverallProgress call, got %d", len(p.OverallProgressCalls))
-	}
-	got := p.OverallProgressCalls[0]
-	if got.Percent != 42 || got.Eta != 12*time.Minute || !got.Known {
-		t.Errorf("got %+v, want {42 12m true}", got)
 }
 
 func TestRunExtractWithRetryTranslatesScopeToSkipFlags(t *testing.T) {
@@ -462,7 +465,7 @@ func TestRunMigrateWithRetrySuccess(t *testing.T) {
 }
 
 func TestRunMigrateWithRetrySetsProgressCallback(t *testing.T) {
-  var captured migrate.MigrateConfig
+	var captured migrate.MigrateConfig
 	origFn := runMigrateFn
 	runMigrateFn = func(_ context.Context, cfg migrate.MigrateConfig) (string, error) {
 		captured = cfg
@@ -471,13 +474,13 @@ func TestRunMigrateWithRetrySetsProgressCallback(t *testing.T) {
 	defer func() { runMigrateFn = origFn }()
 
 	dir := t.TempDir()
-  state := &WizardState{TargetURL: strPtr(testSQCloudURL), EnterpriseKey: strPtr(testEntKey)}
+	state := &WizardState{TargetURL: strPtr(testSQCloudURL), EnterpriseKey: strPtr(testEntKey)}
 	p := &MockPrompter{}
 
 	if err := runMigrateWithRetry(context.Background(), p, state, dir, "token"); err != nil {
 		t.Fatalf("runMigrateWithRetry: %v", err)
 	}
- 	if captured.ProgressCallback == nil {
+	if captured.ProgressCallback == nil {
 		t.Fatal("expected ProgressCallback to be set")
 	}
 

--- a/go/internal/wizard/prompter.go
+++ b/go/internal/wizard/prompter.go
@@ -4,7 +4,10 @@
 
 package wizard
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
 
 // ErrBack is returned by prompt methods when the user clicks the Back button.
 var ErrBack = errors.New("back")
@@ -44,6 +47,13 @@ type Prompter interface {
 	// Display methods (output only, no return).
 	DisplayWelcome()
 	DisplayPhaseProgress(phase WizardPhase)
+
+	// DisplayOverallProgress reports the run-wide percent/ETA snapshot
+	// computed by common.Tracker (#520) for the extract/migrate step
+	// currently in flight. known is false until enough progress has
+	// been made to extrapolate an ETA. Fired roughly every 10s plus
+	// once more at completion (#519).
+	DisplayOverallProgress(percent float64, eta time.Duration, known bool)
 	DisplayMessage(msg string)
 	DisplayError(msg string)
 	DisplayWarning(msg string)

--- a/go/internal/wizard/state.go
+++ b/go/internal/wizard/state.go
@@ -23,8 +23,8 @@ const (
 	PhaseOrgMapping WizardPhase = "org_mapping"
 	PhaseMappings   WizardPhase = "mappings"
 	PhaseValidate   WizardPhase = "validate"
-	PhaseMigrate  WizardPhase = "migrate"
-	PhaseComplete WizardPhase = "complete"
+	PhaseMigrate    WizardPhase = "migrate"
+	PhaseComplete   WizardPhase = "complete"
 )
 
 // WizardState holds the persistent state of a migration wizard session.
@@ -57,13 +57,36 @@ func NewWizardState() *WizardState {
 	return &WizardState{Phase: PhaseInit}
 }
 
-// Save persists the wizard state to .wizard_state.json in the given directory.
+// Save persists the wizard state to .wizard_state.json in the given
+// directory. Written atomically (temp file + rename) so a process killed
+// mid-save (Ctrl-C, crash, OOM) can never leave a truncated/empty state
+// file behind — os.WriteFile alone truncates-then-writes as separate
+// syscalls, and a kill between them corrupts the file for every future
+// Load until it's manually deleted.
 func (s *WizardState) Save(directory string) error {
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(directory, stateFileName), data, 0644)
+
+	tmp, err := os.CreateTemp(directory, stateFileName+".*.tmp")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name()) // no-op once Rename below succeeds
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), filepath.Join(directory, stateFileName))
 }
 
 // resetPhaseState clears state fields written by the given phase so the
@@ -87,6 +110,11 @@ func resetPhaseState(state *WizardState, phase WizardPhase) {
 
 // Load reads a WizardState from .wizard_state.json in the given directory.
 // If the file does not exist, it returns a new state at the INIT phase.
+// A zero-byte file — the signature left by a pre-atomic-write Save that
+// was killed mid-write (Ctrl-C, crash) before this fix — is treated the
+// same as a missing file: WizardState always serializes to non-empty
+// JSON, so an empty file can never have been a legitimately saved state,
+// and there's nothing to resume from it anyway.
 func Load(directory string) (*WizardState, error) {
 	data, err := os.ReadFile(filepath.Join(directory, stateFileName))
 	if err != nil {
@@ -94,6 +122,9 @@ func Load(directory string) (*WizardState, error) {
 			return NewWizardState(), nil
 		}
 		return nil, err
+	}
+	if len(data) == 0 {
+		return NewWizardState(), nil
 	}
 	var state WizardState
 	if err := json.Unmarshal(data, &state); err != nil {

--- a/go/internal/wizard/state_test.go
+++ b/go/internal/wizard/state_test.go
@@ -29,14 +29,14 @@ func TestSaveAndLoad(t *testing.T) {
 	dir := t.TempDir()
 
 	original := &WizardState{
-		Phase:              PhaseStructure,
-		ExtractID:          strPtr("abc-123"),
-		SourceURL:          strPtr("https://sonar.example.com"),
-		TargetURL:          strPtr("https://sonarcloud.io"),
-		EnterpriseKey:      strPtr("my-enterprise"),
+		Phase:               PhaseStructure,
+		ExtractID:           strPtr("abc-123"),
+		SourceURL:           strPtr("https://sonar.example.com"),
+		TargetURL:           strPtr("https://sonarcloud.io"),
+		EnterpriseKey:       strPtr("my-enterprise"),
 		OrganizationsMapped: true,
-		ValidationPassed:   false,
-		MigrationRunID:     nil,
+		ValidationPassed:    false,
+		MigrationRunID:      nil,
 	}
 
 	if err := original.Save(dir); err != nil {
@@ -76,16 +76,56 @@ func TestLoadMissingFile(t *testing.T) {
 	}
 }
 
+// A zero-byte state file is exactly what a pre-atomic-write Save left
+// behind when killed mid-write (Ctrl-C, crash) — Load must treat it like
+// a missing file rather than surfacing "unexpected end of JSON input".
+func TestLoadEmptyFileTreatedAsFresh(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, stateFileName), []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+	state, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load empty file: %v", err)
+	}
+	if state.Phase != PhaseInit {
+		t.Errorf("expected phase %q for empty file, got %q", PhaseInit, state.Phase)
+	}
+}
+
+// Save must not leave a stray temp file behind in the directory —
+// the atomic write's temp file is renamed over the final path, not left
+// alongside it.
+func TestSaveLeavesNoTempFile(t *testing.T) {
+	dir := t.TempDir()
+	state := NewWizardState()
+	if err := state.Save(dir); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != stateFileName {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("expected only %q in directory, got %v", stateFileName, names)
+	}
+}
+
 func TestJSONFormat(t *testing.T) {
 	state := &WizardState{
-		Phase:              PhaseExtract,
-		ExtractID:          strPtr("run-42"),
-		SourceURL:          strPtr("https://sq.local"),
-		TargetURL:          nil,
-		EnterpriseKey:      nil,
+		Phase:               PhaseExtract,
+		ExtractID:           strPtr("run-42"),
+		SourceURL:           strPtr("https://sq.local"),
+		TargetURL:           nil,
+		EnterpriseKey:       nil,
 		OrganizationsMapped: false,
-		ValidationPassed:   false,
-		MigrationRunID:     nil,
+		ValidationPassed:    false,
+		MigrationRunID:      nil,
 	}
 
 	data, err := json.MarshalIndent(state, "", "  ")

--- a/go/internal/wizard/wizard_test.go
+++ b/go/internal/wizard/wizard_test.go
@@ -12,14 +12,15 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 )
 
 const (
-	testOKTrue        = "expected ok=true"
-	testSQCloudURL    = "https://sonarcloud.io/"
-	errExpectExtract  = "expected PhaseExtract, got %s"
+	testOKTrue       = "expected ok=true"
+	testSQCloudURL   = "https://sonarcloud.io/"
+	errExpectExtract = "expected PhaseExtract, got %s"
 )
 
 // MockPrompter supplies pre-programmed responses for tests.
@@ -31,7 +32,8 @@ type MockPrompter struct {
 	ReviewResponses   []bool
 	ChoiceResponses   []int
 
-	Messages []string // captures DisplayMessage, DisplayError, etc.
+	Messages             []string // captures DisplayMessage, DisplayError, etc.
+	OverallProgressCalls []OverallProgressCall
 
 	urlIdx, textIdx, passIdx, confirmIdx, reviewIdx, choiceIdx int
 }
@@ -89,18 +91,29 @@ func (m *MockPrompter) PromptChoice(msg string, options []string) (int, error) {
 	m.choiceIdx++
 	return r, nil
 }
-func (m *MockPrompter) SetBackEnabled(bool)                     { /* no-op for tests */ }
+func (m *MockPrompter) SetBackEnabled(bool)                    { /* no-op for tests */ }
 func (m *MockPrompter) DisplayWelcome()                        { /* no-op for tests */ }
 func (m *MockPrompter) DisplayPhaseProgress(phase WizardPhase) { /* no-op for tests */ }
-func (m *MockPrompter) DisplayMessage(msg string)              { m.Messages = append(m.Messages, msg) }
-func (m *MockPrompter) DisplayError(msg string)                { m.Messages = append(m.Messages, "ERR:"+msg) }
-func (m *MockPrompter) DisplayWarning(msg string)              { m.Messages = append(m.Messages, "WARN:"+msg) }
-func (m *MockPrompter) DisplaySuccess(msg string)              { m.Messages = append(m.Messages, "OK:"+msg) }
+
+// OverallProgressCall records one DisplayOverallProgress invocation (#519).
+type OverallProgressCall struct {
+	Percent float64
+	Eta     time.Duration
+	Known   bool
+}
+
+func (m *MockPrompter) DisplayOverallProgress(percent float64, eta time.Duration, known bool) {
+	m.OverallProgressCalls = append(m.OverallProgressCalls, OverallProgressCall{percent, eta, known})
+}
+func (m *MockPrompter) DisplayMessage(msg string) { m.Messages = append(m.Messages, msg) }
+func (m *MockPrompter) DisplayError(msg string)   { m.Messages = append(m.Messages, "ERR:"+msg) }
+func (m *MockPrompter) DisplayWarning(msg string) { m.Messages = append(m.Messages, "WARN:"+msg) }
+func (m *MockPrompter) DisplaySuccess(msg string) { m.Messages = append(m.Messages, "OK:"+msg) }
 func (m *MockPrompter) DisplaySummary(title string, stats []KV) {
 	/* no-op for tests — summary display not asserted */
 }
 func (m *MockPrompter) DisplayResumeInfo(state *WizardState) { /* no-op for tests */ }
-func (m *MockPrompter) DisplayWizardComplete()                { /* no-op for tests */ }
+func (m *MockPrompter) DisplayWizardComplete()               { /* no-op for tests */ }
 
 // --- Resume Logic Tests ---
 


### PR DESCRIPTION
## Summary
- Adds a live progress bar + ETA field to the GUI wizard below the spinner/"Processing..." message, closing #519. common.Tracker (#520) already computed a run-wide percent/ETA every tick but only logged it internally; this threads it out through a new ProgressCallback on ExtractConfig/MigrateConfig -> a new Prompter.DisplayOverallProgress method -> a new display_overall_progress WebSocket message, with no change to CLI behavior (the callback is nil for CLI callers).
- Tracker.Start now emits one snapshot immediately instead of waiting for the first tick, so short runs no longer show nothing until jumping straight to 100%.
- Tick interval reduced from 30s to 10s.
- ETA under 2 minutes is shown as exact seconds instead of "~1 min"/"~0 min"; at/above 2 minutes it's rounded to the nearest minute.
- Fixes a pre-existing bug found while testing the above: WizardState.Save used a non-atomic os.WriteFile, so a Ctrl-C/crash mid-save could leave .wizard_state.json at 0 bytes, breaking every subsequent gui run with "unexpected end of JSON input". Save now writes via temp-file + rename, and Load treats an already-corrupted empty file as absent state.
- Relabels the GUI header badge from "Experimental" to "Beta".

## Test plan
- [x] go build ./...
- [x] go vet ./...
- [x] go test ./...
- [x] Manually run go run . gui, start a wizard run, confirm the progress bar appears at 0% immediately and advances to 100%
- [x] Confirm CLI-only extract/migrate runs are unaffected (same log line, just every 10s now)
- [x] Confirm a previously-corrupted (0-byte) .wizard_state.json no longer breaks gui startup

Generated with Claude Code
