### PR TITLE
Improve hotspot sync algorithm + add --fast_sync option (#527)

### DIFF
--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -67,6 +67,7 @@ func init() {
 	f.Bool("skip_profiles", false, "Skip quality profile migration/provisioning in SonarQube Cloud")
 	f.Bool(flagSkipIssueSync, false, "Skip the final per-issue and per-hotspot metadata sync (#299). Same semantics as the skip_issue_sync config-file field — defaults to false (sync happens); pass the flag to skip.")
 	f.Bool(flagSkipProjectDataMigration, false, "Skip the entire project-data migration: importProjectData and the trailing per-issue/per-hotspot sync (#303). Defaults to false (data is migrated); pass the flag to skip.")
+	f.Bool(flagFastSync, false, "Skip tagging and back-linking hotspots/issues with zero user changes on the source (original state, no comments, no custom tags). Defaults to false (every hotspot is tagged and back-linked). #527.")
 	f.String("default_organization", "", "SonarQube Cloud organization to migrate every project into when organizations.csv has no mapping defined. Ignored if any mapping is present.")
 	f.String("project_key_pattern", "", "Template for target project keys, built from <ORIGINAL_PROJECT_KEY> and <ORGANIZATION_KEY> (default: <ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>). #138")
 	f.StringSlice("exclude_branches", nil, "Glob patterns for non-main branches to skip during project data import (e.g. feature/*,bugfix/*)")
@@ -130,6 +131,7 @@ func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfi
 	if cmd.Flags().Changed("exclude_branches") {
 		cfg.ExcludeBranches, _ = cmd.Flags().GetStringSlice("exclude_branches")
 	}
+	applyFlagBool(cmd, flagFastSync, &cfg.FastSync)
 
 	// Default the export directory when neither config nor flag supplied
 	// one (issue #247).

--- a/go/cmd/migrate_test.go
+++ b/go/cmd/migrate_test.go
@@ -26,6 +26,7 @@ func newMigrateTestCmd() *cobra.Command {
 	f.String("target_task", "", "")
 	f.Bool("skip_profiles", false, "")
 	f.Bool("debug", false, "")
+	f.Bool(flagFastSync, false, "")
 	f.String("default_organization", "", "")
 	// Deprecated aliases — registered so tests can exercise back-compat (#406).
 	f.String("token", "", "")
@@ -63,6 +64,49 @@ func TestBuildMigrateConfig_DefaultOrganization_CLIOverridesConfig(t *testing.T)
 	}
 	if cfg.DefaultOrganization != "cli-default" {
 		t.Errorf("CLI flag should override config, got %q", cfg.DefaultOrganization)
+	}
+}
+
+// Issue #527: --fast_sync overrides the config file's fast_sync value.
+func TestBuildMigrateConfig_FastSync_CLIOverridesConfig(t *testing.T) {
+	path := writeMigrateConfig(t, `{
+		"fast_sync": false,
+		"target": {
+			"url": "https://sonarcloud.io/",
+			"token": "t"
+		}
+	}`)
+	cmd := newMigrateTestCmd()
+	_ = cmd.Flags().Set("config", path)
+	_ = cmd.Flags().Set(flagFastSync, "true")
+
+	cfg, err := buildMigrateConfig(cmd, nil)
+	if err != nil {
+		t.Fatalf("buildMigrateConfig: %v", err)
+	}
+	if !cfg.FastSync {
+		t.Error("CLI --fast_sync should override config file's false, got FastSync=false")
+	}
+}
+
+// Config file value is used when --fast_sync is absent.
+func TestBuildMigrateConfig_FastSync_ConfigOnly(t *testing.T) {
+	path := writeMigrateConfig(t, `{
+		"fast_sync": true,
+		"target": {
+			"url": "https://sonarcloud.io/",
+			"token": "t"
+		}
+	}`)
+	cmd := newMigrateTestCmd()
+	_ = cmd.Flags().Set("config", path)
+
+	cfg, err := buildMigrateConfig(cmd, nil)
+	if err != nil {
+		t.Fatalf("buildMigrateConfig: %v", err)
+	}
+	if !cfg.FastSync {
+		t.Error("expected config file's fast_sync=true to be used, got FastSync=false")
 	}
 }
 

--- a/go/cmd/sync_issues.go
+++ b/go/cmd/sync_issues.go
@@ -86,6 +86,7 @@ func init() {
 	f.String(flagPEMFilePath, "", "Path to client mTLS PEM file for the source server (maps to source.pem_file_path)")
 	f.String(flagKeyFilePath, "", "Path to client mTLS key file for the source server (maps to source.key_file_path)")
 	f.String(flagCertPassword, "", "Password for the source server mTLS client certificate (maps to source.cert_password)")
+	f.Bool(flagFastSync, false, "Skip tagging and back-linking hotspots/issues with zero user changes on the source (original state, no comments, no custom tags). Defaults to false (every hotspot is tagged and back-linked). #527.")
 	// --debug is inherited from the persistent root flag; see cmd/root.go.
 }
 
@@ -108,6 +109,7 @@ type syncIssuesConfig struct {
 	keyFilePath         string
 	certPassword        string
 	debug               bool
+	fastSync            bool
 }
 
 // loadSyncIssuesFileDefaults reads the shared --config file via the same
@@ -150,6 +152,7 @@ func loadSyncIssuesFileDefaults(path string) (syncIssuesConfig, error) {
 	cfg.certPassword = extractCfg.CertPassword
 
 	cfg.debug = migrateCfg.Debug
+	cfg.fastSync = migrateCfg.FastSync
 	return cfg, nil
 }
 
@@ -182,6 +185,7 @@ func resolveSyncIssuesConfig(cmd *cobra.Command) (syncIssuesConfig, error) {
 	applyFlagString(cmd, flagKeyFilePath, &cfg.keyFilePath)
 	applyFlagString(cmd, flagCertPassword, &cfg.certPassword)
 	applyFlagBool(cmd, flagDebug, &cfg.debug)
+	applyFlagBool(cmd, flagFastSync, &cfg.fastSync)
 
 	if cfg.exportDir == "" {
 		cfg.exportDir = "./migration-files/"
@@ -252,6 +256,7 @@ func runSyncIssuesCmd(cmd *cobra.Command, _ []string) error {
 		DefaultOrganization: cfg.defaultOrganization,
 		ProjectKeys:         cfg.projectKeys,
 		Debug:               cfg.debug,
+		FastSync:            cfg.fastSync,
 	})
 	if err != nil {
 		return fmt.Errorf("sync-issues failed: %w", err)
@@ -260,7 +265,7 @@ func runSyncIssuesCmd(cmd *cobra.Command, _ []string) error {
 	fmt.Printf("Projects synced: %d\n", summary.ProjectsSynced)
 	fmt.Printf("Issues:   %d actionable, %d synced, %d skipped (ambiguous or not found)\n",
 		summary.IssuesActionable, summary.IssuesSynced, summary.IssuesLineMismatch+summary.IssuesNotFound)
-	fmt.Printf("Hotspots: %d actionable, %d synced, %d acknowledged->to_review, %d skipped (ambiguous or not found)\n",
+	fmt.Printf("Hotspots: %d actionable, %d synced, %d acknowledged (not state-synced), %d skipped (ambiguous or not found)\n",
 		summary.HotspotsActionable, summary.HotspotsSynced, summary.HotspotsAckDemoted, summary.HotspotsLineMismatch+summary.HotspotsNotFound)
 	fmt.Println("Sync complete.")
 	return nil

--- a/go/cmd/sync_issues_test.go
+++ b/go/cmd/sync_issues_test.go
@@ -34,6 +34,7 @@ func newSyncIssuesTestCmd() *cobra.Command {
 	f.String(flagKeyFilePath, "", "")
 	f.String(flagCertPassword, "", "")
 	f.Bool(flagDebug, false, "")
+	f.Bool(flagFastSync, false, "")
 	return cmd
 }
 
@@ -138,6 +139,40 @@ func TestResolveSyncIssuesConfig_CLIOverridesConfig(t *testing.T) {
 	}
 	if want := []string{"proj-a", "proj-b"}; !reflect.DeepEqual(cfg.projectKeys, want) {
 		t.Errorf("projectKeys: got %v, want %v", cfg.projectKeys, want)
+	}
+}
+
+// Issue #527: --fast_sync overrides the config file; the config file
+// value is used when the flag is absent; defaults to false otherwise.
+func TestResolveSyncIssuesConfig_FastSync(t *testing.T) {
+	path := writeSyncIssuesConfig(t, `{
+		"fast_sync": false,
+		"source": {"url": "https://sq.example.com", "token": "tok"},
+		"target": {"token": "ct", "default_organization": "org"}
+	}`)
+
+	cmd := newSyncIssuesTestCmd()
+	if err := cmd.ParseFlags([]string{"-c", path, "--" + flagFastSync}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := resolveSyncIssuesConfig(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.fastSync {
+		t.Error("CLI --fast_sync should override config file's false")
+	}
+
+	cmd2 := newSyncIssuesTestCmd()
+	if err := cmd2.ParseFlags([]string{"-c", path}); err != nil {
+		t.Fatal(err)
+	}
+	cfg2, err := resolveSyncIssuesConfig(cmd2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg2.fastSync {
+		t.Error("expected config file's fast_sync=false to be used when flag absent")
 	}
 }
 

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -41,6 +41,7 @@ const (
 	flagExportDir                = "export_dir"
 	flagSkipIssueSync            = "skip_issue_sync"
 	flagSkipProjectDataMigration = "skip_project_data_migration"
+	flagFastSync                 = "fast_sync"
 	flagConcurrency              = "concurrency"
 	flagTimeout                  = "timeout"
 	flagPEMFilePath              = "pem_file_path"
@@ -172,6 +173,7 @@ func init() {
 	f.String(flagExportDir, "./migration-files/", "Working directory for intermediate files (maps to export_directory)")
 	f.Bool(flagSkipIssueSync, false, "Skip the final per-issue and per-hotspot metadata sync (#299). Same semantics as the skip_issue_sync config-file field — defaults to false (sync happens); pass the flag to skip.")
 	f.Bool(flagSkipProjectDataMigration, false, "Skip the entire project-data migration: importProjectData and the trailing per-issue/per-hotspot sync (#303). Defaults to false (data is migrated); pass the flag to skip.")
+	f.Bool(flagFastSync, false, "Skip tagging and back-linking hotspots/issues with zero user changes on the source (original state, no comments, no custom tags). Defaults to false (every hotspot is tagged and back-linked). #527.")
 	f.Int(flagConcurrency, 0, "Max concurrent requests (default: 25) (maps to concurrency)")
 	f.Int(flagTimeout, 0, "HTTP request timeout in seconds (maps to timeout; default: 60)")
 	f.String(flagPEMFilePath, "", "Path to client mTLS PEM file for the source server (maps to source.pem_file_path)")
@@ -207,6 +209,7 @@ type transferConfig struct {
 	debug                    bool
 	excludeBranches          []string
 	unsupportedLanguages     string
+	fastSync                 bool
 }
 
 func applyFlagString(cmd *cobra.Command, name string, target *string) {
@@ -297,6 +300,7 @@ func loadTransferFileDefaults(path string) (transferConfig, error) {
 	cfg.debug = migrateCfg.Debug
 	cfg.excludeBranches = migrateCfg.ExcludeBranches
 	cfg.unsupportedLanguages = migrateCfg.UnsupportedLanguages
+	cfg.fastSync = migrateCfg.FastSync
 	return cfg, nil
 }
 
@@ -349,6 +353,7 @@ func resolveTransferConfig(cmd *cobra.Command) (transferConfig, error) {
 		cfg.excludeBranches, _ = cmd.Flags().GetStringSlice(flagExcludeBranches)
 	}
 	applyFlagString(cmd, flagUnsupportedLanguages, &cfg.unsupportedLanguages)
+	applyFlagBool(cmd, flagFastSync, &cfg.fastSync)
 
 	if cfg.exportDir == "" {
 		cfg.exportDir = "./migration-files/"
@@ -550,6 +555,7 @@ func runTransferMigrate(ctx context.Context, cfg transferConfig) (string, error)
 		Debug:                    cfg.debug,
 		ExcludeBranches:          cfg.excludeBranches,
 		UnsupportedLanguages:     cfg.unsupportedLanguages,
+		FastSync:                 cfg.fastSync,
 		ProjectKeyPattern:        cfg.projectKeyPattern,
 	})
 	if err != nil {

--- a/go/cmd/transfer_test.go
+++ b/go/cmd/transfer_test.go
@@ -36,6 +36,7 @@ func newTransferTestCmd() *cobra.Command {
 	f.String(flagKeyFilePath, "", "")
 	f.String(flagCertPassword, "", "")
 	f.Bool(flagDebug, false, "")
+	f.Bool(flagFastSync, false, "")
 	return cmd
 }
 
@@ -144,6 +145,7 @@ func TestResolveTransferConfig_CLIOverridesConfig(t *testing.T) {
 		"--key_file_path", "/cli/key",
 		"--cert_password", "cli-pass",
 		"--debug",
+		"--" + flagFastSync,
 	}
 	if err := cmd.ParseFlags(args); err != nil {
 		t.Fatal(err)
@@ -173,11 +175,46 @@ func TestResolveTransferConfig_CLIOverridesConfig(t *testing.T) {
 		{"keyFilePath", cfg.keyFilePath, "/cli/key"},
 		{"certPassword", cfg.certPassword, "cli-pass"},
 		{"debug", cfg.debug, true},
+		{"fastSync", cfg.fastSync, true},
 	}
 	for _, c := range checks {
 		if c.got != c.want {
 			t.Errorf("%s: got %v, want %v", c.name, c.got, c.want)
 		}
+	}
+}
+
+// Issue #527: --fast_sync loads from the config file when the CLI flag
+// is absent, and defaults to false when neither is set.
+func TestResolveTransferConfig_FastSync(t *testing.T) {
+	path := writeTransferConfig(t, `{
+		"fast_sync": true,
+		"source": {"url": "https://sq.example.com", "token": "tok"},
+		"target": {"url": "https://sonarcloud.io/", "token": "ct", "default_organization": "org"}
+	}`)
+	cmd := newTransferTestCmd()
+	if err := cmd.ParseFlags([]string{"-c", path}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := resolveTransferConfig(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.fastSync {
+		t.Error("expected config file's fast_sync=true to be used")
+	}
+
+	// Default: neither flag nor config sets it.
+	cmd2 := newTransferTestCmd()
+	if err := cmd2.ParseFlags(nil); err != nil {
+		t.Fatal(err)
+	}
+	cfg2, err := resolveTransferConfig(cmd2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg2.fastSync {
+		t.Error("expected fast_sync to default to false")
 	}
 }
 

--- a/go/internal/extract/tasks_projectdata.go
+++ b/go/internal/extract/tasks_projectdata.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+	"golang.org/x/sync/errgroup"
 )
 
 var htmlTagRe = regexp.MustCompile(`<[^>]+>`)
@@ -120,8 +121,8 @@ func projectIssuesFullTask() func(ctx context.Context, e *Executor) error {
 	}
 }
 
-// projectHotspotsFullTask extracts all hotspots per project per branch.
-// For REVIEWED hotspots, it fetches detail via /api/hotspots/show to get
+// projectHotspotsFullTask extracts all hotspots per project per branch,
+// fetching detail via /api/hotspots/show for every hotspot to get
 // comments and ruleKey.
 //
 // SonarQube Server's /api/hotspots/search applies a TO_REVIEW default
@@ -186,37 +187,55 @@ func projectHotspotsFullTask() func(ctx context.Context, e *Executor) error {
 				}
 
 				enriched := enrichAll(all, meta)
-				// enrichHotspotDetails issues one /api/hotspots/show
-				// call per REVIEWED hotspot purely to pick up comments
-				// + rule — data only the migrate-side hotspot sync
-				// would consume. Skip when opted out. #398.
+				// enrichHotspotDetails issues one /api/hotspots/show call
+				// per hotspot to pick up comments + rule — data only the
+				// migrate-side hotspot sync would consume. Skip when
+				// opted out. #398.
 				if !e.SkipIssueSync {
-					enrichHotspotDetails(ctx, e, enriched)
+					if err := enrichHotspotDetails(ctx, e, enriched); err != nil {
+						return err
+					}
 				}
 				return w.WriteChunk(enriched)
 			})
 	}
 }
 
-// enrichHotspotDetails fetches /api/hotspots/show for each REVIEWED hotspot
-// and merges the detail (comments, rule) into the enriched items in-place.
-func enrichHotspotDetails(ctx context.Context, e *Executor, enriched []json.RawMessage) {
-	for i, item := range enriched {
-		status := extractField(item, "status")
-		if status != "REVIEWED" {
-			continue
-		}
-		hotspotKey := extractField(item, "key")
+// enrichHotspotDetails fetches /api/hotspots/show for every hotspot and
+// merges the detail (comments, rule) into the enriched items in-place.
+//
+// Every hotspot is fetched, not just REVIEWED ones: SonarQube Server
+// lets a user comment on a TO_REVIEW hotspot without changing its
+// status, and #527's sync-eligibility rule treats such a comment as
+// grounds to sync it — a case that can never be detected if TO_REVIEW
+// comments are never fetched. Parallelized with the executor's
+// semaphore since the item count is no longer bounded to the smaller
+// REVIEWED subset.
+func enrichHotspotDetails(ctx context.Context, e *Executor, enriched []json.RawMessage) error {
+	g, ctx := errgroup.WithContext(ctx)
+	for i := range enriched {
+		hotspotKey := extractField(enriched[i], "key")
 		if hotspotKey == "" {
 			continue
 		}
-		detail, err := e.Raw.Get(ctx, "api/hotspots/show", url.Values{"hotspot": {hotspotKey}})
-		if err != nil {
-			e.Logger.Debug("hotspot detail fetch failed", "hotspot", hotspotKey, "err", err)
-			continue
-		}
-		enriched[i] = mergeHotspotDetail(item, detail)
+		g.Go(func() error {
+			if err := acquireSem(ctx, e.Sem); err != nil {
+				return err
+			}
+			defer func() { <-e.Sem }()
+			detail, err := e.Raw.Get(ctx, "api/hotspots/show", url.Values{"hotspot": {hotspotKey}})
+			if err != nil {
+				e.Logger.Debug("hotspot detail fetch failed", "hotspot", hotspotKey, "err", err)
+				return nil
+			}
+			// enriched[i] is written by exactly one goroutine (index i is
+			// fixed per closure) so concurrent writes to disjoint slice
+			// elements are safe.
+			enriched[i] = mergeHotspotDetail(enriched[i], detail)
+			return nil
+		})
 	}
+	return g.Wait()
 }
 
 func mergeHotspotDetail(base, detail json.RawMessage) json.RawMessage {

--- a/go/internal/extract/tasks_projectdata_test.go
+++ b/go/internal/extract/tasks_projectdata_test.go
@@ -315,9 +315,8 @@ func TestProjectIssuesFullTaskSkipIssueSync(t *testing.T) {
 }
 
 // #398: with SkipIssueSync=true the hotspot task must NOT fetch
-// /api/hotspots/show per REVIEWED hotspot — that round-trip exists
-// only to enrich the record with comments + rule for the migrate-side
-// sync.
+// /api/hotspots/show per hotspot — that round-trip exists only to
+// enrich the record with comments + rule for the migrate-side sync.
 func TestProjectHotspotsFullTaskSkipsDetailEnrichment(t *testing.T) {
 	var (
 		mu       sync.Mutex
@@ -360,6 +359,80 @@ func TestProjectHotspotsFullTaskSkipsDetailEnrichment(t *testing.T) {
 	defer mu.Unlock()
 	if showHits != 0 {
 		t.Errorf("expected zero /api/hotspots/show calls with SkipIssueSync=true, got %d", showHits)
+	}
+}
+
+// #527: a TO_REVIEW hotspot can carry a user comment on SonarQube Server
+// without its status ever changing, and the sync-eligibility rule treats
+// that comment as grounds to sync it. That case can only be detected if
+// extraction fetches /api/hotspots/show for TO_REVIEW hotspots too, not
+// only REVIEWED ones.
+func TestProjectHotspotsFullTaskEnrichesToReviewHotspots(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		showHits []string
+	)
+	srv, e := newSrvExecutor(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/hotspots/search":
+			status := r.URL.Query().Get("status")
+			if status == "TO_REVIEW" {
+				json.NewEncoder(w).Encode(map[string]any{
+					"hotspots": []map[string]any{
+						{"key": "hs-tr", "status": "TO_REVIEW", "line": 5, "ruleKey": "rk1"},
+					},
+					"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 1},
+				})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"hotspots": []map[string]any{},
+				"paging":   map[string]any{"pageIndex": 1, "pageSize": 500, "total": 0},
+			})
+		case "/api/hotspots/show":
+			mu.Lock()
+			showHits = append(showHits, r.URL.Query().Get("hotspot"))
+			mu.Unlock()
+			json.NewEncoder(w).Encode(map[string]any{
+				"key": "hs-tr",
+				"comment": []map[string]any{
+					{"login": "alice", "markdown": "still worth a look", "createdAt": "2026-01-01T00:00:00+0000"},
+				},
+				"rule": map[string]any{"key": "rk1"},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer srv.Close()
+
+	if err := projectHotspotsFullTask()(ctx(t), e); err != nil {
+		t.Fatalf("projectHotspotsFullTask: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(showHits) != 1 || showHits[0] != "hs-tr" {
+		t.Fatalf("expected /api/hotspots/show to be called once for hs-tr, got %v", showHits)
+	}
+
+	items, err := e.Store.ReadAll("getProjectHotspotsFull")
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 extracted hotspot, got %d", len(items))
+	}
+	var got struct {
+		Comment []struct {
+			Login string `json:"login"`
+		} `json:"comment"`
+	}
+	if err := json.Unmarshal(items[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got.Comment) != 1 || got.Comment[0].Login != "alice" {
+		t.Errorf("expected the TO_REVIEW hotspot's comment to be merged in, got %s", items[0])
 	}
 }
 

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -51,6 +51,12 @@ type configFileShape struct {
 	// language with no target quality profile are handled (#474):
 	// "exclude" (default), "skip", or "warn".
 	UnsupportedLanguages string `json:"unsupported_languages"`
+	// FastSync skips tagging and back-linking hotspots (and issues) that
+	// have zero user changes on the source — original state, no comments,
+	// no custom tags (#527). Defaults to false (every hotspot is tagged
+	// and back-linked, current behavior). Same FlexibleBool semantics as
+	// skip_issue_sync.
+	FastSync *FlexibleBool `json:"fast_sync"`
 
 	// Shape 2 (command-sectioned).
 	Migrate *configFileShape `json:"migrate"`
@@ -104,6 +110,8 @@ type unifiedTargetBlock struct {
 	ExcludeBranches     []string `json:"exclude_branches"`
 	// UnsupportedLanguages — see configFileShape.UnsupportedLanguages (#474).
 	UnsupportedLanguages string `json:"unsupported_languages"`
+	// FastSync — see configFileShape.FastSync (#527).
+	FastSync *FlexibleBool `json:"fast_sync"`
 }
 
 type sonarCloudBlock struct {
@@ -176,6 +184,12 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 		// #474 — target.unsupported_languages wins, else the top-level field.
 		cfg.UnsupportedLanguages = resolveUnsupportedLanguages(
 			cfg.UnsupportedLanguages, s.UnsupportedLanguages)
+		// #527 — target.fast_sync wins, else the top-level field, else false.
+		var targetFastSync *FlexibleBool
+		if s.Target != nil {
+			targetFastSync = s.Target.FastSync
+		}
+		cfg.FastSync = resolveFastSync(targetFastSync, s.FastSync)
 		if cfg.Concurrency == 0 {
 			cfg.Concurrency = s.Concurrency
 		}
@@ -203,6 +217,9 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 		if s.SkipProjectDataMigration != nil && s.SkipProjectDataMigration.Set {
 			cfg.SkipProjectDataMigration = s.SkipProjectDataMigration.Value
 		}
+		if s.FastSync != nil && s.FastSync.Set {
+			cfg.FastSync = s.FastSync.Value
+		}
 		return cfg
 	case s.Migrate != nil:
 		cfg := s.Migrate.toMigrateConfig()
@@ -215,6 +232,10 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 		}
 		if s.SkipProjectDataMigration != nil && s.SkipProjectDataMigration.Set {
 			cfg.SkipProjectDataMigration = s.SkipProjectDataMigration.Value
+		}
+		// Same outer-wins-else-inner semantics for fast_sync (#527).
+		if s.FastSync != nil && s.FastSync.Set {
+			cfg.FastSync = s.FastSync.Value
 		}
 		return cfg
 	default:
@@ -240,6 +261,9 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 		}
 		if s.SkipProjectDataMigration != nil && s.SkipProjectDataMigration.Set {
 			cfg.SkipProjectDataMigration = s.SkipProjectDataMigration.Value
+		}
+		if s.FastSync != nil && s.FastSync.Set {
+			cfg.FastSync = s.FastSync.Value
 		}
 		return cfg
 	}

--- a/go/internal/migrate/config_file_test.go
+++ b/go/internal/migrate/config_file_test.go
@@ -292,6 +292,76 @@ func TestLoadMigrateConfigFile_SkipIssueSync(t *testing.T) {
 	}
 }
 
+// Issue #527: top-level `fast_sync` parses into MigrateConfig.FastSync
+// one-for-one. Defaults to false (every hotspot is tagged and back-linked).
+func TestLoadMigrateConfigFile_FastSync(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantFast bool
+	}{
+		{"absent (default)", `{"target": {"url": "u", "token": "t"}}`, false},
+		{"top-level true", `{"fast_sync": true, "target": {"url": "u", "token": "t"}}`, true},
+		{"top-level false", `{"fast_sync": false, "target": {"url": "u", "token": "t"}}`, false},
+		{"top-level string on", `{"fast_sync": "on", "target": {"url": "u", "token": "t"}}`, true},
+		{
+			"target overrides top-level (target true, top false)",
+			`{"fast_sync": false, "target": {"url": "u", "token": "t", "fast_sync": true}}`,
+			true,
+		},
+		{
+			"target overrides top-level (target false, top true)",
+			`{"fast_sync": true, "target": {"url": "u", "token": "t", "fast_sync": false}}`,
+			false,
+		},
+		{
+			"target unset falls back to top-level",
+			`{"fast_sync": true, "target": {"url": "u", "token": "t"}}`,
+			true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := dir + "/fast_sync.json"
+			if err := os.WriteFile(path, []byte(c.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadMigrateConfigFile(path)
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if cfg.FastSync != c.wantFast {
+				t.Errorf("FastSync: got %v, want %v", cfg.FastSync, c.wantFast)
+			}
+		})
+	}
+}
+
+// Issue #527: fast_sync also parses in the "migrate"-sectioned shape, with
+// the outer (command-sectioned) field winning when both are set.
+func TestLoadMigrateConfigFile_FastSync_MigrateSectionedShape(t *testing.T) {
+	body := `{
+  "fast_sync": true,
+  "migrate": {
+    "url": "u", "token": "t",
+    "fast_sync": false
+  }
+}`
+	dir := t.TempDir()
+	path := dir + "/fast_sync_sectioned.json"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadMigrateConfigFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !cfg.FastSync {
+		t.Errorf("FastSync: got false, want true (outer wins)")
+	}
+}
+
 // Issue #281: target.default_organization parses into
 // MigrateConfig.DefaultOrganization.
 func TestLoadMigrateConfigFileUnifiedShape_DefaultOrganization(t *testing.T) {

--- a/go/internal/migrate/fast_sync.go
+++ b/go/internal/migrate/fast_sync.go
@@ -1,0 +1,19 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+// resolveFastSync mirrors resolveUnsupportedLanguages for the fast_sync
+// tri-state (#527): the target block's value wins when explicitly set,
+// else the top-level value, else the default (false — every hotspot is
+// tagged and back-linked, the pre-#527 behavior).
+func resolveFastSync(target, top *FlexibleBool) bool {
+	if target != nil && target.Set {
+		return target.Value
+	}
+	if top != nil && top.Set {
+		return top.Value
+	}
+	return false
+}

--- a/go/internal/migrate/hotspot_as_issue_test.go
+++ b/go/internal/migrate/hotspot_as_issue_test.go
@@ -247,7 +247,7 @@ func TestResolveAndSyncHotspotSearchesIssuesNotHotspots(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildCloudIssueIndex: %v", err)
 	}
-	outcome := resolveAndSyncHotspot(context.Background(), e, "proj", "", "srcProj", src, classifyHotspotForSync(src), idx, counter)
+	outcome := resolveAndSyncHotspot(context.Background(), e, hotspotResolveParams{CloudKey: "proj", SourceKey: "srcProj"}, src, classifyHotspotForSync(src), idx, counter)
 	if outcome != syncOutcomeSynced {
 		t.Fatalf("outcome = %v, want synced", outcome)
 	}
@@ -404,13 +404,7 @@ func TestSyncOneHotspotAsIssueCategoryGating(t *testing.T) {
 			if gotTransition != tc.wantTransition {
 				t.Errorf("transitions = %v, want transition applied = %v", rec.transitions, tc.wantTransition)
 			}
-			gotCommentCalls := 0
-			for _, c := range rec.comments {
-				if strings.Contains(c, "user note") {
-					gotCommentCalls++
-				}
-			}
-			if gotCommentCalls != tc.wantCommentCalls {
+			if gotCommentCalls := countMatchingComments(rec.comments, "user note"); gotCommentCalls != tc.wantCommentCalls {
 				t.Errorf("review-comment calls = %d, want %d (comments=%v)", gotCommentCalls, tc.wantCommentCalls, rec.comments)
 			}
 			if !slices.Contains(rec.tagsSet, scanreport.HotspotIssueTag) {
@@ -418,6 +412,17 @@ func TestSyncOneHotspotAsIssueCategoryGating(t *testing.T) {
 			}
 		})
 	}
+}
+
+// countMatchingComments counts how many recorded comment bodies contain substr.
+func countMatchingComments(comments []string, substr string) int {
+	n := 0
+	for _, c := range comments {
+		if strings.Contains(c, substr) {
+			n++
+		}
+	}
+	return n
 }
 
 // #527 (fast_sync follow-up): with e.FastSync=true, hotspotCategoryExcluded
@@ -515,7 +520,7 @@ func TestResolveAndSyncHotspotNotFoundWhenNoIssueOnLine(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildCloudIssueIndex: %v", err)
 	}
-	got := resolveAndSyncHotspot(context.Background(), e, "proj", "", "src", src, classifyHotspotForSync(src), idx, NewTaskCounter("t"))
+	got := resolveAndSyncHotspot(context.Background(), e, hotspotResolveParams{CloudKey: "proj", SourceKey: "src"}, src, classifyHotspotForSync(src), idx, NewTaskCounter("t"))
 	if got != syncOutcomeNotFound {
 		t.Errorf("outcome = %v, want not_found", got)
 	}
@@ -534,7 +539,7 @@ func TestResolveAndSyncHotspotLineMismatchWhenAmbiguous(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildCloudIssueIndex: %v", err)
 	}
-	got := resolveAndSyncHotspot(context.Background(), e, "proj", "", "src", src, classifyHotspotForSync(src), idx, NewTaskCounter("t"))
+	got := resolveAndSyncHotspot(context.Background(), e, hotspotResolveParams{CloudKey: "proj", SourceKey: "src"}, src, classifyHotspotForSync(src), idx, NewTaskCounter("t"))
 	if got != syncOutcomeLineMismatch {
 		t.Errorf("outcome = %v, want line_mismatch", got)
 	}
@@ -559,7 +564,7 @@ func TestResolveAndSyncHotspotUnmatchableSource(t *testing.T) {
 			})
 			e := newCustomCloudTest(t, mux)
 
-			got := resolveAndSyncHotspot(context.Background(), e, "proj", "", "src", tc.src, classifyHotspotForSync(tc.src), nil, NewTaskCounter("t"))
+			got := resolveAndSyncHotspot(context.Background(), e, hotspotResolveParams{CloudKey: "proj", SourceKey: "src"}, tc.src, classifyHotspotForSync(tc.src), nil, NewTaskCounter("t"))
 			if got != syncOutcomeNotFound {
 				t.Errorf("outcome = %v, want not_found", got)
 			}

--- a/go/internal/migrate/hotspot_as_issue_test.go
+++ b/go/internal/migrate/hotspot_as_issue_test.go
@@ -75,7 +75,7 @@ func TestSyncOneHotspotAsIssueAppliesSQSHotspotTag(t *testing.T) {
 	src := matchableHotspot{Key: "hs-1", RuleKey: "java:S2245", Component: "proj:src/Main.java", Line: 12, Status: "TO_REVIEW"}
 	target := matchableIssue{Key: "cloud-issue-1", Line: 12}
 
-	if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "", ""); err != nil {
+	if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "", "", classifyHotspotForSync(src)); err != nil {
 		t.Fatalf("syncOneHotspotAsIssue: %v", err)
 	}
 
@@ -103,7 +103,7 @@ func TestSyncOneHotspotAsIssueTagsUntriagedHotspot(t *testing.T) {
 	src := matchableHotspot{Key: "hs-untriaged", RuleKey: "java:S2077", Line: 4, Status: "TO_REVIEW"}
 	target := matchableIssue{Key: "cloud-issue-1", Line: 4}
 
-	if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "", ""); err != nil {
+	if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "", "", classifyHotspotForSync(src)); err != nil {
 		t.Fatalf("syncOneHotspotAsIssue: %v", err)
 	}
 
@@ -143,8 +143,11 @@ func TestSyncOneHotspotAsIssueStatusMapping(t *testing.T) {
 		{"TO_REVIEW needs no transition", "TO_REVIEW", "", []string{"accept", "falsepositive"}, ""},
 		{"REVIEWED+SAFE becomes a false positive", "REVIEWED", "SAFE", []string{"accept", "falsepositive"}, "falsepositive"},
 		{"REVIEWED+FIXED is accepted", "REVIEWED", "FIXED", []string{"accept", "falsepositive"}, "accept"},
-		{"REVIEWED+ACKNOWLEDGED is accepted, not downgraded to SAFE", "REVIEWED", "ACKNOWLEDGED", []string{"accept", "falsepositive"}, "accept"},
-		{"accept is skipped when the target does not offer it", "REVIEWED", "ACKNOWLEDGED", []string{"confirm"}, ""},
+		{"REVIEWED+FIXED is skipped when accept is not offered (#322)", "REVIEWED", "FIXED", []string{"confirm"}, ""},
+		// #527: ACKNOWLEDGED is never state-transitioned, regardless of what
+		// the target offers — it is tagged/inventoried and comment-synced
+		// only if it carries a user comment, but never re-triaged.
+		{"REVIEWED+ACKNOWLEDGED is never transitioned", "REVIEWED", "ACKNOWLEDGED", []string{"accept", "falsepositive"}, ""},
 	}
 
 	for _, tc := range tests {
@@ -157,7 +160,7 @@ func TestSyncOneHotspotAsIssueStatusMapping(t *testing.T) {
 			src := matchableHotspot{Key: "hs-1", RuleKey: "java:S2245", Line: 12, Status: tc.status, Resolution: tc.resolution}
 			target := matchableIssue{Key: "cloud-issue-1", Line: 12, Transitions: tc.cloudTransits}
 
-			if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "", ""); err != nil {
+			if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "", "", classifyHotspotForSync(src)); err != nil {
 				t.Fatalf("syncOneHotspotAsIssue: %v", err)
 			}
 
@@ -240,7 +243,11 @@ func TestResolveAndSyncHotspotSearchesIssuesNotHotspots(t *testing.T) {
 		Component: "proj:src/Main.java", Line: 12, Status: "REVIEWED", Resolution: "SAFE",
 	}
 	counter := NewTaskCounter("test")
-	outcome := resolveAndSyncHotspot(context.Background(), e, "proj", "org", "", "srcProj", src, counter)
+	idx, err := buildCloudIssueIndex(context.Background(), e, "proj", "org", "", []string{src.RuleKey})
+	if err != nil {
+		t.Fatalf("buildCloudIssueIndex: %v", err)
+	}
+	outcome := resolveAndSyncHotspot(context.Background(), e, "proj", "", "srcProj", src, classifyHotspotForSync(src), idx, counter)
 	if outcome != syncOutcomeSynced {
 		t.Fatalf("outcome = %v, want synced", outcome)
 	}
@@ -276,7 +283,7 @@ func TestSyncOneHotspotAsIssueAddsSourceLinkComment(t *testing.T) {
 	src := matchableHotspot{Key: "hs-42", RuleKey: "java:S2245", Line: 12, Status: "TO_REVIEW", Branch: "main"}
 	target := matchableIssue{Key: "cloud-issue-1", Line: 12}
 
-	if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "https://sq.example.com", "srcProj"); err != nil {
+	if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "https://sq.example.com", "srcProj", classifyHotspotForSync(src)); err != nil {
 		t.Fatalf("syncOneHotspotAsIssue: %v", err)
 	}
 
@@ -311,7 +318,7 @@ func TestSyncOneHotspotAsIssueSourceLinkIsIdempotent(t *testing.T) {
 		Comments: []issueComment{{Markdown: hotspotSourceLinkMarker + "(https://sq.example.com/security_hotspots?id=srcProj&hotspots=hs-42)"}},
 	}
 
-	if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "https://sq.example.com", "srcProj"); err != nil {
+	if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "https://sq.example.com", "srcProj", classifyHotspotForSync(src)); err != nil {
 		t.Fatalf("syncOneHotspotAsIssue: %v", err)
 	}
 
@@ -337,7 +344,7 @@ func TestSyncOneHotspotAsIssueMigratesReviewComments(t *testing.T) {
 	}
 	target := matchableIssue{Key: "cloud-issue-1", Line: 12, Transitions: []string{"falsepositive"}}
 
-	if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "", ""); err != nil {
+	if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "", "", classifyHotspotForSync(src)); err != nil {
 		t.Fatalf("syncOneHotspotAsIssue: %v", err)
 	}
 
@@ -351,6 +358,118 @@ func TestSyncOneHotspotAsIssueMigratesReviewComments(t *testing.T) {
 	}
 	if !got {
 		t.Errorf("review comment not migrated; comments = %v", rec.comments)
+	}
+}
+
+// #527: syncOneHotspotAsIssue must gate the transition and comment
+// steps by category, while back-link and tag stay unconditional when
+// e.FastSync is false (the default — asserted implicitly here since
+// newCustomCloudTest's Executor has the zero value, FastSync: false).
+func TestSyncOneHotspotAsIssueCategoryGating(t *testing.T) {
+	comments := []hotspotComment{{Login: "alice", Markdown: "user note"}}
+
+	tests := []struct {
+		name             string
+		cat              hotspotSyncCategory
+		comments         []hotspotComment
+		wantTransition   bool
+		wantCommentCalls int
+	}{
+		{"excluded — no transition, no comments", hotspotCategoryExcluded, comments, false, 0},
+		{"acknowledged, no user comment — no transition, no comments", hotspotCategoryAcknowledged, nil, false, 0},
+		{"acknowledged, user comment — no transition, comments synced", hotspotCategoryAcknowledged, comments, false, 1},
+		{"eligible — transition + comments", hotspotCategoryEligible, comments, true, 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &hotspotIssueSyncRecorder{}
+			mux := http.NewServeMux()
+			rec.mount(mux)
+			e := newCustomCloudTest(t, mux)
+
+			src := matchableHotspot{
+				Key: "hs-1", RuleKey: "java:S2245", Line: 12,
+				Status: "REVIEWED", Resolution: "SAFE", Comments: tc.comments,
+			}
+			target := matchableIssue{Key: "cloud-issue-1", Line: 12, Transitions: []string{"falsepositive"}}
+
+			if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "", "", tc.cat); err != nil {
+				t.Fatalf("syncOneHotspotAsIssue: %v", err)
+			}
+
+			rec.mu.Lock()
+			defer rec.mu.Unlock()
+			gotTransition := len(rec.transitions) > 0
+			if gotTransition != tc.wantTransition {
+				t.Errorf("transitions = %v, want transition applied = %v", rec.transitions, tc.wantTransition)
+			}
+			gotCommentCalls := 0
+			for _, c := range rec.comments {
+				if strings.Contains(c, "user note") {
+					gotCommentCalls++
+				}
+			}
+			if gotCommentCalls != tc.wantCommentCalls {
+				t.Errorf("review-comment calls = %d, want %d (comments=%v)", gotCommentCalls, tc.wantCommentCalls, rec.comments)
+			}
+			if !slices.Contains(rec.tagsSet, scanreport.HotspotIssueTag) {
+				t.Errorf("expected sqs-hotspot tag regardless of category, tags = %v", rec.tagsSet)
+			}
+		})
+	}
+}
+
+// #527 (fast_sync follow-up): with e.FastSync=true, hotspotCategoryExcluded
+// hotspots must get neither a back-link comment nor a tag — the two write
+// calls that dominated the cost of syncing untouched hotspots. Every other
+// category must be unaffected by the flag: ACKNOWLEDGED and eligible
+// hotspots are never "zero user changes," so they keep the #423 guarantee
+// regardless of fast_sync.
+func TestSyncOneHotspotAsIssueFastSyncSkipsTagAndBacklinkForExcludedOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		cat      hotspotSyncCategory
+		fastSync bool
+		wantTag  bool
+	}{
+		{"excluded, fast_sync on — no tag, no back-link", hotspotCategoryExcluded, true, false},
+		{"excluded, fast_sync off (default) — tag + back-link", hotspotCategoryExcluded, false, true},
+		{"acknowledged, fast_sync on — tag + back-link still applied", hotspotCategoryAcknowledged, true, true},
+		{"eligible, fast_sync on — tag + back-link still applied", hotspotCategoryEligible, true, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &hotspotIssueSyncRecorder{}
+			mux := http.NewServeMux()
+			rec.mount(mux)
+			e := newCustomCloudTest(t, mux)
+			e.FastSync = tc.fastSync
+
+			src := matchableHotspot{Key: "hs-1", RuleKey: "java:S2245", Line: 12, Status: "TO_REVIEW", Branch: "main"}
+			target := matchableIssue{Key: "cloud-issue-1", Line: 12}
+
+			if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "https://sq.example.com", "srcProj", tc.cat); err != nil {
+				t.Fatalf("syncOneHotspotAsIssue: %v", err)
+			}
+
+			rec.mu.Lock()
+			defer rec.mu.Unlock()
+			gotTag := slices.Contains(rec.tagsSet, scanreport.HotspotIssueTag)
+			if gotTag != tc.wantTag {
+				t.Errorf("tag applied = %v, want %v (tags=%v)", gotTag, tc.wantTag, rec.tagsSet)
+			}
+			gotBackLink := false
+			for _, c := range rec.comments {
+				if strings.Contains(c, hotspotSourceLinkMarker) {
+					gotBackLink = true
+				}
+			}
+			if gotBackLink != tc.wantTag {
+				t.Errorf("back-link posted = %v, want %v (comments=%v)", gotBackLink, tc.wantTag, rec.comments)
+			}
+		})
 	}
 }
 
@@ -387,11 +506,16 @@ func hotspotAt(line int) matchableHotspot {
 func TestResolveAndSyncHotspotNotFoundWhenNoIssueOnLine(t *testing.T) {
 	mux := http.NewServeMux()
 	mountIssueSearch(mux, []map[string]any{
-		{"key": "other", "rule": "java:S2245", "line": 99, "issueStatus": "OPEN"},
+		{"key": "other", "rule": "java:S2245", "component": "proj:src/Main.java", "line": 99, "issueStatus": "OPEN"},
 	})
 	e := newCustomCloudTest(t, mux)
 
-	got := resolveAndSyncHotspot(context.Background(), e, "proj", "org", "", "src", hotspotAt(12), NewTaskCounter("t"))
+	src := hotspotAt(12)
+	idx, err := buildCloudIssueIndex(context.Background(), e, "proj", "org", "", []string{src.RuleKey})
+	if err != nil {
+		t.Fatalf("buildCloudIssueIndex: %v", err)
+	}
+	got := resolveAndSyncHotspot(context.Background(), e, "proj", "", "src", src, classifyHotspotForSync(src), idx, NewTaskCounter("t"))
 	if got != syncOutcomeNotFound {
 		t.Errorf("outcome = %v, want not_found", got)
 	}
@@ -400,12 +524,17 @@ func TestResolveAndSyncHotspotNotFoundWhenNoIssueOnLine(t *testing.T) {
 func TestResolveAndSyncHotspotLineMismatchWhenAmbiguous(t *testing.T) {
 	mux := http.NewServeMux()
 	mountIssueSearch(mux, []map[string]any{
-		{"key": "a", "rule": "java:S2245", "line": 12, "issueStatus": "OPEN"},
-		{"key": "b", "rule": "java:S2245", "line": 12, "issueStatus": "OPEN"},
+		{"key": "a", "rule": "java:S2245", "component": "proj:src/Main.java", "line": 12, "issueStatus": "OPEN"},
+		{"key": "b", "rule": "java:S2245", "component": "proj:src/Main.java", "line": 12, "issueStatus": "OPEN"},
 	})
 	e := newCustomCloudTest(t, mux)
 
-	got := resolveAndSyncHotspot(context.Background(), e, "proj", "org", "", "src", hotspotAt(12), NewTaskCounter("t"))
+	src := hotspotAt(12)
+	idx, err := buildCloudIssueIndex(context.Background(), e, "proj", "org", "", []string{src.RuleKey})
+	if err != nil {
+		t.Fatalf("buildCloudIssueIndex: %v", err)
+	}
+	got := resolveAndSyncHotspot(context.Background(), e, "proj", "", "src", src, classifyHotspotForSync(src), idx, NewTaskCounter("t"))
 	if got != syncOutcomeLineMismatch {
 		t.Errorf("outcome = %v, want line_mismatch", got)
 	}
@@ -430,7 +559,7 @@ func TestResolveAndSyncHotspotUnmatchableSource(t *testing.T) {
 			})
 			e := newCustomCloudTest(t, mux)
 
-			got := resolveAndSyncHotspot(context.Background(), e, "proj", "org", "", "src", tc.src, NewTaskCounter("t"))
+			got := resolveAndSyncHotspot(context.Background(), e, "proj", "", "src", tc.src, classifyHotspotForSync(tc.src), nil, NewTaskCounter("t"))
 			if got != syncOutcomeNotFound {
 				t.Errorf("outcome = %v, want not_found", got)
 			}
@@ -461,7 +590,7 @@ func TestSyncOneHotspotAsIssueSurfacesTagFailure(t *testing.T) {
 
 	src := matchableHotspot{Key: "hs-1", RuleKey: "java:S2245", Line: 12, Status: "TO_REVIEW"}
 	target := matchableIssue{Key: "cloud-1", Line: 12}
-	err := syncOneHotspotAsIssue(context.Background(), e, src, target, "", "")
+	err := syncOneHotspotAsIssue(context.Background(), e, src, target, "", "", classifyHotspotForSync(src))
 	if err == nil || !strings.Contains(err.Error(), "tags") {
 		t.Errorf("err = %v, want a tag failure", err)
 	}
@@ -486,7 +615,7 @@ func TestSyncOneHotspotAsIssueToleratesSourceLinkFailure(t *testing.T) {
 
 	src := matchableHotspot{Key: "hs-1", RuleKey: "java:S2245", Line: 12, Status: "TO_REVIEW"}
 	target := matchableIssue{Key: "cloud-1", Line: 12}
-	if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "https://sq.example.com", "p"); err != nil {
+	if err := syncOneHotspotAsIssue(context.Background(), e, src, target, "https://sq.example.com", "p", classifyHotspotForSync(src)); err != nil {
 		t.Errorf("a failed back-link must not fail the sync, got %v", err)
 	}
 

--- a/go/internal/migrate/issuesync_branch_test.go
+++ b/go/internal/migrate/issuesync_branch_test.go
@@ -68,11 +68,14 @@ func TestResolveAndSyncIssueLookupError(t *testing.T) {
 	}
 }
 
-// A cloud-search failure during hotspot resolution is reported as a lookup
-// error, exercising the branch-aware call site. The lookup goes through
-// /api/issues/search: since 2026-07-01 the migrated hotspot is an issue on the
-// target, so /api/hotspots/search is never consulted (#423).
-func TestResolveAndSyncHotspotLookupError(t *testing.T) {
+// A cloud-search failure during the bulk index build (#527) is surfaced as an
+// error rather than silently producing an empty index — the caller
+// (syncProjectHotspots) treats this as a whole-branch failure and skips
+// resolving that branch's hotspots this run, rather than misreporting them
+// as not_found. The lookup goes through /api/issues/search: since
+// 2026-07-01 the migrated hotspot is an issue on the target, so
+// /api/hotspots/search is never consulted (#423).
+func TestBuildCloudIssueIndexLookupError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/issues/search", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -83,10 +86,9 @@ func TestResolveAndSyncHotspotLookupError(t *testing.T) {
 	defer apiSrv.Close()
 	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
 
-	src := matchableHotspot{Key: "h1", RuleKey: "rk1", Component: "src-proj:src/app.go", Line: 10, Branch: "develop"}
-	got := resolveAndSyncHotspot(context.Background(), e, "cloud-proj", "cloud-org", "", "src-proj", src, nil)
-	if got != syncOutcomeLookupError {
-		t.Fatalf("want syncOutcomeLookupError, got %v", got)
+	_, err := buildCloudIssueIndex(context.Background(), e, "cloud-proj", "cloud-org", "develop", []string{"rk1"})
+	if err == nil {
+		t.Fatal("want an error from buildCloudIssueIndex on a cloud search failure")
 	}
 }
 
@@ -158,7 +160,11 @@ func TestResolveAndSyncHotspotNotFound(t *testing.T) {
 	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
 
 	src := matchableHotspot{Key: "h1", RuleKey: "rk1", Component: "src-proj:src/app.go", Line: 10, Message: "Review this"}
-	got := resolveAndSyncHotspot(context.Background(), e, "cloud-proj", "cloud-org", "", "src-proj", src, nil)
+	idx, err := buildCloudIssueIndex(context.Background(), e, "cloud-proj", "cloud-org", "", []string{src.RuleKey})
+	if err != nil {
+		t.Fatalf("buildCloudIssueIndex: %v", err)
+	}
+	got := resolveAndSyncHotspot(context.Background(), e, "cloud-proj", "", "src-proj", src, classifyHotspotForSync(src), idx, nil)
 	if got != syncOutcomeNotFound {
 		t.Fatalf("want syncOutcomeNotFound, got %v", got)
 	}
@@ -185,7 +191,11 @@ func TestResolveAndSyncHotspotLineMismatch(t *testing.T) {
 	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
 
 	src := matchableHotspot{Key: "h1", RuleKey: "rk1", Component: "src-proj:src/app.go", Line: 10, Message: "Review this"}
-	got := resolveAndSyncHotspot(context.Background(), e, "cloud-proj", "cloud-org", "", "src-proj", src, nil)
+	idx, err := buildCloudIssueIndex(context.Background(), e, "cloud-proj", "cloud-org", "", []string{src.RuleKey})
+	if err != nil {
+		t.Fatalf("buildCloudIssueIndex: %v", err)
+	}
+	got := resolveAndSyncHotspot(context.Background(), e, "cloud-proj", "", "src-proj", src, classifyHotspotForSync(src), idx, nil)
 	if got != syncOutcomeLineMismatch {
 		t.Fatalf("want syncOutcomeLineMismatch, got %v", got)
 	}

--- a/go/internal/migrate/issuesync_branch_test.go
+++ b/go/internal/migrate/issuesync_branch_test.go
@@ -164,7 +164,7 @@ func TestResolveAndSyncHotspotNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildCloudIssueIndex: %v", err)
 	}
-	got := resolveAndSyncHotspot(context.Background(), e, "cloud-proj", "", "src-proj", src, classifyHotspotForSync(src), idx, nil)
+	got := resolveAndSyncHotspot(context.Background(), e, hotspotResolveParams{CloudKey: "cloud-proj", SourceKey: "src-proj"}, src, classifyHotspotForSync(src), idx, nil)
 	if got != syncOutcomeNotFound {
 		t.Fatalf("want syncOutcomeNotFound, got %v", got)
 	}
@@ -195,7 +195,7 @@ func TestResolveAndSyncHotspotLineMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildCloudIssueIndex: %v", err)
 	}
-	got := resolveAndSyncHotspot(context.Background(), e, "cloud-proj", "", "src-proj", src, classifyHotspotForSync(src), idx, nil)
+	got := resolveAndSyncHotspot(context.Background(), e, hotspotResolveParams{CloudKey: "cloud-proj", SourceKey: "src-proj"}, src, classifyHotspotForSync(src), idx, nil)
 	if got != syncOutcomeLineMismatch {
 		t.Fatalf("want syncOutcomeLineMismatch, got %v", got)
 	}

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -68,6 +68,12 @@ type MigrateConfig struct {
 	// DefaultUnsupportedLanguages.
 	UnsupportedLanguages string
 
+	// FastSync skips tagging and back-linking hotspots (and issues) that
+	// have zero user changes on the source — original state (TO_REVIEW /
+	// OPEN), no user comment, no custom tags (#527). Defaults to false:
+	// every hotspot is tagged and back-linked, the pre-#527 behavior.
+	FastSync bool
+
 	// ProjectKeyPattern is the template used to derive each target
 	// SonarQube Cloud project key from the source key, the org key, and
 	// the enterprise key. Defaults to DefaultProjectKeyPattern. Issue #138.
@@ -103,6 +109,9 @@ type Executor struct {
 	// language has no quality profile on the target organization (#474):
 	// UnsupportedLanguagesExclude / Skip / Warn.
 	UnsupportedLanguages string
+
+	// FastSync — see MigrateConfig.FastSync (#527).
+	FastSync bool
 
 	// ProjectKeyPattern is the resolved target-key template (issue #138),
 	// consumed by every task that derives a SonarQube Cloud project key
@@ -187,6 +196,7 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 		Sem:                  make(chan struct{}, cfg.Concurrency),
 		ExcludeBranches:      cfg.ExcludeBranches,
 		UnsupportedLanguages: cfg.UnsupportedLanguages,
+		FastSync:             cfg.FastSync,
 		ProjectKeyPattern:    cfg.ProjectKeyPattern,
 		Logger:               logger,
 	}

--- a/go/internal/migrate/sync_issues_standalone.go
+++ b/go/internal/migrate/sync_issues_standalone.go
@@ -47,6 +47,9 @@ type SyncIssuesConfig struct {
 	ProjectKeys []string
 
 	Debug bool
+
+	// FastSync — see MigrateConfig.FastSync (#527).
+	FastSync bool
 }
 
 func (cfg *SyncIssuesConfig) applyDefaults() {
@@ -162,6 +165,7 @@ func RunSyncIssues(ctx context.Context, cfg SyncIssuesConfig) (SyncIssuesSummary
 		Mapping:           mapping,
 		Sem:               make(chan struct{}, cfg.Concurrency),
 		ProjectKeyPattern: cfg.ProjectKeyPattern,
+		FastSync:          cfg.FastSync,
 		Logger:            logger,
 	}
 

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -112,6 +112,76 @@ func IsAcknowledgedResolution(resolution string) bool {
 	return strings.EqualFold(strings.TrimSpace(resolution), "ACKNOWLEDGED")
 }
 
+// hotspotHasUserComment reports whether at least one comment on the
+// hotspot was authored by a real user, as opposed to a technical
+// comment SonarQube itself might create (#527). A non-empty Login is
+// the signal: system/automated comments carry no (or a blank) login.
+func hotspotHasUserComment(comments []hotspotComment) bool {
+	for _, c := range comments {
+		if strings.TrimSpace(c.Login) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// HotspotSyncEligibility implements #527's sync-eligibility rule:
+//
+//   - eligible: the hotspot's status is not TO_REVIEW, OR it carries a
+//     user (non-technical) comment. Eligible hotspots get the full
+//     state-transition + comment sync.
+//   - acknowledged: the hotspot is REVIEWED + ACKNOWLEDGED. This is
+//     orthogonal to eligible (an ACKNOWLEDGED hotspot is always
+//     "eligible" by the first clause, since its status is REVIEWED) but
+//     callers MUST treat it as an override: never apply the state
+//     transition, and only sync comments when hasUserComment is true.
+//     ACKNOWLEDGED hotspots are always inventoried in the reporting
+//     denominator, whether or not they carry a user comment.
+//
+// A hotspot that is neither eligible nor acknowledged (TO_REVIEW, no
+// user comment) is excluded from sync entirely — it is still resolved
+// against the target and tagged (#423), but gets no state/comment sync
+// and is not counted in the %-synced denominator.
+func HotspotSyncEligibility(status, resolution string, hasUserComment bool) (eligible, acknowledged bool) {
+	s := strings.ToUpper(strings.TrimSpace(status))
+	r := strings.ToUpper(strings.TrimSpace(resolution))
+	acknowledged = s == "REVIEWED" && r == "ACKNOWLEDGED"
+	eligible = s != "TO_REVIEW" || hasUserComment
+	return eligible, acknowledged
+}
+
+// hotspotSyncCategory buckets a source hotspot for dispatch and
+// reporting (#527).
+type hotspotSyncCategory int
+
+const (
+	// hotspotCategoryExcluded — TO_REVIEW with no user comment. Still
+	// resolved against Cloud and tagged (#423), but gets no
+	// transition/comment sync and is not counted in the %-synced
+	// denominator.
+	hotspotCategoryExcluded hotspotSyncCategory = iota
+	// hotspotCategoryAcknowledged — REVIEWED + ACKNOWLEDGED. Always
+	// tagged and always counted in the denominator; comment-synced only
+	// when it carries a user comment; never state-transitioned.
+	hotspotCategoryAcknowledged
+	// hotspotCategoryEligible — full sync: state transition + comments.
+	hotspotCategoryEligible
+)
+
+// classifyHotspotForSync applies HotspotSyncEligibility to a
+// matchableHotspot, deriving hasUserComment from its parsed comments.
+func classifyHotspotForSync(h matchableHotspot) hotspotSyncCategory {
+	eligible, acknowledged := HotspotSyncEligibility(h.Status, h.Resolution, hotspotHasUserComment(h.Comments))
+	switch {
+	case acknowledged:
+		return hotspotCategoryAcknowledged
+	case eligible:
+		return hotspotCategoryEligible
+	default:
+		return hotspotCategoryExcluded
+	}
+}
+
 // hotspotResolutionPriority orders source resolutions from most to
 // least "cautious" — used by dedupeActionableHotspots when several
 // source-branch records collapse to the same cloud hotspot. The most
@@ -205,6 +275,107 @@ func dedupeActionableHotspots(in []matchableHotspot) []matchableHotspot {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
+// Bulk Cloud issue index (#527)
+// ---------------------------------------------------------------------------
+
+// cloudIssueIndexKey mirrors the (file, rule) scope that
+// findCloudIssueCandidates used to search per-hotspot.
+type cloudIssueIndexKey struct {
+	File    string
+	RuleKey string
+}
+
+// cloudIssueIndex is a read-only-after-build, per-branch cache of Cloud
+// issue candidates keyed by (bare file path, rule key). Built once per
+// (project, branch) via buildCloudIssueIndex instead of issuing one
+// /api/issues/search call per source hotspot — the per-item search was
+// the actual cost #527 wants eliminated, since every hotspot still has
+// to be resolved and tagged regardless of sync eligibility (#423).
+type cloudIssueIndex map[cloudIssueIndexKey][]matchableIssue
+
+// cloudIssueSearchRuleChunkSize caps how many rule keys are joined into
+// one `rules=` query parameter per buildCloudIssueIndex request.
+// SonarQube doesn't document a hard limit on rules= cardinality, but
+// reverse proxies commonly cap the request line around 8KB; 60 keys
+// keeps every chunk's encoded query well under that even for long
+// "repo:RuleKey" names.
+const cloudIssueSearchRuleChunkSize = 60
+
+// buildCloudIssueIndex fetches every Cloud issue whose rule is in
+// ruleKeys, scoped to the whole project on the given branch, and
+// indexes results by (bare file path, rule key) — the same scope/shape
+// findCloudIssueCandidates used per-hotspot, just fetched once for the
+// whole branch instead of once per source item (#527).
+func buildCloudIssueIndex(ctx context.Context, e *Executor, cloudKey, orgKey, branch string, ruleKeys []string) (cloudIssueIndex, error) {
+	idx := make(cloudIssueIndex)
+	for _, chunk := range chunkStrings(ruleKeys, cloudIssueSearchRuleChunkSize) {
+		params := url.Values{}
+		params.Set("componentKeys", cloudKey)
+		params.Set("organization", orgKey)
+		params.Set("rules", strings.Join(chunk, ","))
+		if branch != "" {
+			params.Set("branch", branch)
+		}
+		// Same statuses/fields findCloudIssueCandidates asked for per-item.
+		params.Set("issueStatuses", "OPEN,CONFIRMED,FALSE_POSITIVE,ACCEPTED")
+		params.Set("additionalFields", "transitions,comments")
+		apiIssues, err := e.Cloud.Issues.SearchAll(ctx, params)
+		if err != nil {
+			return idx, err
+		}
+		for _, ai := range apiIssues {
+			m := apiIssueToMatchable(ai)
+			key := cloudIssueIndexKey{File: stripProjectKeyPrefix(m.Component), RuleKey: m.Rule}
+			idx[key] = append(idx[key], m)
+		}
+	}
+	return idx, nil
+}
+
+// chunkStrings splits ss into slices of at most n elements each.
+func chunkStrings(ss []string, n int) [][]string {
+	if n <= 0 || len(ss) == 0 {
+		return nil
+	}
+	var out [][]string
+	for i := 0; i < len(ss); i += n {
+		end := i + n
+		if end > len(ss) {
+			end = len(ss)
+		}
+		out = append(out, ss[i:end])
+	}
+	return out
+}
+
+// groupHotspotsByBranch buckets hotspots by their (source) Branch field
+// so one buildCloudIssueIndex call is issued per (project, branch) pair
+// — /api/issues/search resolves componentKeys against a single branch.
+func groupHotspotsByBranch(hotspots []matchableHotspot) map[string][]matchableHotspot {
+	out := make(map[string][]matchableHotspot)
+	for _, h := range hotspots {
+		out[h.Branch] = append(out[h.Branch], h)
+	}
+	return out
+}
+
+// distinctRuleKeys returns the de-duplicated, sorted set of RuleKey
+// values across hotspots (sorted for deterministic chunk boundaries).
+func distinctRuleKeys(hotspots []matchableHotspot) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, h := range hotspots {
+		if h.RuleKey == "" || seen[h.RuleKey] {
+			continue
+		}
+		seen[h.RuleKey] = true
+		out = append(out, h.RuleKey)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ---------------------------------------------------------------------------
 // Main task entry point
 // ---------------------------------------------------------------------------
 
@@ -283,22 +454,6 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 	if len(sourceHotspots) == 0 {
 		return result
 	}
-	// Every source hotspot needs a target visit now, not only the triaged
-	// ones. SonarQube Cloud dropped hotspots on 2026-07-01, so each one lands
-	// as an ordinary issue and has to be tagged `sqs-hotspot` to stay
-	// identifiable as a former hotspot (#423) — including TO_REVIEW hotspots,
-	// which carry no triage at all and were previously filtered out here.
-	//
-	// hotspotHasManualChanges is retained because the predict pipeline still
-	// uses it to report how many hotspots carry migratable triage.
-	actionable := make([]matchableHotspot, 0, len(sourceHotspots))
-	triaged := 0
-	for _, h := range sourceHotspots {
-		if hotspotHasManualChanges(h) {
-			triaged++
-		}
-		actionable = append(actionable, h)
-	}
 	// #323 follow-up: the source extract carries one hotspot record per
 	// branch of the SQS project, but a single SQC hotspot exists per
 	// (file, line, rule). Without dedup, two source records that map
@@ -309,14 +464,52 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 	// ACKNOWLEDGED demotion is lost. Dedup by (component, ruleKey,
 	// line) before dispatch, picking the most cautious resolution per
 	// group so an ACK on any branch wins over SAFE/FIXED on another.
-	preDedupCount := len(actionable)
-	actionable = dedupeActionableHotspots(actionable)
-	if dropped := preDedupCount - len(actionable); dropped > 0 {
+	preDedupCount := len(sourceHotspots)
+	all := dedupeActionableHotspots(sourceHotspots)
+	if dropped := preDedupCount - len(all); dropped > 0 {
 		e.Logger.Info("syncHotspotMetadata: deduplicated cross-branch source hotspots",
-			"project", input.CloudKey, "before", preDedupCount, "after", len(actionable), "dropped", dropped)
+			"project", input.CloudKey, "before", preDedupCount, "after", len(all), "dropped", dropped)
 	}
-	result.Stats.Actionable = int64(len(actionable))
-	if len(actionable) == 0 {
+
+	// Every source hotspot still needs a target visit: SonarQube Cloud
+	// dropped hotspots on 2026-07-01, so each one lands as an ordinary
+	// issue and has to be tagged `sqs-hotspot` to stay identifiable as a
+	// former hotspot (#423), regardless of whether it needs a state/
+	// comment sync. What #527 changes is which hotspots get that
+	// state/comment sync applied, and what counts toward the %-synced
+	// denominator:
+	//
+	//   - hotspotCategoryExcluded    (TO_REVIEW, no user comment): tagged
+	//     only, not counted in the denominator.
+	//   - hotspotCategoryAcknowledged (REVIEWED+ACKNOWLEDGED): tagged
+	//     always, comment-synced only with a user comment, never
+	//     state-transitioned, always counted in the denominator.
+	//   - hotspotCategoryEligible: tagged + fully state/comment synced,
+	//     counted in the denominator.
+	type classified struct {
+		h   matchableHotspot
+		cat hotspotSyncCategory
+	}
+	items := make([]classified, 0, len(all))
+	var eligibleCount, ackCount, excludedCount, triaged int
+	for _, h := range all {
+		if hotspotHasManualChanges(h) {
+			triaged++
+		}
+		cat := classifyHotspotForSync(h)
+		switch cat {
+		case hotspotCategoryEligible:
+			eligibleCount++
+		case hotspotCategoryAcknowledged:
+			ackCount++
+		default:
+			excludedCount++
+		}
+		items = append(items, classified{h: h, cat: cat})
+	}
+	result.Stats.Actionable = int64(eligibleCount + ackCount)
+	result.Stats.AckDemoted = int64(ackCount)
+	if len(items) == 0 {
 		e.Logger.Info("syncHotspotMetadata: no source hotspots to sync", "project", input.CloudKey, "source_total", len(sourceHotspots))
 		return result
 	}
@@ -333,47 +526,70 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 	e.Logger.Info("syncHotspotMetadata: syncing hotspots as issues",
 		"project", input.CloudKey,
 		"source_total", len(sourceHotspots),
-		"to_sync", len(actionable),
+		"eligible", eligibleCount,
+		"acknowledged", ackCount,
+		"excluded", excludedCount,
 		"carrying_triage", triaged,
 	)
 
-	// 3 + 4. Per-actionable-source: targeted search + resolve by
-	// (ruleKey, line). Race-safety: actionable is read-only, each
-	// goroutine takes one hotspot by value, stats counters are
-	// atomic.
+	// 3. Bulk-fetch Cloud issue candidates once per (project, branch) —
+	// #527: this replaces the previous one-search-per-hotspot approach,
+	// which was the actual cost driver since every hotspot (eligible or
+	// not) had to be resolved for tagging (#423). Built as an in-memory
+	// index; per-hotspot resolution below is then a zero-network lookup.
+	byBranch := groupHotspotsByBranch(all)
+	indexes := make(map[string]cloudIssueIndex, len(byBranch))
+	failedBranches := make(map[string]bool, len(byBranch))
+	for branch, hs := range byBranch {
+		idx, err := buildCloudIssueIndex(ctx, e, input.CloudKey, input.OrgKey, branch, distinctRuleKeys(hs))
+		if err != nil {
+			logAPIWarn(e.Logger, "syncHotspotMetadata: bulk candidate index build failed", err,
+				"project", input.CloudKey, "branch", branch, "rules", len(distinctRuleKeys(hs)))
+			failedBranches[branch] = true
+			continue
+		}
+		indexes[branch] = idx
+	}
+
+	// 4. Resolve + dispatch every hotspot from the cached index. Race-
+	// safety: items/indexes are read-only from here, each goroutine takes
+	// one item by value, stats counters are atomic.
 	// Public base URL for back-links — prefer the SQS sonar.core.serverBaseURL
 	// setting over the (often localhost) connection URL (#321).
 	baseURL := resolveSourceBaseURL(e, input.ServerURL)
 
-	var a, b, c, ack atomic.Int64
+	var a, b, c atomic.Int64
 	label := "Project key " + input.CloudKey + " hotspot sync:"
-	runProjectSyncLoop(ctx, e, actionable, label, 10,
-		func(gctx context.Context, src matchableHotspot) {
-			outcome := resolveAndSyncHotspot(gctx, e, input.CloudKey, input.OrgKey, baseURL, input.ServerKey, src, counter)
+	runProjectSyncLoop(ctx, e, items, label, 10,
+		func(gctx context.Context, it classified) {
+			if failedBranches[it.h.Branch] {
+				return
+			}
+			outcome := resolveAndSyncHotspot(gctx, e, input.CloudKey, baseURL, input.ServerKey, it.h, it.cat, indexes[it.h.Branch], counter)
 			switch outcome {
 			case syncOutcomeSynced:
-				a.Add(1)
+				if it.cat == hotspotCategoryEligible {
+					a.Add(1)
+				}
 			case syncOutcomeLineMismatch:
 				b.Add(1)
 			case syncOutcomeNotFound:
 				c.Add(1)
-			case syncOutcomeAckDemoted:
-				ack.Add(1)
 			}
 		})
 	result.Stats.A = a.Load()
 	result.Stats.B = b.Load()
 	result.Stats.C = c.Load()
-	result.Stats.AckDemoted = ack.Load()
 	return result
 }
 
-// resolveAndSyncHotspot searches Cloud for hotspots in the source
-// hotspot's file, then resolves via the scored matcher (matchscore.go,
-// issue #412). Returns the case a/b/c/lookup outcome.
-func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, baseURL, sourceKey string, src matchableHotspot, counter *TaskCounter) syncOutcome {
+// resolveAndSyncHotspot resolves the source hotspot's target issue from
+// the pre-built per-branch cloudIssueIndex (#527) — a plain map lookup,
+// no network call — then applies whatever sync the hotspot's category
+// calls for. Returns the case a/b/c outcome.
+func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, baseURL, sourceKey string, src matchableHotspot, cat hotspotSyncCategory, index cloudIssueIndex, counter *TaskCounter) syncOutcome {
 	// Strip "projectKey:" and any trailing "moduleKey:" segments so the bare
-	// file path can be used in the cloud search. Multi-module (monorepo)
+	// file path can be used against the index. Multi-module (monorepo)
 	// projects add a module key after the project key; SonarCloud has no
 	// module layer so only the plain file path matches the cloud component.
 	filePath := stripProjectKeyPrefix(src.Component)
@@ -383,19 +599,14 @@ func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, b
 	}
 	// The target counterpart is an ISSUE, not a hotspot: SonarQube Cloud has
 	// had no hotspots since 2026-07-01, so /api/hotspots/search can never
-	// return the migrated finding. Reuse the issue matcher, which additionally
-	// scopes the search server-side by rule — something the hotspot endpoint
-	// never accepted (#423).
-	candidates, err := findCloudIssueCandidates(ctx, e, cloudKey, orgKey, filePath, src.RuleKey, src.Branch)
-	if err != nil {
-		logAPIWarn(e.Logger, "syncHotspotMetadata: cloud candidate lookup failed", err,
-			"project", cloudKey, "source_key", src.Key, "file", filePath, "branch", src.Branch)
-		return syncOutcomeLookupError
-	}
+	// return the migrated finding. The index was built from the issue
+	// matcher's shape, which additionally scopes by rule — something the
+	// hotspot endpoint never accepted (#423).
+	candidates := index[cloudIssueIndexKey{File: filePath, RuleKey: src.RuleKey}]
 	target, outcome := classifyIssueCandidatesByLine(candidates, src.Line)
 	switch outcome {
 	case syncOutcomeSynced:
-		if err := syncOneHotspotAsIssue(ctx, e, src, target, baseURL, sourceKey); err != nil {
+		if err := syncOneHotspotAsIssue(ctx, e, src, target, baseURL, sourceKey, cat); err != nil {
 			counter.Fail()
 			logAPIWarn(e.Logger, "syncHotspotMetadata: hotspot sync failed", err,
 				"source_key", src.Key, "cloud_key", target.Key)
@@ -427,34 +638,58 @@ func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, b
 // sqs-hotspot tag applied last so its presence signals that everything before
 // it completed.
 //
-// Unlike the issue sync, this runs for EVERY hotspot, including a TO_REVIEW one
-// with no triage and no comments, because the tag itself is the deliverable:
+// This runs for EVERY hotspot, including a TO_REVIEW one with no triage and
+// no comments, because the back-link and tag are normally always applied:
 // with no hotspot concept left on the target, the tag is the only thing that
-// keeps a former hotspot identifiable.
-func syncOneHotspotAsIssue(ctx context.Context, e *Executor, src matchableHotspot, target matchableIssue, baseURL, projectKey string) error {
+// keeps a former hotspot identifiable (#423). Which of the transition/
+// comment steps actually run depends on cat, per #527's eligibility rules:
+//
+//   - hotspotCategoryEligible: transition + comments, as before.
+//   - hotspotCategoryAcknowledged: never transitioned (the state is not
+//     synced by policy, not because Cloud can't represent it); comments
+//     synced only if the hotspot carries a user comment.
+//   - hotspotCategoryExcluded: neither transition nor comments.
+//
+// e.FastSync (#527 follow-up) additionally skips the back-link and tag
+// steps for hotspotCategoryExcluded hotspots — TO_REVIEW with no user
+// comment is "zero user changes" on the source, and back-linking to a
+// hotspot nobody will ever review has no audience. It's opt-in (default
+// false) because it trades away #423's identifiability guarantee for
+// exactly this subset. ACKNOWLEDGED is deliberately excluded from this
+// skip: reaching that state is itself a user action, so it's never
+// "zero changes" even without a comment.
+func syncOneHotspotAsIssue(ctx context.Context, e *Executor, src matchableHotspot, target matchableIssue, baseURL, projectKey string, cat hotspotSyncCategory) error {
+	var firstErr error
+	skipTagAndLink := e.FastSync && cat == hotspotCategoryExcluded
+
 	// 1. Review state. The hotspot's status/resolution maps onto the unified
 	// issue-status enum, and the existing issue machinery turns that into a
 	// transition — including gating "accept" on the Cloud issue actually
-	// offering it (#322).
-	//
-	// ACKNOWLEDGED no longer has to be demoted to SAFE. That conflation was
-	// forced by Cloud's hotspot API having no ACKNOWLEDGED resolution; the
-	// issue model expresses it faithfully as ACCEPTED.
-	synthetic := matchableIssue{
-		Key:         src.Key,
-		IssueStatus: scanreport.HotspotIssueStatus(src.Status, src.Resolution),
-		Resolution:  src.Resolution,
-	}
-	var firstErr error
-	if syncIssueTransition(ctx, e, target.Key, synthetic, target.Transitions) {
-		firstErr = fmt.Errorf("transition to %s failed", synthetic.IssueStatus)
+	// offering it (#322). Skipped for ACKNOWLEDGED and excluded hotspots.
+	if cat == hotspotCategoryEligible {
+		synthetic := matchableIssue{
+			Key:         src.Key,
+			IssueStatus: scanreport.HotspotIssueStatus(src.Status, src.Resolution),
+			Resolution:  src.Resolution,
+		}
+		if syncIssueTransition(ctx, e, target.Key, synthetic, target.Transitions) {
+			firstErr = fmt.Errorf("transition to %s failed", synthetic.IssueStatus)
+		}
 	}
 
-	// 2. Review comments, via the issue comment path.
-	if len(src.Comments) > 0 {
+	// 2. Review comments, via the issue comment path. Eligible hotspots
+	// always sync comments; ACKNOWLEDGED hotspots only when they carry a
+	// user comment (#527); excluded hotspots never do.
+	syncComments := cat == hotspotCategoryEligible ||
+		(cat == hotspotCategoryAcknowledged && hotspotHasUserComment(src.Comments))
+	if syncComments && len(src.Comments) > 0 {
 		if syncIssueComments(ctx, e, target.Key, hotspotCommentsAsIssueComments(src.Comments), target.Comments) && firstErr == nil {
 			firstErr = fmt.Errorf("one or more comments failed")
 		}
+	}
+
+	if skipTagAndLink {
+		return firstErr
 	}
 
 	// 3. Back-link to the origin (#321). It still points at the source

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -433,6 +433,67 @@ type syncHotspotResult struct {
 	Error string
 }
 
+// classifiedHotspot pairs a source hotspot with the sync category
+// classifyHotspotForSync assigned it, computed once up front so the
+// dispatch loop doesn't re-derive it per goroutine.
+type classifiedHotspot struct {
+	h   matchableHotspot
+	cat hotspotSyncCategory
+}
+
+// hotspotCategoryCounts tallies a project's hotspots by sync category,
+// for logging and for the #527 %-synced reporting denominator.
+type hotspotCategoryCounts struct {
+	eligible, ack, excluded, triaged int
+}
+
+// classifyAndCountHotspots classifies every hotspot for dispatch and
+// tallies the category counts, in one pass. Split out of
+// syncProjectHotspots to keep that function's cognitive complexity low.
+func classifyAndCountHotspots(all []matchableHotspot) ([]classifiedHotspot, hotspotCategoryCounts) {
+	items := make([]classifiedHotspot, 0, len(all))
+	var counts hotspotCategoryCounts
+	for _, h := range all {
+		if hotspotHasManualChanges(h) {
+			counts.triaged++
+		}
+		cat := classifyHotspotForSync(h)
+		switch cat {
+		case hotspotCategoryEligible:
+			counts.eligible++
+		case hotspotCategoryAcknowledged:
+			counts.ack++
+		default:
+			counts.excluded++
+		}
+		items = append(items, classifiedHotspot{h: h, cat: cat})
+	}
+	return items, counts
+}
+
+// buildBranchIndexes builds one cloudIssueIndex per branch present among
+// all's hotspots (#527's bulk-fetch, see buildCloudIssueIndex). A branch
+// whose index build fails is recorded in the returned failure set rather
+// than aborting the whole project — its hotspots are skipped this run.
+// Split out of syncProjectHotspots to keep that function's cognitive
+// complexity low.
+func buildBranchIndexes(ctx context.Context, e *Executor, input syncHotspotInput, all []matchableHotspot) (map[string]cloudIssueIndex, map[string]bool) {
+	byBranch := groupHotspotsByBranch(all)
+	indexes := make(map[string]cloudIssueIndex, len(byBranch))
+	failedBranches := make(map[string]bool, len(byBranch))
+	for branch, hs := range byBranch {
+		idx, err := buildCloudIssueIndex(ctx, e, input.CloudKey, input.OrgKey, branch, distinctRuleKeys(hs))
+		if err != nil {
+			logAPIWarn(e.Logger, "syncHotspotMetadata: bulk candidate index build failed", err,
+				"project", input.CloudKey, "branch", branch, "rules", len(distinctRuleKeys(hs)))
+			failedBranches[branch] = true
+			continue
+		}
+		indexes[branch] = idx
+	}
+	return indexes, failedBranches
+}
+
 // syncProjectHotspots synchronises hotspot metadata for a single
 // project using the targeted per-actionable-source-hotspot search
 // approach introduced in #356. Replaces the previous fetch-all + FIFO
@@ -486,29 +547,9 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 	//     state-transitioned, always counted in the denominator.
 	//   - hotspotCategoryEligible: tagged + fully state/comment synced,
 	//     counted in the denominator.
-	type classified struct {
-		h   matchableHotspot
-		cat hotspotSyncCategory
-	}
-	items := make([]classified, 0, len(all))
-	var eligibleCount, ackCount, excludedCount, triaged int
-	for _, h := range all {
-		if hotspotHasManualChanges(h) {
-			triaged++
-		}
-		cat := classifyHotspotForSync(h)
-		switch cat {
-		case hotspotCategoryEligible:
-			eligibleCount++
-		case hotspotCategoryAcknowledged:
-			ackCount++
-		default:
-			excludedCount++
-		}
-		items = append(items, classified{h: h, cat: cat})
-	}
-	result.Stats.Actionable = int64(eligibleCount + ackCount)
-	result.Stats.AckDemoted = int64(ackCount)
+	items, counts := classifyAndCountHotspots(all)
+	result.Stats.Actionable = int64(counts.eligible + counts.ack)
+	result.Stats.AckDemoted = int64(counts.ack)
 	if len(items) == 0 {
 		e.Logger.Info("syncHotspotMetadata: no source hotspots to sync", "project", input.CloudKey, "source_total", len(sourceHotspots))
 		return result
@@ -526,10 +567,10 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 	e.Logger.Info("syncHotspotMetadata: syncing hotspots as issues",
 		"project", input.CloudKey,
 		"source_total", len(sourceHotspots),
-		"eligible", eligibleCount,
-		"acknowledged", ackCount,
-		"excluded", excludedCount,
-		"carrying_triage", triaged,
+		"eligible", counts.eligible,
+		"acknowledged", counts.ack,
+		"excluded", counts.excluded,
+		"carrying_triage", counts.triaged,
 	)
 
 	// 3. Bulk-fetch Cloud issue candidates once per (project, branch) —
@@ -537,19 +578,7 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 	// which was the actual cost driver since every hotspot (eligible or
 	// not) had to be resolved for tagging (#423). Built as an in-memory
 	// index; per-hotspot resolution below is then a zero-network lookup.
-	byBranch := groupHotspotsByBranch(all)
-	indexes := make(map[string]cloudIssueIndex, len(byBranch))
-	failedBranches := make(map[string]bool, len(byBranch))
-	for branch, hs := range byBranch {
-		idx, err := buildCloudIssueIndex(ctx, e, input.CloudKey, input.OrgKey, branch, distinctRuleKeys(hs))
-		if err != nil {
-			logAPIWarn(e.Logger, "syncHotspotMetadata: bulk candidate index build failed", err,
-				"project", input.CloudKey, "branch", branch, "rules", len(distinctRuleKeys(hs)))
-			failedBranches[branch] = true
-			continue
-		}
-		indexes[branch] = idx
-	}
+	indexes, failedBranches := buildBranchIndexes(ctx, e, input, all)
 
 	// 4. Resolve + dispatch every hotspot from the cached index. Race-
 	// safety: items/indexes are read-only from here, each goroutine takes
@@ -558,14 +587,15 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 	// setting over the (often localhost) connection URL (#321).
 	baseURL := resolveSourceBaseURL(e, input.ServerURL)
 
+	resolveParams := hotspotResolveParams{CloudKey: input.CloudKey, BaseURL: baseURL, SourceKey: input.ServerKey}
 	var a, b, c atomic.Int64
 	label := "Project key " + input.CloudKey + " hotspot sync:"
 	runProjectSyncLoop(ctx, e, items, label, 10,
-		func(gctx context.Context, it classified) {
+		func(gctx context.Context, it classifiedHotspot) {
 			if failedBranches[it.h.Branch] {
 				return
 			}
-			outcome := resolveAndSyncHotspot(gctx, e, input.CloudKey, baseURL, input.ServerKey, it.h, it.cat, indexes[it.h.Branch], counter)
+			outcome := resolveAndSyncHotspot(gctx, e, resolveParams, it.h, it.cat, indexes[it.h.Branch], counter)
 			switch outcome {
 			case syncOutcomeSynced:
 				if it.cat == hotspotCategoryEligible {
@@ -583,11 +613,21 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 	return result
 }
 
+// hotspotResolveParams bundles the per-project constants resolveAndSyncHotspot
+// needs alongside each hotspot, keeping the function's parameter count
+// within the project's limit — every hotspot in a project shares the same
+// CloudKey/BaseURL/SourceKey.
+type hotspotResolveParams struct {
+	CloudKey  string
+	BaseURL   string
+	SourceKey string
+}
+
 // resolveAndSyncHotspot resolves the source hotspot's target issue from
 // the pre-built per-branch cloudIssueIndex (#527) — a plain map lookup,
 // no network call — then applies whatever sync the hotspot's category
 // calls for. Returns the case a/b/c outcome.
-func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, baseURL, sourceKey string, src matchableHotspot, cat hotspotSyncCategory, index cloudIssueIndex, counter *TaskCounter) syncOutcome {
+func resolveAndSyncHotspot(ctx context.Context, e *Executor, p hotspotResolveParams, src matchableHotspot, cat hotspotSyncCategory, index cloudIssueIndex, counter *TaskCounter) syncOutcome {
 	// Strip "projectKey:" and any trailing "moduleKey:" segments so the bare
 	// file path can be used against the index. Multi-module (monorepo)
 	// projects add a module key after the project key; SonarCloud has no
@@ -606,7 +646,7 @@ func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, baseURL, 
 	target, outcome := classifyIssueCandidatesByLine(candidates, src.Line)
 	switch outcome {
 	case syncOutcomeSynced:
-		if err := syncOneHotspotAsIssue(ctx, e, src, target, baseURL, sourceKey, cat); err != nil {
+		if err := syncOneHotspotAsIssue(ctx, e, src, target, p.BaseURL, p.SourceKey, cat); err != nil {
 			counter.Fail()
 			logAPIWarn(e.Logger, "syncHotspotMetadata: hotspot sync failed", err,
 				"source_key", src.Key, "cloud_key", target.Key)

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -596,6 +596,9 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 				return
 			}
 			outcome := resolveAndSyncHotspot(gctx, e, resolveParams, it.h, it.cat, indexes[it.h.Branch], counter)
+			if it.cat == hotspotCategoryExcluded {
+				return // tagged only; not in the denominator, so not counted as b/c
+			}
 			switch outcome {
 			case syncOutcomeSynced:
 				if it.cat == hotspotCategoryEligible {

--- a/go/internal/migrate/tasks_hotspotsync_test.go
+++ b/go/internal/migrate/tasks_hotspotsync_test.go
@@ -5,6 +5,11 @@
 package migrate
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -156,5 +161,187 @@ func TestDedupeActionableHotspotsOffsetDistinguishesCoLocated(t *testing.T) {
 	}
 	if !offsets[17] || !offsets[35] {
 		t.Errorf("expected both column offsets (17, 35) preserved as distinct reps, got %v", offsets)
+	}
+}
+
+// #527: a comment counts as user-created only when its Login is
+// non-empty — blank/whitespace-only logins are treated as
+// SonarQube-technical.
+func TestHotspotHasUserComment(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []hotspotComment
+		want bool
+	}{
+		{"no comments", nil, false},
+		{"blank login", []hotspotComment{{Login: "", Markdown: "auto note"}}, false},
+		{"whitespace-only login", []hotspotComment{{Login: "   ", Markdown: "auto note"}}, false},
+		{"real login", []hotspotComment{{Login: "alice", Markdown: "reviewed"}}, true},
+		{"mixed — one real among technical", []hotspotComment{{Login: ""}, {Login: "bob"}}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hotspotHasUserComment(tc.in); got != tc.want {
+				t.Errorf("hotspotHasUserComment(%+v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// #527: eligibility rule — not TO_REVIEW, or a user comment, makes a
+// hotspot eligible for full sync; REVIEWED+ACKNOWLEDGED is always
+// flagged as acknowledged regardless of the eligible verdict.
+func TestHotspotSyncEligibility(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         string
+		resolution     string
+		hasUserComment bool
+		wantEligible   bool
+		wantAck        bool
+	}{
+		{"TO_REVIEW, no comment — excluded", "TO_REVIEW", "", false, false, false},
+		{"TO_REVIEW, user comment — eligible", "TO_REVIEW", "", true, true, false},
+		{"REVIEWED+SAFE — eligible", "REVIEWED", "SAFE", false, true, false},
+		{"REVIEWED+FIXED — eligible", "REVIEWED", "FIXED", false, true, false},
+		{"REVIEWED+ACKNOWLEDGED, no comment — eligible+ack", "REVIEWED", "ACKNOWLEDGED", false, true, true},
+		{"REVIEWED+ACKNOWLEDGED, user comment — eligible+ack", "REVIEWED", "ACKNOWLEDGED", true, true, true},
+		{"case-insensitive / whitespace", "  reviewed  ", " acknowledged ", false, true, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotEligible, gotAck := HotspotSyncEligibility(tc.status, tc.resolution, tc.hasUserComment)
+			if gotEligible != tc.wantEligible || gotAck != tc.wantAck {
+				t.Errorf("HotspotSyncEligibility(%q, %q, %v) = (%v, %v), want (%v, %v)",
+					tc.status, tc.resolution, tc.hasUserComment, gotEligible, gotAck, tc.wantEligible, tc.wantAck)
+			}
+		})
+	}
+}
+
+// #527: classifyHotspotForSync wraps HotspotSyncEligibility into the
+// three dispatch buckets, deriving hasUserComment from Comments.
+func TestClassifyHotspotForSync(t *testing.T) {
+	tests := []struct {
+		name string
+		h    matchableHotspot
+		want hotspotSyncCategory
+	}{
+		{"TO_REVIEW, no comment — excluded", matchableHotspot{Status: "TO_REVIEW"}, hotspotCategoryExcluded},
+		{
+			"TO_REVIEW, technical comment only — excluded",
+			matchableHotspot{Status: "TO_REVIEW", Comments: []hotspotComment{{Login: ""}}},
+			hotspotCategoryExcluded,
+		},
+		{
+			"TO_REVIEW, user comment — eligible",
+			matchableHotspot{Status: "TO_REVIEW", Comments: []hotspotComment{{Login: "alice"}}},
+			hotspotCategoryEligible,
+		},
+		{"REVIEWED+SAFE — eligible", matchableHotspot{Status: "REVIEWED", Resolution: "SAFE"}, hotspotCategoryEligible},
+		{"REVIEWED+ACKNOWLEDGED — acknowledged", matchableHotspot{Status: "REVIEWED", Resolution: "ACKNOWLEDGED"}, hotspotCategoryAcknowledged},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyHotspotForSync(tc.h); got != tc.want {
+				t.Errorf("classifyHotspotForSync(%+v) = %v, want %v", tc.h, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChunkStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		n    int
+		want [][]string
+	}{
+		{"empty", nil, 3, nil},
+		{"n<=0", []string{"a"}, 0, nil},
+		{"exact multiple", []string{"a", "b", "c", "d"}, 2, [][]string{{"a", "b"}, {"c", "d"}}},
+		{"remainder", []string{"a", "b", "c"}, 2, [][]string{{"a", "b"}, {"c"}}},
+		{"n larger than input", []string{"a", "b"}, 60, [][]string{{"a", "b"}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := chunkStrings(tc.in, tc.n)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("chunkStrings(%v, %d) = %v, want %v", tc.in, tc.n, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGroupHotspotsByBranch(t *testing.T) {
+	in := []matchableHotspot{
+		{Key: "a", Branch: "main"},
+		{Key: "b", Branch: "develop"},
+		{Key: "c", Branch: "main"},
+		{Key: "d"}, // no branch — empty-string bucket
+	}
+	got := groupHotspotsByBranch(in)
+	if len(got["main"]) != 2 || len(got["develop"]) != 1 || len(got[""]) != 1 {
+		t.Fatalf("unexpected grouping: %+v", got)
+	}
+}
+
+func TestDistinctRuleKeys(t *testing.T) {
+	in := []matchableHotspot{
+		{RuleKey: "java:S2245"},
+		{RuleKey: "java:S2077"},
+		{RuleKey: "java:S2245"},
+		{RuleKey: ""},
+	}
+	got := distinctRuleKeys(in)
+	want := []string{"java:S2077", "java:S2245"} // sorted
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("distinctRuleKeys(...) = %v, want %v", got, want)
+	}
+}
+
+// #527: buildCloudIssueIndex must chunk rule keys to stay under the
+// per-request cap, issue one search per chunk, and index results by
+// (bare file path, rule key) — the same scope the per-hotspot search
+// used, just fetched once for the whole branch.
+func TestBuildCloudIssueIndexChunksAndIndexes(t *testing.T) {
+	var searchCalls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/issues/search", func(w http.ResponseWriter, r *http.Request) {
+		searchCalls++
+		rules := r.URL.Query().Get("rules")
+		var issues []map[string]any
+		for i, rk := range strings.Split(rules, ",") {
+			issues = append(issues, map[string]any{
+				"key": rk + "-issue", "rule": rk, "component": "proj:src/Main.java", "line": 10 + i,
+			})
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"issues": issues,
+			"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": len(issues)},
+		})
+	})
+	e := newCustomCloudTest(t, mux)
+
+	ruleKeys := make([]string, 0, 125)
+	for i := 0; i < 125; i++ {
+		ruleKeys = append(ruleKeys, "java:S"+strconv.Itoa(1000+i))
+	}
+
+	idx, err := buildCloudIssueIndex(context.Background(), e, "proj", "org", "main", ruleKeys)
+	if err != nil {
+		t.Fatalf("buildCloudIssueIndex: %v", err)
+	}
+	wantChunks := (len(ruleKeys) + cloudIssueSearchRuleChunkSize - 1) / cloudIssueSearchRuleChunkSize
+	if searchCalls != wantChunks {
+		t.Errorf("expected %d chunked search calls for %d rule keys, got %d", wantChunks, len(ruleKeys), searchCalls)
+	}
+	if len(idx) != len(ruleKeys) {
+		t.Errorf("expected %d indexed (file, rule) entries, got %d", len(ruleKeys), len(idx))
+	}
+	sample := ruleKeys[0]
+	candidates := idx[cloudIssueIndexKey{File: "src/Main.java", RuleKey: sample}]
+	if len(candidates) != 1 || candidates[0].Key != sample+"-issue" {
+		t.Errorf("expected indexed candidate for %q, got %+v", sample, candidates)
 	}
 }

--- a/go/internal/migrate/tasks_hotspotsync_test.go
+++ b/go/internal/migrate/tasks_hotspotsync_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -343,5 +344,221 @@ func TestBuildCloudIssueIndexChunksAndIndexes(t *testing.T) {
 	candidates := idx[cloudIssueIndexKey{File: "src/Main.java", RuleKey: sample}]
 	if len(candidates) != 1 || candidates[0].Key != sample+"-issue" {
 		t.Errorf("expected indexed candidate for %q, got %+v", sample, candidates)
+	}
+}
+
+// #323: HotspotHasManualChanges is the exported, raw-field counterpart of
+// hotspotHasManualChanges used by the predict pipeline, which only has the
+// extract's status/resolution/hasComments in hand (no matchableHotspot).
+func TestHotspotHasManualChanges_Exported(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      string
+		resolution  string
+		hasComments bool
+		want        bool
+	}{
+		{"TO_REVIEW, no comments — skip", "TO_REVIEW", "", false, false},
+		{"TO_REVIEW, comments — sync", "TO_REVIEW", "", true, true},
+		{"REVIEWED, no resolution — skip", "REVIEWED", "", false, false},
+		{"REVIEWED + SAFE — sync", "REVIEWED", "SAFE", false, true},
+		{"REVIEWED + ACKNOWLEDGED — sync", "REVIEWED", "ACKNOWLEDGED", false, true},
+		{"REVIEWED + FIXED — sync", "REVIEWED", "FIXED", false, true},
+		{"REVIEWED + unknown resolution — skip", "REVIEWED", "WHATEVER", false, false},
+		{"REVIEWED + unknown resolution + comments — sync", "REVIEWED", "WHATEVER", true, true},
+		{"case-insensitive", "reviewed", "safe", false, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HotspotHasManualChanges(tc.status, tc.resolution, tc.hasComments); got != tc.want {
+				t.Errorf("HotspotHasManualChanges(%q, %q, %v) = %v, want %v", tc.status, tc.resolution, tc.hasComments, got, tc.want)
+			}
+		})
+	}
+}
+
+// #323: IsAcknowledgedResolution isolates the ACKNOWLEDGED literal so the
+// predict pipeline doesn't duplicate it.
+func TestIsAcknowledgedResolution(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"exact match", "ACKNOWLEDGED", true},
+		{"case-insensitive", "acknowledged", true},
+		{"surrounding whitespace", "  Acknowledged  ", true},
+		{"different resolution", "SAFE", false},
+		{"empty", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsAcknowledgedResolution(tc.in); got != tc.want {
+				t.Errorf("IsAcknowledgedResolution(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// #527: classifyAndCountHotspots must classify every hotspot and tally
+// the category counts (and the separate, informational "triaged" count)
+// in a single pass.
+func TestClassifyAndCountHotspots(t *testing.T) {
+	in := []matchableHotspot{
+		{Key: "excluded-1", Status: "TO_REVIEW"},
+		{Key: "eligible-1", Status: "REVIEWED", Resolution: "SAFE"},
+		{Key: "eligible-2", Status: "TO_REVIEW", Comments: []hotspotComment{{Login: "alice"}}},
+		{Key: "ack-1", Status: "REVIEWED", Resolution: "ACKNOWLEDGED"},
+		{Key: "ack-2", Status: "REVIEWED", Resolution: "ACKNOWLEDGED", Comments: []hotspotComment{{Login: "bob"}}},
+	}
+	items, counts := classifyAndCountHotspots(in)
+
+	if len(items) != len(in) {
+		t.Fatalf("expected %d classified items, got %d", len(in), len(items))
+	}
+	if counts.eligible != 2 {
+		t.Errorf("eligible = %d, want 2", counts.eligible)
+	}
+	if counts.ack != 2 {
+		t.Errorf("ack = %d, want 2", counts.ack)
+	}
+	if counts.excluded != 1 {
+		t.Errorf("excluded = %d, want 1", counts.excluded)
+	}
+	// hotspotHasManualChanges (the separate, #356 "triaged" signal) only
+	// counts REVIEWED+{SAFE,ACKNOWLEDGED,FIXED} or any comment — every
+	// hotspot here except excluded-1 trips it.
+	if counts.triaged != 4 {
+		t.Errorf("triaged = %d, want 4", counts.triaged)
+	}
+
+	byKey := make(map[string]hotspotSyncCategory, len(items))
+	for _, it := range items {
+		byKey[it.h.Key] = it.cat
+	}
+	want := map[string]hotspotSyncCategory{
+		"excluded-1": hotspotCategoryExcluded,
+		"eligible-1": hotspotCategoryEligible,
+		"eligible-2": hotspotCategoryEligible,
+		"ack-1":      hotspotCategoryAcknowledged,
+		"ack-2":      hotspotCategoryAcknowledged,
+	}
+	if !reflect.DeepEqual(byKey, want) {
+		t.Errorf("category assignment = %+v, want %+v", byKey, want)
+	}
+}
+
+// #527: buildBranchIndexes must build one index per distinct branch found
+// among the given hotspots, and record a branch as failed (without
+// aborting the others) when its search call errors.
+func TestBuildBranchIndexes(t *testing.T) {
+	var mainCalls, devCalls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/issues/search", func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("branch") {
+		case "main":
+			mainCalls++
+			json.NewEncoder(w).Encode(map[string]any{
+				"issues": []map[string]any{
+					{"key": "iss-main", "rule": "java:S2245", "component": "proj:src/Main.java", "line": 12},
+				},
+				"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 1},
+			})
+		case "develop":
+			devCalls++
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected branch %q", r.URL.Query().Get("branch"))
+		}
+	})
+	e := newCustomCloudTest(t, mux)
+
+	all := []matchableHotspot{
+		{Key: "h1", RuleKey: "java:S2245", Branch: "main"},
+		{Key: "h2", RuleKey: "java:S2245", Branch: "develop"},
+	}
+	indexes, failed := buildBranchIndexes(context.Background(), e, syncHotspotInput{CloudKey: "proj", OrgKey: "org"}, all)
+
+	// The HTTP client retries transient 5xx errors, so develop's failing
+	// search may be attempted more than once — only main's success count
+	// is exact.
+	if mainCalls != 1 {
+		t.Fatalf("expected exactly one successful search call for main, got %d", mainCalls)
+	}
+	if devCalls == 0 {
+		t.Fatalf("expected at least one search attempt for develop, got 0")
+	}
+	if failed["develop"] != true {
+		t.Errorf("develop branch should be marked failed, got %v", failed)
+	}
+	if failed["main"] {
+		t.Errorf("main branch should not be marked failed")
+	}
+	idx, ok := indexes["main"]
+	if !ok {
+		t.Fatalf("expected an index for main, got %v", indexes)
+	}
+	if _, ok := indexes["develop"]; ok {
+		t.Errorf("failed branch develop must not have an index entry")
+	}
+	candidates := idx[cloudIssueIndexKey{File: "src/Main.java", RuleKey: "java:S2245"}]
+	if len(candidates) != 1 || candidates[0].Key != "iss-main" {
+		t.Errorf("expected main's index to contain iss-main, got %+v", candidates)
+	}
+}
+
+// #527: runSyncHotspotMetadata is the task's Run function — it reads
+// createProjects, syncs each project's hotspots, and writes one
+// syncHotspotMetadata record per project with the eligible/acknowledged
+// stats. End-to-end exercise of the whole per-project pipeline.
+func TestRunSyncHotspotMetadataWritesRecord(t *testing.T) {
+	rec := &hotspotIssueSyncRecorder{}
+	mux := http.NewServeMux()
+	rec.mount(mux)
+	e := newCustomCloudTest(t, mux)
+
+	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
+	writeJSONL(filepath.Join(e.ExportDir, "extract-01", "getProjectHotspotsFull"), []map[string]any{
+		// Eligible: REVIEWED+SAFE, matches the recorder's fixed search
+		// result (java:S2245 @ proj:src/Main.java:12) — gets synced.
+		{"key": "h1", "project": "proj1", "status": "REVIEWED", "resolution": "SAFE", "ruleKey": "java:S2245", "component": "proj:src/Main.java", "line": 12},
+		// Excluded: TO_REVIEW, no comment, a different line so it does
+		// NOT dedupe with h1 — never counted as actionable regardless
+		// of whether it finds a Cloud counterpart.
+		{"key": "h2", "project": "proj1", "status": "TO_REVIEW", "ruleKey": "java:S2245", "component": "proj:src/Main.java", "line": 50},
+	})
+	writeTaskJSONL(t, e, "createProjects", []map[string]any{
+		{"cloud_project_key": "cloud_proj1", "sonarcloud_org_key": "org1", "server_url": testServerURL, "key": "proj1"},
+	})
+
+	if err := runSyncHotspotMetadata(context.Background(), e); err != nil {
+		t.Fatalf("runSyncHotspotMetadata: %v", err)
+	}
+
+	items, err := e.Store.ReadAll("syncHotspotMetadata")
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 syncHotspotMetadata record, got %d: %s", len(items), items)
+	}
+	var got struct {
+		CloudProjectKey string `json:"cloud_project_key"`
+		Synced          int    `json:"synced"`
+		Actionable      int    `json:"actionable"`
+	}
+	if err := json.Unmarshal(items[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.CloudProjectKey != "cloud_proj1" {
+		t.Errorf("cloud_project_key = %q, want cloud_proj1", got.CloudProjectKey)
+	}
+	// Only h1 (eligible) counts toward actionable/synced; h2 (excluded)
+	// is tagged/back-linked but contributes to neither.
+	if got.Actionable != 1 {
+		t.Errorf("actionable = %d, want 1 (only h1 is eligible)", got.Actionable)
+	}
+	if got.Synced != 1 {
+		t.Errorf("synced = %d, want 1", got.Synced)
 	}
 }

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -285,6 +285,16 @@ const metadataSyncTag = "metadata-synchronized"
 // Assignee was previously a trigger but was dropped per the issue spec:
 // auto-assigned issues (e.g. via "default assignee") are common and
 // inflate the actionable set without carrying real triage signal.
+//
+// #527 / --fast_sync note: syncProjectIssues only ever visits, tags, and
+// back-links issues that pass this filter — an untouched issue (OPEN, no
+// custom tags, no comments) never reaches the per-item Cloud lookup at
+// all, unconditionally, regardless of the --fast_sync flag. So --fast_sync
+// has no additional effect on the issue path today; its effect is visible
+// only on the hotspot path (tasks_hotspotsync.go's syncOneHotspotAsIssue),
+// which — unlike this one — still resolves and tags every hotspot by
+// default so #423's identifiability guarantee holds even for hotspots
+// with zero user changes.
 func hasManualChanges(iss matchableIssue) bool {
 	status := strings.ToUpper(iss.Status)
 	resolution := strings.ToUpper(iss.Resolution)

--- a/go/internal/predict/predict_test.go
+++ b/go/internal/predict/predict_test.go
@@ -344,10 +344,10 @@ func TestGeneratePredictiveReport_ConsolidatesSonarAuth(t *testing.T) {
 	}
 }
 
-// #323: predictive report must surface per-project hotspot sync stats
-// and route projects with ACKNOWLEDGED hotspots to NearPerfect with
-// the "N ACKNOWLEDGED hotspot(s) left as TO_REVIEW" callout in the
-// Details column.
+// #323 / #527: predictive report must surface per-project hotspot sync
+// stats and route projects with ACKNOWLEDGED hotspots to NearPerfect
+// with the "N ACKNOWLEDGED hotspot(s) inventoried but not state-synced"
+// callout in the Details column.
 func TestGeneratePredictiveReport_HotspotAcknowledgedDemotion(t *testing.T) {
 	exportDir := t.TempDir()
 
@@ -365,8 +365,8 @@ func TestGeneratePredictiveReport_HotspotAcknowledgedDemotion(t *testing.T) {
 	writeFile(t, extractDir, "extract.json", `{"url":"`+testServerURL+`"}`)
 
 	// Three actionable hotspots: 2 SAFE (cleanly synced), 1 ACKNOWLEDGED
-	// (demoted to TO_REVIEW). Plus one TO_REVIEW with no comments — not
-	// actionable, must NOT inflate the actionable count.
+	// (inventoried, never state-synced). Plus one TO_REVIEW with no
+	// comments — excluded, must NOT inflate the actionable count.
 	writeJSONL(t, filepath.Join(extractDir, "getProjectHotspotsFull", "hotspots.jsonl"),
 		[]map[string]any{
 			{"key": "h1", "project": "com.example:app", "status": "REVIEWED", "resolution": "SAFE"},

--- a/go/internal/predict/sync_hotspot_metadata.go
+++ b/go/internal/predict/sync_hotspot_metadata.go
@@ -17,10 +17,14 @@ import (
 // extract's getProjectHotspotsFull task and emits one synthetic
 // syncHotspotMetadata JSONL record per project so the predictive
 // report can surface the same sync stats / NearPerfect routing as the
-// real migrate (#323). The predict pipeline can compute the
-// ACKNOWLEDGED demotion count exactly (it depends only on source-side
-// resolution); it cannot predict line_mismatch / not_found and
-// assumes a 1:1 match for non-ACKNOWLEDGED actionable hotspots.
+// real migrate (#323). It applies the same sync-eligibility rule real
+// migrate uses (migrate.HotspotSyncEligibility, #527): a hotspot counts
+// toward "actionable" only if it is not TO_REVIEW, has a user comment,
+// or is ACKNOWLEDGED (inventoried but never state-synced). The predict
+// pipeline can compute this exactly (it depends only on source-side
+// status/resolution/comments); it cannot predict line_mismatch /
+// not_found and assumes a 1:1 match for eligible, non-ACKNOWLEDGED
+// hotspots.
 //
 // Schema matches what runSyncHotspotMetadata writes in real migrate
 // so the existing collectSyncStats / collectSyncOutcome paths render
@@ -43,9 +47,13 @@ func synthesizeSyncHotspotMetadata(exportDir, runDir string, extractMapping stru
 	// Index (server_url, source key) → cloud_project_key.
 	cloudByProject := buildCloudByProject(projects)
 
+	// eligible/ack mirror the real-migrate hotspotSyncCategory split
+	// (#527): eligible hotspots would get a full state/comment sync,
+	// ACKNOWLEDGED ones are inventoried but never state-transitioned.
+	// Excluded hotspots (TO_REVIEW, no user comment) are not counted.
 	type counts struct {
-		actionable int
-		ack        int
+		eligible int
+		ack      int
 	}
 	perProject := make(map[string]*counts, len(cloudByProject))
 
@@ -60,8 +68,9 @@ func synthesizeSyncHotspotMetadata(exportDir, runDir string, extractMapping stru
 		}
 		status := jsonStringField(item.Data, "status")
 		resolution := jsonStringField(item.Data, "resolution")
-		hasComments := jsonHasNonEmptyArray(item.Data, "comment")
-		if !migrate.HotspotHasManualChanges(status, resolution, hasComments) {
+		hasUserComment := jsonHasUserComment(item.Data)
+		eligible, acknowledged := migrate.HotspotSyncEligibility(status, resolution, hasUserComment)
+		if !eligible && !acknowledged {
 			continue
 		}
 		c, ok := perProject[cloudKey]
@@ -69,9 +78,10 @@ func synthesizeSyncHotspotMetadata(exportDir, runDir string, extractMapping stru
 			c = &counts{}
 			perProject[cloudKey] = c
 		}
-		c.actionable++
-		if migrate.IsAcknowledgedResolution(resolution) {
+		if acknowledged {
 			c.ack++
+		} else {
+			c.eligible++
 		}
 	}
 
@@ -86,11 +96,11 @@ func synthesizeSyncHotspotMetadata(exportDir, runDir string, extractMapping stru
 	for cloudKey, c := range perProject {
 		rec := map[string]any{
 			"cloud_project_key":    cloudKey,
-			"synced":               c.actionable - c.ack,
+			"synced":               c.eligible,
 			"line_mismatch":        0,
 			"not_found":            0,
 			"acknowledged_demoted": c.ack,
-			"actionable":           c.actionable,
+			"actionable":           c.eligible + c.ack,
 		}
 		b, err := json.Marshal(rec)
 		if err != nil {
@@ -103,15 +113,16 @@ func synthesizeSyncHotspotMetadata(exportDir, runDir string, extractMapping stru
 	return nil
 }
 
-// jsonHasNonEmptyArray reports whether the named top-level field is a
-// JSON array with at least one element. Used to detect hotspot
-// comment presence without parsing the full comment shape.
-func jsonHasNonEmptyArray(raw json.RawMessage, key string) bool {
+// jsonHasUserComment reports whether the hotspot's raw JSON "comment"
+// array contains at least one entry with a non-empty "login" — the
+// #527 "user comment" signal, mirroring migrate.hotspotHasUserComment
+// for the raw-JSON extract shape.
+func jsonHasUserComment(raw json.RawMessage) bool {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &obj); err != nil {
 		return false
 	}
-	v, ok := obj[key]
+	v, ok := obj["comment"]
 	if !ok {
 		return false
 	}
@@ -119,5 +130,10 @@ func jsonHasNonEmptyArray(raw json.RawMessage, key string) bool {
 	if err := json.Unmarshal(v, &arr); err != nil {
 		return false
 	}
-	return len(arr) > 0
+	for _, c := range arr {
+		if jsonStringField(c, "login") != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/go/internal/predict/sync_hotspot_metadata_test.go
+++ b/go/internal/predict/sync_hotspot_metadata_test.go
@@ -1,0 +1,111 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package predict
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+)
+
+// #527: the predictive pipeline must apply the same sync-eligibility
+// rule as real migrate (migrate.HotspotSyncEligibility) — a hotspot is
+// actionable only if it is not TO_REVIEW, carries a user (non-technical)
+// comment, or is ACKNOWLEDGED (inventoried but never state-synced).
+func TestSynthesizeSyncHotspotMetadataEligibility(t *testing.T) {
+	exportDir := t.TempDir()
+
+	writeFile(t, exportDir, "organizations.csv",
+		"sonarqube_org_key,sonarcloud_org_key,server_url\n"+
+			"default,target-org,"+testServerURL+"\n")
+	writeFile(t, exportDir, "projects.csv",
+		"name,key,server_url,sonarqube_org_key\n"+
+			"App,com.example:app,"+testServerURL+",default\n")
+	writeFile(t, exportDir, "gates.csv",
+		"name,server_url,source_gate_key,is_default,sonarqube_org_key\n")
+
+	extractDir := filepath.Join(exportDir, "extract-0001")
+	writeFile(t, extractDir, "extract.json", `{"url":"`+testServerURL+`"}`)
+
+	writeJSONL(t, filepath.Join(extractDir, "getProjectHotspotsFull", "hotspots.jsonl"),
+		[]map[string]any{
+			// Excluded: TO_REVIEW, no comment at all.
+			{"key": "h1", "project": "com.example:app", "status": "TO_REVIEW"},
+			// Excluded: TO_REVIEW, only a technical (blank-login) comment.
+			{"key": "h2", "project": "com.example:app", "status": "TO_REVIEW",
+				"comment": []map[string]any{{"login": "", "markdown": "auto"}}},
+			// Eligible: TO_REVIEW, but a real user commented on it.
+			{"key": "h3", "project": "com.example:app", "status": "TO_REVIEW",
+				"comment": []map[string]any{{"login": "alice", "markdown": "still worth a look"}}},
+			// Eligible: REVIEWED+SAFE.
+			{"key": "h4", "project": "com.example:app", "status": "REVIEWED", "resolution": "SAFE"},
+			// Acknowledged: never state-synced, but inventoried.
+			{"key": "h5", "project": "com.example:app", "status": "REVIEWED", "resolution": "ACKNOWLEDGED"},
+			// Acknowledged, with a user comment — still just "acknowledged"
+			// for the actionable/synced counts (comment sync isn't tracked
+			// as a separate predictive count).
+			{"key": "h6", "project": "com.example:app", "status": "REVIEWED", "resolution": "ACKNOWLEDGED",
+				"comment": []map[string]any{{"login": "bob", "markdown": "seen, accepted"}}},
+		})
+
+	runDir, err := BuildPredictiveRun(exportDir)
+	if err != nil {
+		t.Fatalf("BuildPredictiveRun: %v", err)
+	}
+
+	rows, err := common.NewDataStore(runDir).ReadAll("syncHotspotMetadata")
+	if err != nil {
+		t.Fatalf("read syncHotspotMetadata: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 syncHotspotMetadata record, got %d: %s", len(rows), rows)
+	}
+
+	var rec struct {
+		Synced              int `json:"synced"`
+		Actionable          int `json:"actionable"`
+		AcknowledgedDemoted int `json:"acknowledged_demoted"`
+	}
+	if err := json.Unmarshal(rows[0], &rec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// eligible = h3, h4 -> 2 ; acknowledged = h5, h6 -> 2.
+	if rec.Synced != 2 {
+		t.Errorf("synced = %d, want 2 (eligible, non-ACK hotspots)", rec.Synced)
+	}
+	if rec.AcknowledgedDemoted != 2 {
+		t.Errorf("acknowledged_demoted = %d, want 2", rec.AcknowledgedDemoted)
+	}
+	if rec.Actionable != 4 {
+		t.Errorf("actionable = %d, want 4 (eligible + acknowledged); h1/h2 must be excluded", rec.Actionable)
+	}
+}
+
+// #527: jsonHasUserComment mirrors migrate.hotspotHasUserComment for the
+// raw-JSON extract shape — a comment counts only when its login is
+// non-empty.
+func TestJsonHasUserComment(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"no comment field", `{}`, false},
+		{"empty array", `{"comment":[]}`, false},
+		{"blank login only", `{"comment":[{"login":"","markdown":"auto"}]}`, false},
+		{"real login", `{"comment":[{"login":"alice","markdown":"hi"}]}`, true},
+		{"mixed", `{"comment":[{"login":""},{"login":"bob"}]}`, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := jsonHasUserComment(json.RawMessage(tc.raw)); got != tc.want {
+				t.Errorf("jsonHasUserComment(%s) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -1329,35 +1329,23 @@ func TestCollectSummaryNCDFallbackMovesProjectToPartial(t *testing.T) {
 	}
 
 	// Project A → Partial with the explanatory Issue.
-	var sawA bool
-	for _, p := range projSection.Partial {
-		if p.Name != "Project A" {
-			continue
-		}
-		sawA = true
-		joined := strings.Join(p.Issues, " | ")
-		if !strings.Contains(joined, "reference branch") {
-			t.Errorf("Project A Partial Issues must mention the substituted NCD type, got %q", joined)
-		}
-		if !strings.Contains(joined, "replaced by the org default") {
-			t.Errorf("Project A Partial Issues must mention org-default substitution, got %q", joined)
-		}
+	projA := findItemByName(projSection.Partial, "Project A")
+	if projA == nil {
+		t.Fatalf("Project A must appear in Partial, got Partial=%v", projSection.Partial)
 	}
-	if !sawA {
-		t.Errorf("Project A must appear in Partial, got Partial=%v", projSection.Partial)
+	joined := strings.Join(projA.Issues, " | ")
+	if !strings.Contains(joined, "reference branch") {
+		t.Errorf("Project A Partial Issues must mention the substituted NCD type, got %q", joined)
+	}
+	if !strings.Contains(joined, "replaced by the org default") {
+		t.Errorf("Project A Partial Issues must mention org-default substitution, got %q", joined)
 	}
 
-	// Project B (supported NCD type) → stays in Succeeded.
-	var sawB bool
-	for _, p := range projSection.Succeeded {
-		if p.Name == "Project B" {
-			sawB = true
-		}
-		if p.Name == "Project A" {
-			t.Errorf("Project A must NOT remain in Succeeded after Partial move")
-		}
+	// Project B (supported NCD type) → stays in Succeeded; Project A must not.
+	if findItemByName(projSection.Succeeded, "Project A") != nil {
+		t.Errorf("Project A must NOT remain in Succeeded after Partial move")
 	}
-	if !sawB {
+	if findItemByName(projSection.Succeeded, "Project B") == nil {
 		t.Errorf("Project B must remain in Succeeded, got Succeeded=%v", projSection.Succeeded)
 	}
 }
@@ -1518,6 +1506,17 @@ func findSection(s *MigrationSummary, name string) *Section {
 	for i := range s.Sections {
 		if s.Sections[i].Name == name {
 			return &s.Sections[i]
+		}
+	}
+	return nil
+}
+
+// findItemByName returns a pointer to the first item in items whose Name
+// matches, or nil if none does.
+func findItemByName(items []EntityItem, name string) *EntityItem {
+	for i := range items {
+		if items[i].Name == name {
+			return &items[i]
 		}
 	}
 	return nil

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -1667,9 +1667,10 @@ func TestCollectLimitations_GlobalProjectDataSkipped(t *testing.T) {
 	}
 }
 
-// #323: encodeSyncStats must emit "ack=N" alongside i=/h= when any
-// ACKNOWLEDGED hotspots had to be left in TO_REVIEW. Only emitted
-// when N > 0 so unrelated projects keep their compact marker.
+// #323 / #527: encodeSyncStats must emit "ack=N" alongside i=/h= when
+// any ACKNOWLEDGED hotspots were inventoried (counted in the
+// denominator but never state-synced). Only emitted when N > 0 so
+// unrelated projects keep their compact marker.
 func TestEncodeSyncStatsAckSegment(t *testing.T) {
 	cases := []struct {
 		name string
@@ -1736,10 +1737,10 @@ func TestCollectSyncStatsReadsAcknowledgedDemoted(t *testing.T) {
 	}
 }
 
-// #323: collectSyncOutcome must route a project to NearPerfect when
-// the hotspot record carries acknowledged_demoted > 0 — even if
+// #323 / #527: collectSyncOutcome must route a project to NearPerfect
+// when the hotspot record carries acknowledged_demoted > 0 — even if
 // line_mismatch and not_found are both zero (everything matched
-// cleanly, but ACKNOWLEDGED hotspots couldn't preserve their state).
+// cleanly, but ACKNOWLEDGED hotspots are never state-synced by policy).
 func TestCollectSyncOutcomeNearPerfectOnAcknowledgedDemoted(t *testing.T) {
 	dir := t.TempDir()
 	writeTaskJSONL(t, dir, "syncHotspotMetadata", []map[string]any{

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -1444,10 +1444,14 @@ func renderSyncStatsLine(payload string) string {
 	return strings.Join(segments, "; ")
 }
 
-// formatAckDemotedSegment renders the #323 ACKNOWLEDGED-demotion
-// segment: "N ACKNOWLEDGED hotspot(s) left as TO_REVIEW (status not
-// supported on SonarQube Cloud)". Skipped silently when N is invalid
-// or zero.
+// formatAckDemotedSegment renders the ACKNOWLEDGED-hotspot segment: "N
+// ACKNOWLEDGED hotspot(s) inventoried but not state-synced (comments
+// still synced if present)". ACKNOWLEDGED hotspots are counted in the
+// %-synced denominator but are never state-transitioned, by policy
+// (#527) — not because SonarQube Cloud can't represent the state, as
+// the wording previously implied (Cloud's issue model expresses
+// ACKNOWLEDGED faithfully as ACCEPTED; see scanreport.HotspotIssueStatus).
+// Skipped silently when N is invalid or zero.
 func formatAckDemotedSegment(value string) string {
 	n, err := strconv.Atoi(value)
 	if err != nil || n <= 0 {
@@ -1457,7 +1461,7 @@ func formatAckDemotedSegment(value string) string {
 	if n != 1 {
 		noun = "hotspots"
 	}
-	return fmt.Sprintf("%d ACKNOWLEDGED %s left as TO_REVIEW (status not supported on SonarQube Cloud)", n, noun)
+	return fmt.Sprintf("%d ACKNOWLEDGED %s inventoried but not state-synced (comments still synced if present)", n, noun)
 }
 
 func formatSyncStatSegment(label, fraction string) string {

--- a/go/internal/report/summary/pdf_test.go
+++ b/go/internal/report/summary/pdf_test.go
@@ -622,12 +622,12 @@ func TestSuccessDetailsDroppedUserPermsLine(t *testing.T) {
 	}
 }
 
-// #356 / #323: per-project sync stats marker renders a one-line "x% of
-// items with manual changes synced" comment plus an "N ACKNOWLEDGED
-// hotspot(s) left as TO_REVIEW" segment when hotspots had to be
-// demoted. The line renders in both actual and predictive reports —
-// the predict pipeline synthesizes hotspot stats from the extract
-// (#323).
+// #356 / #323 / #527: per-project sync stats marker renders a one-line
+// "x% of items with manual changes synced" comment plus an "N
+// ACKNOWLEDGED hotspot(s) inventoried but not state-synced" segment
+// when ACKNOWLEDGED hotspots were counted in the denominator. The line
+// renders in both actual and predictive reports — the predict pipeline
+// synthesizes hotspot stats from the extract (#323).
 func TestSuccessDetailsSyncStatsLine(t *testing.T) {
 	item := EntityItem{Detail: "acme_proj|syncStats:i=42/50,h=10/12"}
 
@@ -662,18 +662,18 @@ func TestSuccessDetailsSyncStatsLine(t *testing.T) {
 			t.Errorf("did not expect sync line for plain detail, got %q", got)
 		}
 	})
-	t.Run("ack= segment renders ACKNOWLEDGED-demoted callout (#323)", func(t *testing.T) {
+	t.Run("ack= segment renders ACKNOWLEDGED callout (#527)", func(t *testing.T) {
 		got := successDetails(EntityItem{Detail: "p|syncStats:h=8/10,ack=2"}, false, false, false)
 		if !strings.Contains(got, "80% of hotspots with manual changes synced (8/10)") {
 			t.Errorf("expected hotspot sync line, got %q", got)
 		}
-		if !strings.Contains(got, "2 ACKNOWLEDGED hotspots left as TO_REVIEW") {
-			t.Errorf("expected ACKNOWLEDGED-demoted callout, got %q", got)
+		if !strings.Contains(got, "2 ACKNOWLEDGED hotspots inventoried but not state-synced") {
+			t.Errorf("expected ACKNOWLEDGED callout, got %q", got)
 		}
 	})
-	t.Run("ack=1 uses singular noun (#323)", func(t *testing.T) {
+	t.Run("ack=1 uses singular noun (#527)", func(t *testing.T) {
 		got := successDetails(EntityItem{Detail: "p|syncStats:ack=1"}, false, false, false)
-		if !strings.Contains(got, "1 ACKNOWLEDGED hotspot left as TO_REVIEW") {
+		if !strings.Contains(got, "1 ACKNOWLEDGED hotspot inventoried but not state-synced") {
 			t.Errorf("expected singular noun for ack=1, got %q", got)
 		}
 		if strings.Contains(got, "hotspots ") {


### PR DESCRIPTION
## Summary
- Hotspot sync now classifies each source hotspot as **excluded** (TO_REVIEW, no user comment), **acknowledged** (REVIEWED+ACKNOWLEDGED), or **eligible**, and replaces the previous per-hotspot Cloud search with a bulk per-(project, branch) index build (`buildCloudIssueIndex`).
- Every hotspot is still resolved and tagged `sqs-hotspot` from that cached index (#423), but only eligible/acknowledged hotspots get the state-transition + comment sync; the %-synced reporting denominator is now the eligible+acknowledged set instead of every hotspot.
- Extraction now fetches hotspot detail (comments) for every status, not just REVIEWED, so a TO_REVIEW hotspot with a genuine user comment is still detected as eligible.
- Real-world testing (743-hotspot project, none touched) showed the remaining per-hotspot tag + back-link write calls still dominate runtime even after the search was batched. Added `--fast_sync` (usable on `migrate`, `transfer`, and `sync-issues`, via CLI flag or config file — top-level or inside the `target` subsection, target wins) which skips those two writes for hotspots with zero user changes on the source (original TO_REVIEW state, no user comment, no custom tags). Defaults to **off** — current behavior (every hotspot tagged + back-linked) is unchanged unless explicitly opted in.
- Confirmed via code research that the issue-sync path already skips untouched issues unconditionally (`hasManualChanges`), so `--fast_sync` has no additional effect there today — documented in place rather than adding dead logic.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./... -race` (full suite green)
- [x] New unit tests: hotspot eligibility classification, bulk index build/chunking, category-gated tag/back-link skipping under `--fast_sync`, config-file resolution (all 4 shapes + target-override) for `fast_sync`, CLI flag override tests for `migrate`/`transfer`/`sync-issues`
- [ ] Manual: re-run against the real `laravel` project (743 untouched hotspots) with `--fast_sync` and confirm the sync duration drops sharply from the observed 3.5 minutes

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)