### PR TITLE
Issue #541 Migrate OOMs on large instances: extract corpus re-read per project, ×25 concurrency 

### DIFF
--- a/docs/ADVANCED-CONFIG.md
+++ b/docs/ADVANCED-CONFIG.md
@@ -44,6 +44,7 @@ Only `source.url` / `source.token` (for `extract`) and `target.url` / `target.to
 | Parameter | CLI flag | Commands | Default | Required | Role |
 |---|---|---|---|:--:|---|
 | `concurrency` | `--concurrency` | all | `10` | No | Max parallel HTTP calls. Overridable per block via `source`/`target`. |
+| `project_data_build_concurrency` | `--project_data_build_concurrency` | migrate | `4` | No | Max number of scanner reports built at once during project-data migration. Lower it if the migration runs out of memory on a large instance; raise it toward `concurrency` if report building is the bottleneck. Overridable via `target.project_data_build_concurrency`. |
 | `timeout` | `--timeout` | extract, transfer | `60` | No | HTTP request timeout in seconds. Overridable per block. |
 | `export_directory` | `--export_directory` (`--export_dir` on `transfer`) | all | `./migration-files` | No | Root directory for extract / migrate output. |
 | `skip_issue_sync` | `--skip_issue_sync` | extract, migrate, transfer | `false` | No | Skip the final per-issue / per-hotspot metadata sync (#299). Accepts `true`/`on`/`yes`/`1` (case-insensitive). CLI flag is a one-way override. |
@@ -75,6 +76,7 @@ Only `source.url` / `source.token` (for `extract`) and `target.url` / `target.to
 | `target.enterprise_key` | `--enterprise_key` | `null` | No¹ | SonarQube Cloud enterprise key. ¹Required for any enterprise-scoped endpoint (portfolios, org listings, etc.). |
 | `target.edition` | `--edition` | `enterprise` | No | SonarQube Cloud edition: `enterprise`, `team`, or `foss`. |
 | `target.concurrency` | `--concurrency` | top-level | No | Override top-level concurrency for migrate / reset calls. |
+| `target.project_data_build_concurrency` | `--project_data_build_concurrency` | top-level | No | Override top-level `project_data_build_concurrency` for migrate calls. |
 | `target.timeout` | `--timeout` | top-level | No | Override top-level timeout for migrate / reset calls. |
 | `target.run_id` | `--run_id` | `null` | No | Resume an in-progress migrate run by ID. |
 | `target.target_task` | `--target_task` | `null` | No | Stop migrate at a specific task (dependencies still run). |
@@ -105,6 +107,7 @@ All optional.
 | Field | Default | Description |
 |---|---|---|
 | `concurrency` | `10` | Default max parallel HTTP calls. |
+| `project_data_build_concurrency` | `4` | Default max number of scanner reports built at once during project-data migration. |
 | `timeout` | `60` | Default HTTP request timeout in seconds. |
 | `export_directory` | `./migration-files` | Root directory for extract / migrate output. |
 | `skip_issue_sync` | `false` | When `true` (or `"on"` / `"yes"` / `1`), skip the final per-issue and per-hotspot metadata sync that runs after project data is replayed. Defaults to `false` so the sync happens. Accepted aliases are case-insensitive. Issue #299. |
@@ -143,6 +146,7 @@ The CLI flags `--skip_issue_sync` and `--skip_project_data_migration` on `migrat
 | `enterprise_key` | | SonarCloud enterprise key (required for any enterprise-scoped endpoint — portfolios, org listings, etc.). |
 | `edition` | | `"enterprise"` (default), `"team"`, or `"foss"`. |
 | `concurrency` | | Override top-level default. |
+| `project_data_build_concurrency` | | Override top-level `project_data_build_concurrency` default. |
 | `timeout` | | Override top-level default. |
 | `run_id` | | Resume an in-progress migrate run by ID. |
 | `target_task` | | Stop migrate at a specific task. |
@@ -279,6 +283,7 @@ sonar-migration-tool migrate --target_token <token> --enterprise_key <key> [flag
 | `--default_organization <key>` | SonarCloud org applied to every project when `organizations.csv` has no mapping defined. |
 | `--project_key_pattern <pattern>` | Template for target project keys (`<ORIGINAL_PROJECT_KEY>` / `<ORGANIZATION_KEY>`). Default `<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>`. See [Project key renaming strategy](#project-key-renaming-strategy). |
 | `--concurrency <n>` | Max concurrent requests. |
+| `--project_data_build_concurrency <n>` | Max number of scanner reports built at once during project-data migration (default `4`). Lower it if the migration runs out of memory on a large instance; raise it toward `--concurrency` if report building is the bottleneck. |
 
 ### `reset`
 

--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -61,6 +61,7 @@ func init() {
 	_ = f.MarkDeprecated("token", "use --target_token instead")
 	f.String("run_id", "", "ID of a run to resume in case of failures")
 	f.Int("concurrency", 0, "Maximum number of concurrent requests")
+	f.Int("project_data_build_concurrency", 0, "Maximum number of scanner reports built at once during project-data migration (default 4). Lower this if the migration runs out of memory on a large instance; raise it toward --concurrency if report building is the bottleneck.")
 	f.Int("timeout", 0, "Per-HTTP-request timeout in seconds (default: 60). Maps to the top-level timeout config field.")
 	f.String("export_directory", "", "Root directory containing all SonarQube exports")
 	f.String("target_task", "", "Name of a specific migration task to complete")
@@ -102,6 +103,7 @@ func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfi
 	overrideString(cmd, "default_organization", &cfg.DefaultOrganization)
 	overrideString(cmd, "project_key_pattern", &cfg.ProjectKeyPattern)
 	overrideInt(cmd, "concurrency", &cfg.Concurrency)
+	overrideInt(cmd, "project_data_build_concurrency", &cfg.BuildConcurrency)
 	overrideInt(cmd, "timeout", &cfg.Timeout)
 	if cmd.Flags().Changed("skip_profiles") {
 		cfg.SkipProfiles, _ = cmd.Flags().GetBool("skip_profiles")

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -34,6 +35,10 @@ it to a Cloud organization. Also updates CI/CD pipelines post-migration.`,
 		debug, _ := cmd.Flags().GetBool("debug")
 		configureDefaultLogger(debug)
 		logStartupVersion()
+		// Derive a soft heap ceiling from the cgroup / system memory so
+		// large migrations collect early instead of being OOM-killed.
+		// No-op when GOMEMLIMIT is already set.
+		common.ApplyMemoryLimit(slog.Default())
 		if debug {
 			slog.Default().Debug("debug mode enabled", "command", cmd.Name())
 		}

--- a/go/internal/common/memlimit.go
+++ b/go/internal/common/memlimit.go
@@ -1,0 +1,183 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package common
+
+import (
+	"bufio"
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strconv"
+	"strings"
+)
+
+// Go's garbage collector doubles the heap before collecting (GOGC=100).
+// The migrate phase allocates hard enough that on a large SonarQube
+// instance the allocation rate outruns collection and the kernel OOM-kills
+// the process. A soft memory limit makes the collector run sooner, which
+// is exactly the right lever for a workload whose garbage is short-lived.
+//
+// Operators used to have to discover this themselves and set GOMEMLIMIT by
+// hand. These helpers derive the same ceiling automatically from whatever
+// the process is actually allowed to use — the cgroup limit under a
+// container or systemd slice, total system memory otherwise.
+const (
+	// memLimitFraction leaves headroom for the parts of the process the
+	// Go heap limit does not cover (stacks, the binary, OS page cache
+	// pressure) and for the collector to do useful work before the box
+	// runs out. SetMemoryLimit is soft: if the live heap exceeds it, Go
+	// keeps collecting rather than failing, so a value that is slightly
+	// too low degrades throughput instead of breaking the run.
+	memLimitFraction = 0.8
+
+	// memLimitFloor is the point below which throttling the heap does
+	// more harm than good — we back off entirely rather than strangle a
+	// small container.
+	memLimitFloor = 512 << 20 // 512 MiB
+
+	// cgroupUnlimited is the threshold above which a cgroup v1 limit means
+	// "no limit". The kernel writes PAGE_COUNTER_MAX, whose exact value
+	// depends on page size, so a threshold is more reliable than testing
+	// for a specific sentinel.
+	cgroupUnlimited = int64(1) << 62
+)
+
+// memorySource names where a detected limit came from, for logging.
+const (
+	sourceCgroupV2 = "cgroup-v2"
+	sourceCgroupV1 = "cgroup-v1"
+	sourceMemInfo  = "meminfo"
+)
+
+// applyMemoryLimit is the testable core of ApplyMemoryLimit. root is the
+// filesystem root to probe (tests pass a fixture directory), getenv reads
+// the environment, and setLimit applies the limit — all injected so the
+// detection logic can be exercised without a container.
+//
+// Returns the applied limit in bytes and its source, or (0, "") when no
+// limit was applied.
+func applyMemoryLimit(root string, getenv func(string) string,
+	setLimit func(int64) int64, logger *slog.Logger,
+) (int64, string) {
+	// An explicit GOMEMLIMIT always wins: the Go runtime has already
+	// applied it, and an operator who set it deliberately (including
+	// GOMEMLIMIT=off) should not be second-guessed.
+	if getenv("GOMEMLIMIT") != "" {
+		return 0, ""
+	}
+
+	detected, source := detectMemoryBudget(root)
+	if detected <= 0 {
+		return 0, ""
+	}
+
+	limit := int64(float64(detected) * memLimitFraction)
+	if limit < memLimitFloor {
+		if logger != nil {
+			logger.Debug("memory limit not applied: detected budget too small",
+				"detectedMiB", detected>>20, "source", source)
+		}
+		return 0, ""
+	}
+
+	setLimit(limit)
+	if logger != nil {
+		logger.Info("memory limit applied",
+			"limitMiB", limit>>20,
+			"detectedMiB", detected>>20,
+			"source", source,
+			"override", "set GOMEMLIMIT to override, GOMEMLIMIT=off to disable")
+	}
+	return limit, source
+}
+
+// detectMemoryBudget returns the memory the process may use, preferring the
+// cgroup limit (which is what the kernel actually enforces) over total
+// system memory (which, in a container, is the host's and therefore a lie).
+func detectMemoryBudget(root string) (int64, string) {
+	if v := cgroupV2Limit(root); v > 0 {
+		return v, sourceCgroupV2
+	}
+	if v := cgroupV1Limit(root); v > 0 {
+		return v, sourceCgroupV1
+	}
+	if v := memTotal(root); v > 0 {
+		return v, sourceMemInfo
+	}
+	return 0, ""
+}
+
+// cgroupV2Limit reads the cgroup v2 memory ceiling. memory.max is the hard
+// limit and memory.high the throttling threshold; when both are set the
+// lower one is what the process will actually feel, so we take the min.
+// The literal "max" means unlimited.
+func cgroupV2Limit(root string) int64 {
+	limit := int64(0)
+	for _, name := range []string{"memory.max", "memory.high"} {
+		v := readCgroupValue(filepath.Join(root, "sys/fs/cgroup", name))
+		if v <= 0 {
+			continue
+		}
+		if limit == 0 || v < limit {
+			limit = v
+		}
+	}
+	return limit
+}
+
+// cgroupV1Limit reads the cgroup v1 memory ceiling.
+func cgroupV1Limit(root string) int64 {
+	return readCgroupValue(filepath.Join(root, "sys/fs/cgroup/memory/memory.limit_in_bytes"))
+}
+
+// readCgroupValue parses a single-value cgroup file, returning 0 for
+// missing, malformed, or effectively-unlimited values.
+func readCgroupValue(path string) int64 {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	s := strings.TrimSpace(string(b))
+	if s == "" || s == "max" {
+		return 0
+	}
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || v <= 0 || v >= cgroupUnlimited {
+		return 0
+	}
+	return v
+}
+
+// memTotal reads MemTotal from /proc/meminfo, which is reported in kB.
+func memTotal(root string) int64 {
+	f, err := os.Open(filepath.Join(root, "proc/meminfo"))
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if !bytes.HasPrefix(line, []byte("MemTotal:")) {
+			continue
+		}
+		fields := strings.Fields(string(line))
+		if len(fields) < 2 {
+			return 0
+		}
+		kb, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil || kb <= 0 {
+			return 0
+		}
+		return kb << 10
+	}
+	return 0
+}
+
+// setMemoryLimit is the real applier, indirected so tests can spy on it.
+var setMemoryLimit = debug.SetMemoryLimit

--- a/go/internal/common/memlimit.go
+++ b/go/internal/common/memlimit.go
@@ -24,7 +24,14 @@ import (
 // Operators used to have to discover this themselves and set GOMEMLIMIT by
 // hand. These helpers derive the same ceiling automatically from whatever
 // the process is actually allowed to use — the cgroup limit under a
-// container or systemd slice, total system memory otherwise.
+// container or a systemd slice, total system memory otherwise.
+//
+// "Under a systemd slice" requires resolving the process's own cgroup from
+// /proc/self/cgroup rather than reading the hierarchy root: a unit with
+// MemoryMax= runs in /system.slice/<unit>, and the root it sits under is
+// unlimited. Reading only the root found nothing there and silently fell
+// through to total system memory, which is no protection at all when the
+// unit's cap is the thing about to kill the process.
 const (
 	// memLimitFraction leaves headroom for the parts of the process the
 	// Go heap limit does not cover (stacks, the binary, OS page cache
@@ -111,27 +118,104 @@ func detectMemoryBudget(root string) (int64, string) {
 	return 0, ""
 }
 
-// cgroupV2Limit reads the cgroup v2 memory ceiling. memory.max is the hard
-// limit and memory.high the throttling threshold; when both are set the
-// lower one is what the process will actually feel, so we take the min.
-// The literal "max" means unlimited.
-func cgroupV2Limit(root string) int64 {
-	limit := int64(0)
-	for _, name := range []string{"memory.max", "memory.high"} {
-		v := readCgroupValue(filepath.Join(root, "sys/fs/cgroup", name))
-		if v <= 0 {
+// cgroupSelfPaths returns the cgroup-relative paths to probe, from the
+// hierarchy root down to the process's own cgroup.
+//
+// The empty path is always first. Inside a cgroup namespace — the usual
+// container case — /proc/self/cgroup reports "/" and the mount root IS the
+// process's cgroup, so the empty path is the whole answer. Outside one, a
+// process placed in a nested cgroup (a systemd unit with MemoryMax= lands
+// in /system.slice/<unit>) sees an unlimited hierarchy root, and its real
+// ceiling lives further down. Probing only the root missed those entirely.
+//
+// controller selects the v1 hierarchy to read; pass "" for unified v2.
+// A missing or unparseable /proc/self/cgroup degrades to the empty path,
+// i.e. exactly the old root-only behaviour.
+func cgroupSelfPaths(root, controller string) []string {
+	paths := []string{""}
+
+	rel := cgroupSelfPath(root, controller)
+	segments := strings.Split(strings.Trim(rel, "/"), "/")
+	cur := ""
+	for _, seg := range segments {
+		if seg == "" {
 			continue
 		}
-		if limit == 0 || v < limit {
-			limit = v
+		cur += "/" + seg
+		paths = append(paths, cur)
+	}
+	return paths
+}
+
+// cgroupSelfPath parses /proc/self/cgroup and returns the path this process
+// belongs to in the requested hierarchy, or "" when it cannot be determined.
+//
+// Lines are "hierarchy-ID:controller-list:cgroup-path". The unified v2
+// hierarchy is the entry with ID 0 and an empty controller list; a v1
+// hierarchy is identified by its controller appearing in the list.
+func cgroupSelfPath(root, controller string) string {
+	b, err := os.ReadFile(filepath.Join(root, "proc/self/cgroup"))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		parts := strings.SplitN(strings.TrimSpace(line), ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		if cgroupLineMatches(parts[0], parts[1], controller) {
+			return parts[2]
+		}
+	}
+	return ""
+}
+
+// cgroupLineMatches reports whether a /proc/self/cgroup line belongs to the
+// requested hierarchy.
+func cgroupLineMatches(id, controllers, want string) bool {
+	if want == "" {
+		return id == "0" && controllers == ""
+	}
+	for _, c := range strings.Split(controllers, ",") {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+// cgroupV2Limit reads the cgroup v2 memory ceiling for this process.
+//
+// memory.max is the hard limit and memory.high the throttling threshold,
+// and the kernel enforces both hierarchically: a process is bound by the
+// tightest limit anywhere in its ancestor chain. So the effective ceiling
+// is the minimum across every level, not the first one that happens to be
+// set — an ancestor slice capped looser than the unit's own MemoryMax must
+// not mask it. The literal "max" means unlimited and is skipped.
+func cgroupV2Limit(root string) int64 {
+	limit := int64(0)
+	for _, rel := range cgroupSelfPaths(root, "") {
+		for _, name := range []string{"memory.max", "memory.high"} {
+			v := readCgroupValue(filepath.Join(root, "sys/fs/cgroup", rel, name))
+			if v > 0 && (limit == 0 || v < limit) {
+				limit = v
+			}
 		}
 	}
 	return limit
 }
 
-// cgroupV1Limit reads the cgroup v1 memory ceiling.
+// cgroupV1Limit reads the cgroup v1 memory ceiling for this process, taking
+// the minimum across the ancestor chain for the same reason as v2.
 func cgroupV1Limit(root string) int64 {
-	return readCgroupValue(filepath.Join(root, "sys/fs/cgroup/memory/memory.limit_in_bytes"))
+	limit := int64(0)
+	for _, rel := range cgroupSelfPaths(root, "memory") {
+		v := readCgroupValue(filepath.Join(root, "sys/fs/cgroup/memory", rel, "memory.limit_in_bytes"))
+		if v > 0 && (limit == 0 || v < limit) {
+			limit = v
+		}
+	}
+	return limit
 }
 
 // readCgroupValue parses a single-value cgroup file, returning 0 for

--- a/go/internal/common/memlimit_linux.go
+++ b/go/internal/common/memlimit_linux.go
@@ -1,0 +1,27 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+//go:build linux
+
+package common
+
+import (
+	"log/slog"
+	"os"
+)
+
+// ApplyMemoryLimit sets a soft Go heap ceiling derived from the cgroup
+// memory limit (v2, then v1), falling back to total system memory. It is a
+// no-op when GOMEMLIMIT is already set, so an operator can always override
+// the detection (GOMEMLIMIT=off disables the limit entirely).
+//
+// Returns the applied limit in bytes and the source it was derived from, or
+// (0, "") when no limit was applied.
+//
+// Linux only: cgroups are the mechanism that actually constrains the
+// migration VMs this guards against. On other platforms it is a no-op and
+// operators set GOMEMLIMIT by hand.
+func ApplyMemoryLimit(logger *slog.Logger) (int64, string) {
+	return applyMemoryLimit("/", os.Getenv, setMemoryLimit, logger)
+}

--- a/go/internal/common/memlimit_other.go
+++ b/go/internal/common/memlimit_other.go
@@ -1,0 +1,18 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+//go:build !linux
+
+package common
+
+import "log/slog"
+
+// ApplyMemoryLimit is a no-op on non-Linux platforms, where there is no
+// cgroup to read and the migration workloads this guards against do not
+// run. Operators on these platforms can still set GOMEMLIMIT by hand.
+//
+// See the Linux implementation for the behaviour this stands in for.
+func ApplyMemoryLimit(_ *slog.Logger) (int64, string) {
+	return 0, ""
+}

--- a/go/internal/common/memlimit_test.go
+++ b/go/internal/common/memlimit_test.go
@@ -1,0 +1,322 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package common
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// fakeRoot builds a filesystem fixture standing in for "/". files maps a
+// path relative to the root (e.g. "sys/fs/cgroup/memory.max") to contents.
+func fakeRoot(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		full := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", full, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", full, err)
+		}
+	}
+	return root
+}
+
+// noEnv is a getenv that reports every variable as unset.
+func noEnv(string) string { return "" }
+
+// quietLogger discards output so tests don't spam stderr.
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError + 1}))
+}
+
+// spy records what SetMemoryLimit would have been called with.
+func spy(applied *int64) func(int64) int64 {
+	return func(n int64) int64 {
+		*applied = n
+		return n
+	}
+}
+
+const gib = int64(1) << 30
+
+// Fixture paths, relative to the fake root.
+const (
+	pathV2Max   = "sys/fs/cgroup/memory.max"
+	pathV2High  = "sys/fs/cgroup/memory.high"
+	pathV1Limit = "sys/fs/cgroup/memory/memory.limit_in_bytes"
+	pathMemInfo = "proc/meminfo"
+)
+
+// want80 mirrors the production truncation. It must be a function, not a
+// constant expression: 80% of a power-of-two byte count is not an integer,
+// so folding it at compile time fails to convert to int64.
+func want80(n int64) int64 { return int64(float64(n) * memLimitFraction) }
+
+func TestApplyMemoryLimitCgroupV2(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathV2Max: "34359738368\n", // 32 GiB
+	})
+
+	var applied int64
+	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+	if source != sourceCgroupV2 {
+		t.Errorf("source = %q, want %q", source, sourceCgroupV2)
+	}
+	want := want80(32 * gib)
+	if limit != want {
+		t.Errorf("limit = %d, want %d", limit, want)
+	}
+	if applied != want {
+		t.Errorf("SetMemoryLimit called with %d, want %d", applied, want)
+	}
+}
+
+// "max" is the cgroup v2 spelling of unlimited, so detection must fall
+// through to the next source rather than treating it as a real number.
+func TestApplyMemoryLimitCgroupV2MaxFallsThrough(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathV2Max:   "max\n",
+		pathMemInfo: "MemTotal:       16777216 kB\n",
+	})
+
+	var applied int64
+	_, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+	if source != sourceMemInfo {
+		t.Errorf("source = %q, want %q", source, sourceMemInfo)
+	}
+}
+
+// When both v2 knobs are set, the lower one is what the process actually
+// feels, so that is the one we must derive the limit from.
+func TestApplyMemoryLimitCgroupV2PrefersLowerOfMaxAndHigh(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathV2Max:  "34359738368\n", // 32 GiB
+		pathV2High: "17179869184\n", // 16 GiB
+	})
+
+	var applied int64
+	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+	if source != sourceCgroupV2 {
+		t.Errorf("source = %q, want %q", source, sourceCgroupV2)
+	}
+	want := want80(16 * gib)
+	if limit != want {
+		t.Errorf("limit = %d, want %d (should follow memory.high, the lower knob)", limit, want)
+	}
+}
+
+func TestApplyMemoryLimitCgroupV1(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathV1Limit: "8589934592\n", // 8 GiB
+	})
+
+	var applied int64
+	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+	if source != sourceCgroupV1 {
+		t.Errorf("source = %q, want %q", source, sourceCgroupV1)
+	}
+	want := want80(8 * gib)
+	if limit != want {
+		t.Errorf("limit = %d, want %d", limit, want)
+	}
+}
+
+// cgroup v1 signals "unlimited" with a near-INT64_MAX sentinel whose exact
+// value depends on page size, so we test the threshold rather than a
+// specific constant.
+func TestApplyMemoryLimitCgroupV1UnlimitedSentinelFallsThrough(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathV1Limit: "9223372036854771712\n",
+		pathMemInfo: "MemTotal:       16777216 kB\n",
+	})
+
+	var applied int64
+	_, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+	if source != sourceMemInfo {
+		t.Errorf("source = %q, want %q", source, sourceMemInfo)
+	}
+}
+
+func TestApplyMemoryLimitMemInfoFallback(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathMemInfo: "MemFree:         1024 kB\nMemTotal:       33554432 kB\nSwapTotal: 0 kB\n",
+	})
+
+	var applied int64
+	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+	if source != sourceMemInfo {
+		t.Errorf("source = %q, want %q", source, sourceMemInfo)
+	}
+	want := want80(32 * gib)
+	if limit != want {
+		t.Errorf("limit = %d, want %d", limit, want)
+	}
+}
+
+// An operator who set GOMEMLIMIT deliberately must win — including
+// GOMEMLIMIT=off, which is the documented way to disable the limit.
+func TestApplyMemoryLimitRespectsExistingGOMEMLIMIT(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathV2Max: "34359738368\n",
+	})
+
+	for _, val := range []string{"16GiB", "off"} {
+		var applied int64
+		getenv := func(k string) string {
+			if k == "GOMEMLIMIT" {
+				return val
+			}
+			return ""
+		}
+		limit, source := applyMemoryLimit(root, getenv, spy(&applied), quietLogger())
+
+		if limit != 0 || source != "" {
+			t.Errorf("GOMEMLIMIT=%s: got (%d, %q), want (0, \"\")", val, limit, source)
+		}
+		if applied != 0 {
+			t.Errorf("GOMEMLIMIT=%s: SetMemoryLimit must not be called, got %d", val, applied)
+		}
+	}
+}
+
+func TestApplyMemoryLimitNoSourcesAvailable(t *testing.T) {
+	root := fakeRoot(t, nil)
+
+	var applied int64
+	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+	if limit != 0 || source != "" {
+		t.Errorf("got (%d, %q), want (0, \"\")", limit, source)
+	}
+	if applied != 0 {
+		t.Errorf("SetMemoryLimit must not be called, got %d", applied)
+	}
+}
+
+// Below the floor, throttling the heap does more harm than good, so we
+// back off rather than strangle a small container.
+func TestApplyMemoryLimitBelowFloorBacksOff(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathV2Max: "268435456\n", // 256 MiB -> 204 MiB, under the floor
+	})
+
+	var applied int64
+	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+	if limit != 0 || source != "" {
+		t.Errorf("got (%d, %q), want (0, \"\")", limit, source)
+	}
+	if applied != 0 {
+		t.Errorf("SetMemoryLimit must not be called below the floor, got %d", applied)
+	}
+}
+
+// Exactly at the floor the limit still applies — the guard is "below",
+// not "at or below".
+func TestApplyMemoryLimitAtFloorApplies(t *testing.T) {
+	// Pick a budget whose 80% lands exactly on the floor.
+	budget := int64(float64(memLimitFloor) / memLimitFraction)
+	root := fakeRoot(t, map[string]string{
+		pathV2Max: strconv.FormatInt(budget, 10),
+	})
+
+	var applied int64
+	limit, _ := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+	if limit < memLimitFloor {
+		t.Errorf("limit = %d, want >= floor %d", limit, memLimitFloor)
+	}
+	if applied == 0 {
+		t.Error("SetMemoryLimit should have been called at the floor")
+	}
+}
+
+func TestReadCgroupValueRejectsGarbage(t *testing.T) {
+	tests := []struct {
+		name, content string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   \n"},
+		{"non-numeric", "not-a-number\n"},
+		{"negative", "-1\n"},
+		{"zero", "0\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := fakeRoot(t, map[string]string{pathV2Max: tc.content})
+			if got := cgroupV2Limit(root); got != 0 {
+				t.Errorf("cgroupV2Limit = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestReadCgroupValueMissingFile(t *testing.T) {
+	if got := readCgroupValue(filepath.Join(t.TempDir(), "nope")); got != 0 {
+		t.Errorf("readCgroupValue on missing file = %d, want 0", got)
+	}
+}
+
+func TestMemTotalMalformed(t *testing.T) {
+	tests := []struct {
+		name, content string
+	}{
+		{"missing MemTotal", "MemFree: 1024 kB\n"},
+		{"no value", "MemTotal:\n"},
+		{"non-numeric", "MemTotal:       abc kB\n"},
+		{"zero", "MemTotal:       0 kB\n"},
+		{"empty file", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := fakeRoot(t, map[string]string{pathMemInfo: tc.content})
+			if got := memTotal(root); got != 0 {
+				t.Errorf("memTotal = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestMemTotalMissingFile(t *testing.T) {
+	if got := memTotal(t.TempDir()); got != 0 {
+		t.Errorf("memTotal on missing file = %d, want 0", got)
+	}
+}
+
+// A nil logger must not panic — callers outside cmd may not have one.
+func TestApplyMemoryLimitNilLogger(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathV2Max: "34359738368\n",
+	})
+	var applied int64
+	if _, source := applyMemoryLimit(root, noEnv, spy(&applied), nil); source != sourceCgroupV2 {
+		t.Errorf("source = %q, want %q", source, sourceCgroupV2)
+	}
+}
+
+// ApplyMemoryLimit is the exported wrapper; on Linux it probes the real
+// root, elsewhere it is a no-op. Either way it must not panic and must not
+// return a limit below the floor.
+func TestApplyMemoryLimitExportedIsSafe(t *testing.T) {
+	limit, source := ApplyMemoryLimit(quietLogger())
+	if limit != 0 && limit < memLimitFloor {
+		t.Errorf("ApplyMemoryLimit returned %d, below floor %d", limit, memLimitFloor)
+	}
+	if limit == 0 && source != "" {
+		t.Errorf("no limit applied but source = %q", source)
+	}
+}

--- a/go/internal/common/memlimit_test.go
+++ b/go/internal/common/memlimit_test.go
@@ -47,6 +47,14 @@ func spy(applied *int64) func(int64) int64 {
 
 const gib = int64(1) << 30
 
+// Shared assertion messages and fixture values, kept as constants so the
+// literals are not repeated across every table entry.
+const (
+	msgSource  = "source = %q, want %q"
+	msgLimit   = "limit = %d, want %d"
+	bytes32GiB = "34359738368\n"
+)
+
 // Fixture paths, relative to the fake root.
 const (
 	pathV2Max   = "sys/fs/cgroup/memory.max"
@@ -62,18 +70,18 @@ func want80(n int64) int64 { return int64(float64(n) * memLimitFraction) }
 
 func TestApplyMemoryLimitCgroupV2(t *testing.T) {
 	root := fakeRoot(t, map[string]string{
-		pathV2Max: "34359738368\n", // 32 GiB
+		pathV2Max: bytes32GiB, // 32 GiB
 	})
 
 	var applied int64
 	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
 
 	if source != sourceCgroupV2 {
-		t.Errorf("source = %q, want %q", source, sourceCgroupV2)
+		t.Errorf(msgSource, source, sourceCgroupV2)
 	}
 	want := want80(32 * gib)
 	if limit != want {
-		t.Errorf("limit = %d, want %d", limit, want)
+		t.Errorf(msgLimit, limit, want)
 	}
 	if applied != want {
 		t.Errorf("SetMemoryLimit called with %d, want %d", applied, want)
@@ -92,7 +100,7 @@ func TestApplyMemoryLimitCgroupV2MaxFallsThrough(t *testing.T) {
 	_, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
 
 	if source != sourceMemInfo {
-		t.Errorf("source = %q, want %q", source, sourceMemInfo)
+		t.Errorf(msgSource, source, sourceMemInfo)
 	}
 }
 
@@ -100,7 +108,7 @@ func TestApplyMemoryLimitCgroupV2MaxFallsThrough(t *testing.T) {
 // feels, so that is the one we must derive the limit from.
 func TestApplyMemoryLimitCgroupV2PrefersLowerOfMaxAndHigh(t *testing.T) {
 	root := fakeRoot(t, map[string]string{
-		pathV2Max:  "34359738368\n", // 32 GiB
+		pathV2Max:  bytes32GiB,      // 32 GiB
 		pathV2High: "17179869184\n", // 16 GiB
 	})
 
@@ -108,7 +116,7 @@ func TestApplyMemoryLimitCgroupV2PrefersLowerOfMaxAndHigh(t *testing.T) {
 	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
 
 	if source != sourceCgroupV2 {
-		t.Errorf("source = %q, want %q", source, sourceCgroupV2)
+		t.Errorf(msgSource, source, sourceCgroupV2)
 	}
 	want := want80(16 * gib)
 	if limit != want {
@@ -125,11 +133,11 @@ func TestApplyMemoryLimitCgroupV1(t *testing.T) {
 	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
 
 	if source != sourceCgroupV1 {
-		t.Errorf("source = %q, want %q", source, sourceCgroupV1)
+		t.Errorf(msgSource, source, sourceCgroupV1)
 	}
 	want := want80(8 * gib)
 	if limit != want {
-		t.Errorf("limit = %d, want %d", limit, want)
+		t.Errorf(msgLimit, limit, want)
 	}
 }
 
@@ -146,7 +154,7 @@ func TestApplyMemoryLimitCgroupV1UnlimitedSentinelFallsThrough(t *testing.T) {
 	_, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
 
 	if source != sourceMemInfo {
-		t.Errorf("source = %q, want %q", source, sourceMemInfo)
+		t.Errorf(msgSource, source, sourceMemInfo)
 	}
 }
 
@@ -159,11 +167,11 @@ func TestApplyMemoryLimitMemInfoFallback(t *testing.T) {
 	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
 
 	if source != sourceMemInfo {
-		t.Errorf("source = %q, want %q", source, sourceMemInfo)
+		t.Errorf(msgSource, source, sourceMemInfo)
 	}
 	want := want80(32 * gib)
 	if limit != want {
-		t.Errorf("limit = %d, want %d", limit, want)
+		t.Errorf(msgLimit, limit, want)
 	}
 }
 
@@ -171,7 +179,7 @@ func TestApplyMemoryLimitMemInfoFallback(t *testing.T) {
 // GOMEMLIMIT=off, which is the documented way to disable the limit.
 func TestApplyMemoryLimitRespectsExistingGOMEMLIMIT(t *testing.T) {
 	root := fakeRoot(t, map[string]string{
-		pathV2Max: "34359738368\n",
+		pathV2Max: bytes32GiB,
 	})
 
 	for _, val := range []string{"16GiB", "off"} {
@@ -300,11 +308,11 @@ func TestMemTotalMissingFile(t *testing.T) {
 // A nil logger must not panic — callers outside cmd may not have one.
 func TestApplyMemoryLimitNilLogger(t *testing.T) {
 	root := fakeRoot(t, map[string]string{
-		pathV2Max: "34359738368\n",
+		pathV2Max: bytes32GiB,
 	})
 	var applied int64
 	if _, source := applyMemoryLimit(root, noEnv, spy(&applied), nil); source != sourceCgroupV2 {
-		t.Errorf("source = %q, want %q", source, sourceCgroupV2)
+		t.Errorf(msgSource, source, sourceCgroupV2)
 	}
 }
 

--- a/go/internal/common/memlimit_test.go
+++ b/go/internal/common/memlimit_test.go
@@ -126,7 +126,7 @@ func TestApplyMemoryLimitCgroupV2PrefersLowerOfMaxAndHigh(t *testing.T) {
 
 func TestApplyMemoryLimitCgroupV1(t *testing.T) {
 	root := fakeRoot(t, map[string]string{
-		pathV1Limit: "8589934592\n", // 8 GiB
+		pathV1Limit: bytes8GiB, // 8 GiB
 	})
 
 	var applied int64
@@ -326,5 +326,170 @@ func TestApplyMemoryLimitExportedIsSafe(t *testing.T) {
 	}
 	if limit == 0 && source != "" {
 		t.Errorf("no limit applied but source = %q", source)
+	}
+}
+
+// --- cgroup path resolution (systemd slices, nested containers) ---------
+
+const (
+	pathSelfCgroup = "proc/self/cgroup"
+
+	// A systemd unit's own cgroup, as /proc/self/cgroup reports it.
+	selfCgroupUnit = "0::/system.slice/smt.service\n"
+
+	bytes4GiB = "4294967296\n"
+	bytes8GiB = "8589934592\n"
+)
+
+// Outside a cgroup namespace the hierarchy root is unlimited and the real
+// ceiling sits in the process's own cgroup. Reading only the root found
+// nothing and fell through to total system memory.
+func TestApplyMemoryLimitCgroupV2NestedPath(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathSelfCgroup: selfCgroupUnit,
+		// Root and intermediate are unlimited, as on a real systemd host.
+		pathV2Max:                               "max\n",
+		"sys/fs/cgroup/system.slice/memory.max": "max\n",
+		"sys/fs/cgroup/system.slice/smt.service/memory.max": bytes4GiB, // 4 GiB
+	})
+
+	var applied int64
+	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+	if source != sourceCgroupV2 {
+		t.Fatalf("source = %q, want %q — the unit's MemoryMax must be found", source, sourceCgroupV2)
+	}
+	if want := want80(4 * gib); limit != want {
+		t.Errorf("limit = %d, want %d", limit, want)
+	}
+}
+
+// The kernel enforces memory.max hierarchically, so the effective ceiling
+// is the minimum across the chain. A looser ancestor must not mask a
+// tighter leaf, and a tighter ancestor must not be ignored in favour of a
+// looser leaf. This is the case that separates "minimum" from "first hit".
+func TestApplyMemoryLimitCgroupV2TakesMinimumAcrossAncestors(t *testing.T) {
+	tests := []struct {
+		name           string
+		ancestor, leaf string
+		wantGiB        int64
+	}{
+		{"tighter ancestor wins", "2147483648\n" /*2G*/, bytes8GiB /*8G*/, 2},
+		{"tighter leaf wins", "34359738368\n" /*32G*/, bytes4GiB /*4G*/, 4},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := fakeRoot(t, map[string]string{
+				pathSelfCgroup:                          selfCgroupUnit,
+				pathV2Max:                               "max\n",
+				"sys/fs/cgroup/system.slice/memory.max": tc.ancestor,
+				"sys/fs/cgroup/system.slice/smt.service/memory.max": tc.leaf,
+			})
+
+			var applied int64
+			limit, _ := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+			if want := want80(tc.wantGiB * gib); limit != want {
+				t.Errorf("limit = %d, want %d (%d GiB budget)", limit, want, tc.wantGiB)
+			}
+		})
+	}
+}
+
+// Inside a cgroup namespace /proc/self/cgroup reports "/", so the mount
+// root is the process's own cgroup and behaviour is unchanged.
+func TestApplyMemoryLimitCgroupV2NamespacedRootUnchanged(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathSelfCgroup: "0::/\n",
+		pathV2Max:      bytes32GiB,
+	})
+
+	var applied int64
+	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+	if source != sourceCgroupV2 {
+		t.Errorf(msgSource, source, sourceCgroupV2)
+	}
+	if want := want80(32 * gib); limit != want {
+		t.Errorf(msgLimit, limit, want)
+	}
+}
+
+// v1 names its hierarchy by controller and nests under the controller
+// mount, so it needs its own path resolution.
+func TestApplyMemoryLimitCgroupV1NestedPath(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathSelfCgroup: "12:pids:/system.slice/smt.service\n" +
+			"9:memory:/system.slice/smt.service\n" +
+			selfCgroupUnit,
+		"sys/fs/cgroup/memory/system.slice/smt.service/memory.limit_in_bytes": bytes8GiB, // 8 GiB
+	})
+
+	var applied int64
+	limit, source := applyMemoryLimit(root, noEnv, spy(&applied), quietLogger())
+
+	if source != sourceCgroupV1 {
+		t.Fatalf("source = %q, want %q", source, sourceCgroupV1)
+	}
+	if want := want80(8 * gib); limit != want {
+		t.Errorf(msgLimit, limit, want)
+	}
+}
+
+// A missing or unparseable /proc/self/cgroup must degrade to the old
+// root-only probe rather than losing detection entirely.
+func TestCgroupSelfPathsAlwaysIncludesRoot(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+	}{
+		{"missing file", nil},
+		{"unparseable", map[string]string{pathSelfCgroup: "garbage without colons\n"}},
+		{"empty", map[string]string{pathSelfCgroup: ""}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cgroupSelfPaths(fakeRoot(t, tc.files), "")
+			if len(got) != 1 || got[0] != "" {
+				t.Errorf("cgroupSelfPaths = %q, want exactly [\"\"]", got)
+			}
+		})
+	}
+}
+
+func TestCgroupSelfPathsWalksAncestors(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathSelfCgroup: selfCgroupUnit,
+	})
+
+	got := cgroupSelfPaths(root, "")
+	want := []string{"", "/system.slice", "/system.slice/smt.service"}
+
+	if len(got) != len(want) {
+		t.Fatalf("cgroupSelfPaths = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("path %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// The v2 line is the one with hierarchy ID 0 and no controllers; a v1
+// hierarchy is picked by its controller name. Selecting the wrong line
+// would probe a path that does not exist for that hierarchy.
+func TestCgroupSelfPathSelectsCorrectHierarchy(t *testing.T) {
+	root := fakeRoot(t, map[string]string{
+		pathSelfCgroup: "12:pids:/pids-path\n9:memory,cpu:/memory-path\n0::/unified-path\n",
+	})
+
+	if got := cgroupSelfPath(root, ""); got != "/unified-path" {
+		t.Errorf("v2 path = %q, want /unified-path", got)
+	}
+	if got := cgroupSelfPath(root, "memory"); got != "/memory-path" {
+		t.Errorf("v1 memory path = %q, want /memory-path (comma-separated controller list)", got)
+	}
+	if got := cgroupSelfPath(root, "nosuch"); got != "" {
+		t.Errorf("unknown controller = %q, want empty", got)
 	}
 }

--- a/go/internal/common/store.go
+++ b/go/internal/common/store.go
@@ -59,9 +59,47 @@ func (ds *DataStore) Writer(taskName string) (*ChunkWriter, error) {
 	return NewChunkWriter(ds.taskDir(taskName))
 }
 
-// ReadAll returns every JSONL object for a completed task as raw JSON.
-func (ds *DataStore) ReadAll(taskName string) ([]json.RawMessage, error) {
-	dir := ds.taskDir(taskName)
+// Records streams every JSONL object of a completed task, one chunk file at
+// a time. Peak memory is one chunk file rather than the whole task.
+//
+// Error policy is identical to ReadAll, which is now a thin wrapper:
+//   - a missing task directory yields nothing (ReadAll's (nil, nil));
+//   - any other ReadDir failure, or the first per-file read error, yields
+//     (nil, err) and ends iteration without yielding any record from the
+//     failing file, preserving ReadAll's all-or-nothing contract.
+//
+// Note this differs deliberately from structure.ExtractItems, which warns
+// and keeps partial records (#312/#314). The two stores have different
+// contracts and both are relied upon; the error in this signature is what
+// makes the difference visible rather than buried in a comment.
+//
+// taskName is resolved through taskDir, so Windows sanitization (#486)
+// applies here too.
+func (ds *DataStore) Records(taskName string) func(yield func(json.RawMessage, error) bool) {
+	return func(yield func(json.RawMessage, error) bool) {
+		dir := ds.taskDir(taskName)
+		names, err := jsonlFileNames(dir)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		for _, name := range names {
+			items, err := ReadJSONLFile(filepath.Join(dir, name))
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			if !yieldRecords(items, yield) {
+				return
+			}
+		}
+	}
+}
+
+// jsonlFileNames lists the .jsonl file names directly under dir. A missing
+// directory is not an error — the task simply never ran — and returns no
+// names, which is what gives ReadAll its (nil, nil).
+func jsonlFileNames(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -69,16 +107,38 @@ func (ds *DataStore) ReadAll(taskName string) ([]json.RawMessage, error) {
 		}
 		return nil, fmt.Errorf("reading task dir %s: %w", dir, err)
 	}
-	var all []json.RawMessage
+	var names []string
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
 			continue
 		}
-		items, err := ReadJSONLFile(filepath.Join(dir, entry.Name()))
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}
+
+// yieldRecords passes each record to yield, reporting false as soon as the
+// consumer stops so the caller can abandon the remaining files unopened.
+func yieldRecords(items []json.RawMessage, yield func(json.RawMessage, error) bool) bool {
+	for _, item := range items {
+		if !yield(item, nil) {
+			return false
+		}
+	}
+	return true
+}
+
+// ReadAll returns every JSONL object for a completed task as raw JSON.
+//
+// Prefer Records for anything whose size scales with the instance — this
+// materializes every record of the task at once.
+func (ds *DataStore) ReadAll(taskName string) ([]json.RawMessage, error) {
+	var all []json.RawMessage
+	for item, err := range ds.Records(taskName) {
 		if err != nil {
 			return nil, err
 		}
-		all = append(all, items...)
+		all = append(all, item)
 	}
 	return all, nil
 }

--- a/go/internal/common/store_stream_test.go
+++ b/go/internal/common/store_stream_test.go
@@ -33,6 +33,13 @@ func writeStoreChunks(t *testing.T, taskDir string, chunks [][]string) {
 	}
 }
 
+// Shared assertion message and fixture task name, so neither literal is
+// repeated across every test.
+const (
+	errRecordsFmt = "Records: %v"
+	taskName      = "someTask"
+)
+
 // collectRecords drains the iterator, returning records and the first error.
 func collectRecords(seq func(func(json.RawMessage, error) bool)) ([]json.RawMessage, error) {
 	var out []json.RawMessage
@@ -52,16 +59,16 @@ func collectRecords(seq func(func(json.RawMessage, error) bool)) ([]json.RawMess
 func TestRecordsMatchesReadAllAcrossChunks(t *testing.T) {
 	dir := t.TempDir()
 	ds := NewDataStore(dir)
-	writeStoreChunks(t, filepath.Join(dir, "someTask"), [][]string{
+	writeStoreChunks(t, filepath.Join(dir, taskName), [][]string{
 		{`{"n":1}`, `{"n":2}`},
 		{`{"n":3}`},
 	})
 
-	streamed, err := collectRecords(ds.Records("someTask"))
+	streamed, err := collectRecords(ds.Records(taskName))
 	if err != nil {
-		t.Fatalf("Records: %v", err)
+		t.Fatalf(errRecordsFmt, err)
 	}
-	slurped, err := ds.ReadAll("someTask")
+	slurped, err := ds.ReadAll(taskName)
 	if err != nil {
 		t.Fatalf("ReadAll: %v", err)
 	}
@@ -104,7 +111,7 @@ func TestRecordsMissingDirYieldsNothing(t *testing.T) {
 func TestRecordsAbortsOnFileError(t *testing.T) {
 	dir := t.TempDir()
 	ds := NewDataStore(dir)
-	taskDir := filepath.Join(dir, "someTask")
+	taskDir := filepath.Join(dir, taskName)
 	writeStoreChunks(t, taskDir, [][]string{{`{"n":1}`}})
 
 	bad := filepath.Join(taskDir, "results.2.jsonl")
@@ -113,12 +120,12 @@ func TestRecordsAbortsOnFileError(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(bad, 0o600) })
 
-	_, err := collectRecords(ds.Records("someTask"))
+	_, err := collectRecords(ds.Records(taskName))
 	if err == nil {
 		t.Error("Records should surface the per-file error")
 	}
 
-	if _, err := ds.ReadAll("someTask"); err == nil {
+	if _, err := ds.ReadAll(taskName); err == nil {
 		t.Error("ReadAll should still return the error")
 	}
 }
@@ -140,7 +147,7 @@ func TestRecordsSanitizesTaskName(t *testing.T) {
 
 	got, err := collectRecords(ds.Records("getTemplateGroupsScanners:apply"))
 	if err != nil {
-		t.Fatalf("Records: %v", err)
+		t.Fatalf(errRecordsFmt, err)
 	}
 	if len(got) != 1 || string(got[0]) != `{"k":"v"}` {
 		t.Errorf("got %v, want the single written record", got)
@@ -151,7 +158,7 @@ func TestRecordsSanitizesTaskName(t *testing.T) {
 func TestRecordsStopsEarly(t *testing.T) {
 	dir := t.TempDir()
 	ds := NewDataStore(dir)
-	taskDir := filepath.Join(dir, "someTask")
+	taskDir := filepath.Join(dir, taskName)
 	writeStoreChunks(t, taskDir, [][]string{{`{"n":1}`}})
 
 	bad := filepath.Join(taskDir, "results.2.jsonl")
@@ -161,7 +168,7 @@ func TestRecordsStopsEarly(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(bad, 0o600) })
 
 	count := 0
-	for _, err := range ds.Records("someTask") {
+	for _, err := range ds.Records(taskName) {
 		if err != nil {
 			t.Fatalf("unexpected error before break: %v", err)
 		}
@@ -177,16 +184,16 @@ func TestRecordsStopsEarly(t *testing.T) {
 func TestRecordsIgnoresNonJSONLFiles(t *testing.T) {
 	dir := t.TempDir()
 	ds := NewDataStore(dir)
-	taskDir := filepath.Join(dir, "someTask")
+	taskDir := filepath.Join(dir, taskName)
 	writeStoreChunks(t, taskDir, [][]string{{`{"n":1}`}})
 
 	if err := os.WriteFile(filepath.Join(taskDir, "notes.txt"), []byte("ignore me"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := collectRecords(ds.Records("someTask"))
+	got, err := collectRecords(ds.Records(taskName))
 	if err != nil {
-		t.Fatalf("Records: %v", err)
+		t.Fatalf(errRecordsFmt, err)
 	}
 	if len(got) != 1 {
 		t.Errorf("got %d records, want 1", len(got))

--- a/go/internal/common/store_stream_test.go
+++ b/go/internal/common/store_stream_test.go
@@ -1,0 +1,194 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package common
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// writeStoreChunks writes one results.N.jsonl per chunk directly into the
+// task directory, bypassing ChunkWriter so a test can control the exact
+// file layout. Multi-chunk tasks are what production actually produces.
+func writeStoreChunks(t *testing.T, taskDir string, chunks [][]string) {
+	t.Helper()
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i, lines := range chunks {
+		var buf []byte
+		for _, l := range lines {
+			buf = append(buf, l...)
+			buf = append(buf, '\n')
+		}
+		name := filepath.Join(taskDir, "results."+strconv.Itoa(i+1)+".jsonl")
+		if err := os.WriteFile(name, buf, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// collectRecords drains the iterator, returning records and the first error.
+func collectRecords(seq func(func(json.RawMessage, error) bool)) ([]json.RawMessage, error) {
+	var out []json.RawMessage
+	var firstErr error
+	for item, err := range seq {
+		if err != nil {
+			firstErr = err
+			break
+		}
+		out = append(out, item)
+	}
+	return out, firstErr
+}
+
+// The wrapper must agree with the iterator exactly — that equivalence is
+// what lets the existing ReadAll call sites stay untouched.
+func TestRecordsMatchesReadAllAcrossChunks(t *testing.T) {
+	dir := t.TempDir()
+	ds := NewDataStore(dir)
+	writeStoreChunks(t, filepath.Join(dir, "someTask"), [][]string{
+		{`{"n":1}`, `{"n":2}`},
+		{`{"n":3}`},
+	})
+
+	streamed, err := collectRecords(ds.Records("someTask"))
+	if err != nil {
+		t.Fatalf("Records: %v", err)
+	}
+	slurped, err := ds.ReadAll("someTask")
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+
+	if len(streamed) != 3 {
+		t.Fatalf("streamed %d records, want 3", len(streamed))
+	}
+	if len(slurped) != len(streamed) {
+		t.Fatalf("ReadAll %d vs Records %d", len(slurped), len(streamed))
+	}
+	for i := range streamed {
+		if string(streamed[i]) != string(slurped[i]) {
+			t.Errorf("record %d: %s vs %s", i, streamed[i], slurped[i])
+		}
+	}
+}
+
+// ReadAll returns (nil, nil) for a task that never ran; Records must yield
+// nothing at all rather than surfacing an error.
+func TestRecordsMissingDirYieldsNothing(t *testing.T) {
+	ds := NewDataStore(t.TempDir())
+
+	got, err := collectRecords(ds.Records("neverRan"))
+	if err != nil {
+		t.Fatalf("missing dir should not error, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d records, want 0", len(got))
+	}
+
+	items, err := ds.ReadAll("neverRan")
+	if err != nil || items != nil {
+		t.Errorf("ReadAll = (%v, %v), want (nil, nil)", items, err)
+	}
+}
+
+// Unlike the extract reader, the store is all-or-nothing: a per-file read
+// error aborts and no record from the failing file is yielded. Callers of
+// ReadAll rely on never seeing a partial task.
+func TestRecordsAbortsOnFileError(t *testing.T) {
+	dir := t.TempDir()
+	ds := NewDataStore(dir)
+	taskDir := filepath.Join(dir, "someTask")
+	writeStoreChunks(t, taskDir, [][]string{{`{"n":1}`}})
+
+	bad := filepath.Join(taskDir, "results.2.jsonl")
+	if err := os.WriteFile(bad, []byte(`{"n":2}`+"\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(bad, 0o600) })
+
+	_, err := collectRecords(ds.Records("someTask"))
+	if err == nil {
+		t.Error("Records should surface the per-file error")
+	}
+
+	if _, err := ds.ReadAll("someTask"); err == nil {
+		t.Error("ReadAll should still return the error")
+	}
+}
+
+// Task names embedding ':' are sanitized for Windows (#486). Records
+// resolves through the same taskDir, so Writer / ReadAll / Records must all
+// agree on where the data lives.
+func TestRecordsSanitizesTaskName(t *testing.T) {
+	dir := t.TempDir()
+	ds := NewDataStore(dir)
+
+	w, err := ds.Writer("getTemplateGroupsScanners:apply")
+	if err != nil {
+		t.Fatalf("Writer: %v", err)
+	}
+	if err := w.WriteOne(json.RawMessage(`{"k":"v"}`)); err != nil {
+		t.Fatalf("WriteOne: %v", err)
+	}
+
+	got, err := collectRecords(ds.Records("getTemplateGroupsScanners:apply"))
+	if err != nil {
+		t.Fatalf("Records: %v", err)
+	}
+	if len(got) != 1 || string(got[0]) != `{"k":"v"}` {
+		t.Errorf("got %v, want the single written record", got)
+	}
+}
+
+// Breaking out must stop before the next chunk file is opened.
+func TestRecordsStopsEarly(t *testing.T) {
+	dir := t.TempDir()
+	ds := NewDataStore(dir)
+	taskDir := filepath.Join(dir, "someTask")
+	writeStoreChunks(t, taskDir, [][]string{{`{"n":1}`}})
+
+	bad := filepath.Join(taskDir, "results.2.jsonl")
+	if err := os.WriteFile(bad, []byte(`{"n":2}`+"\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(bad, 0o600) })
+
+	count := 0
+	for _, err := range ds.Records("someTask") {
+		if err != nil {
+			t.Fatalf("unexpected error before break: %v", err)
+		}
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("yielded %d records after break, want 1", count)
+	}
+}
+
+// Non-.jsonl files in a task directory are ignored by both paths.
+func TestRecordsIgnoresNonJSONLFiles(t *testing.T) {
+	dir := t.TempDir()
+	ds := NewDataStore(dir)
+	taskDir := filepath.Join(dir, "someTask")
+	writeStoreChunks(t, taskDir, [][]string{{`{"n":1}`}})
+
+	if err := os.WriteFile(filepath.Join(taskDir, "notes.txt"), []byte("ignore me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := collectRecords(ds.Records("someTask"))
+	if err != nil {
+		t.Fatalf("Records: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("got %d records, want 1", len(got))
+	}
+}

--- a/go/internal/migrate/buildsem_test.go
+++ b/go/internal/migrate/buildsem_test.go
@@ -1,0 +1,96 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+)
+
+// The default must be well below the request concurrency default, because
+// it bounds memory rather than request rate.
+func TestBuildConcurrencyDefaultIsLowerThanRequestConcurrency(t *testing.T) {
+	cfg := &MigrateConfig{}
+	cfg.applyDefaults()
+
+	if cfg.BuildConcurrency != DefaultBuildConcurrency {
+		t.Errorf("BuildConcurrency = %d, want %d", cfg.BuildConcurrency, DefaultBuildConcurrency)
+	}
+	if cfg.BuildConcurrency >= cfg.Concurrency {
+		t.Errorf("BuildConcurrency (%d) should be well below Concurrency (%d): it bounds memory, not request rate",
+			cfg.BuildConcurrency, cfg.Concurrency)
+	}
+}
+
+// An explicit value must survive applyDefaults, so an operator can raise it
+// back toward --concurrency when report building is the bottleneck.
+func TestBuildConcurrencyExplicitValueWins(t *testing.T) {
+	cfg := &MigrateConfig{BuildConcurrency: 25}
+	cfg.applyDefaults()
+
+	if cfg.BuildConcurrency != 25 {
+		t.Errorf("BuildConcurrency = %d, want the explicit 25", cfg.BuildConcurrency)
+	}
+}
+
+// The semaphore must actually bound concurrency: with capacity 1, a second
+// acquire cannot succeed until the first is released.
+func TestBuildSemSerializes(t *testing.T) {
+	sem := make(chan struct{}, 1)
+	ctx := context.Background()
+
+	if err := common.AcquireSem(ctx, sem); err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	acquired := make(chan struct{})
+	go func() {
+		_ = common.AcquireSem(ctx, sem)
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("second acquire succeeded while the first was still held")
+	default:
+	}
+
+	<-sem // release the first
+
+	<-acquired // the waiter must now proceed
+}
+
+// A cancelled context must not block forever on a full semaphore — this is
+// what lets a failing run tear down instead of hanging.
+func TestBuildSemRespectsContextCancellation(t *testing.T) {
+	sem := make(chan struct{}, 1)
+	if err := common.AcquireSem(context.Background(), sem); err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := common.AcquireSem(ctx, sem); err == nil {
+		t.Error("acquire on a cancelled context should return an error, not block")
+	}
+}
+
+// Executors built without a BuildSem (test fixtures, the reset path) must
+// still work — importBranch nil-checks rather than assuming one exists.
+func TestExecutorWithoutBuildSemIsUsable(t *testing.T) {
+	e := newProjectDataExecutor(t, t.TempDir())
+	if e.BuildSem != nil {
+		t.Fatal("fixture unexpectedly has a BuildSem; this test guards the nil path")
+	}
+
+	// The nil-guard shape importBranch uses.
+	buildSem := e.BuildSem
+	if buildSem != nil {
+		t.Fatal("nil BuildSem must not be acquired")
+	}
+}

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -28,6 +28,7 @@ type configFileShape struct {
 	Edition            string `json:"edition"`
 	ExportDirectory    string `json:"export_directory"`
 	Concurrency        int    `json:"concurrency"`
+	BuildConcurrency   int    `json:"project_data_build_concurrency"`
 	Timeout            int    `json:"timeout"`
 	RunID              string `json:"run_id"`
 	TargetTask         string `json:"target_task"`
@@ -104,6 +105,7 @@ type unifiedTargetBlock struct {
 	Timeout             int      `json:"timeout"`
 	RunID               string   `json:"run_id"`
 	TargetTask          string   `json:"target_task"`
+	BuildConcurrency    int      `json:"project_data_build_concurrency"`
 	OrganizationKey     string   `json:"organization_key"`     // provisional, ignored
 	DefaultOrganization string   `json:"default_organization"` // #281
 	ProjectKeyPattern   string   `json:"project_key_pattern"`  // #138
@@ -139,9 +141,10 @@ type OrgConfigEntry struct {
 }
 
 type settingsBlock struct {
-	ExportDirectory string `json:"export_directory"`
-	Concurrency     int    `json:"concurrency"`
-	Timeout         int    `json:"timeout"`
+	ExportDirectory  string `json:"export_directory"`
+	Concurrency      int    `json:"concurrency"`
+	BuildConcurrency int    `json:"project_data_build_concurrency"`
+	Timeout          int    `json:"timeout"`
 }
 
 func parseConfigFile(path string) (configFileShape, error) {
@@ -175,6 +178,7 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 			cfg.RunID = s.Target.RunID
 			cfg.TargetTask = s.Target.TargetTask
 			cfg.Concurrency = s.Target.Concurrency
+			cfg.BuildConcurrency = s.Target.BuildConcurrency
 			cfg.Timeout = s.Target.Timeout
 			cfg.DefaultOrganization = s.Target.DefaultOrganization
 			cfg.ProjectKeyPattern = s.Target.ProjectKeyPattern
@@ -192,6 +196,9 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 		cfg.FastSync = resolveFastSync(targetFastSync, s.FastSync)
 		if cfg.Concurrency == 0 {
 			cfg.Concurrency = s.Concurrency
+		}
+		if cfg.BuildConcurrency == 0 {
+			cfg.BuildConcurrency = s.BuildConcurrency
 		}
 		if cfg.Timeout == 0 {
 			cfg.Timeout = s.Timeout
@@ -246,6 +253,7 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 			Edition:            s.Edition,
 			ExportDirectory:    s.ExportDirectory,
 			Concurrency:        s.Concurrency,
+			BuildConcurrency:   s.BuildConcurrency,
 			Timeout:            s.Timeout,
 			RunID:              s.RunID,
 			TargetTask:         s.TargetTask,
@@ -293,6 +301,7 @@ func (sc sonarCloudBlock) toMigrateConfig(settings *settingsBlock) MigrateConfig
 	if settings != nil {
 		cfg.ExportDirectory = settings.ExportDirectory
 		cfg.Concurrency = settings.Concurrency
+		cfg.BuildConcurrency = settings.BuildConcurrency
 		cfg.Timeout = settings.Timeout
 	}
 	return cfg

--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -183,6 +183,13 @@ func serverExtractItems(e *Executor, extractKey, serverURL string) func(yield fu
 	}
 }
 
+// serverAgnosticExtractItems streams every record of extractKey across all
+// extract runs, with no filtering at all. For config-scale tasks that are
+// keyed by something other than server/project/branch.
+func serverAgnosticExtractItems(e *Executor, extractKey string) func(yield func(structure.ExtractItem) bool) {
+	return structure.ExtractItems(e.ExportDir, e.Mapping, extractKey)
+}
+
 // hotspotHeader is the stage-one decode for getProjectHotspotsFull, whose
 // records name their project differently from every other extract task:
 // "project" with a "projectKey" fallback. A record with no branch matches

--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -202,13 +202,17 @@ func (h hotspotHeader) projectKey() string {
 	return h.ProjectKey
 }
 
-// matches reports whether a hotspot record belongs to the given scope. A
-// record with no branch belongs to every branch.
+// matches reports whether a hotspot record belongs to the given scope.
+//
+// Two independent wildcards, and both are needed. An empty scope Branch
+// wants every branch of the project — that is how the metadata sync reads
+// hotspots. A record with no branch belongs to every branch, which is how
+// the per-branch report loader has always treated them.
 func (h hotspotHeader) matches(scope extractScope) bool {
 	if h.projectKey() != scope.ProjectKey {
 		return false
 	}
-	return h.Branch == "" || h.Branch == scope.Branch
+	return scope.Branch == "" || h.Branch == "" || h.Branch == scope.Branch
 }
 
 // scopedHotspotItems is scopedExtractItems for getProjectHotspotsFull.

--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -133,7 +133,9 @@ type recordHeader struct {
 }
 
 // matches reports whether a record belongs to the given scope. An empty
-// scope Branch matches any branch; an empty record Branch never excludes.
+// scope Branch matches any branch; otherwise the record's branch must be
+// exactly equal (a record with no branch does NOT match a concrete
+// branch — see hotspotHeader.matches for the task that differs).
 func (h recordHeader) matches(scope extractScope) bool {
 	if h.ProjectKey != scope.ProjectKey {
 		return false

--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -101,8 +101,118 @@ func sortExtractItems(taskName string, items []structure.ExtractItem) {
 }
 
 // readExtractItems reads JSONL items from an extract task across all extract runs.
+//
+// This materializes every record of every project. Use scopedExtractItems
+// for anything read per project or per branch.
 func readExtractItems(e *Executor, taskKey string) ([]structure.ExtractItem, error) {
 	return structure.ReadExtractData(e.ExportDir, e.Mapping, taskKey)
+}
+
+// extractScope is the (server, project, branch) slice of an extract task
+// that one project-data loader cares about. An empty Branch matches every
+// branch.
+type extractScope struct {
+	ServerURL  string
+	ProjectKey string
+	Branch     string
+}
+
+// recordHeader is stage one of the two-stage decode every project-data
+// loader uses. Only the routing fields are declared, so encoding/json skips
+// everything else with d.skip(), which scans without allocating.
+//
+// This is the difference that matters. common.ExtractField unmarshals into
+// a map[string]json.RawMessage, and json.RawMessage.UnmarshalJSON is an
+// append — so it copies every value in the record, including a source
+// file's full text and its per-line highlighted HTML, just to read one key.
+// Loaders decode the payload only once the scope has matched.
+type recordHeader struct {
+	Key        string `json:"key"`
+	ProjectKey string `json:"projectKey"`
+	Branch     string `json:"branch"`
+}
+
+// matches reports whether a record belongs to the given scope. An empty
+// scope Branch matches any branch; an empty record Branch never excludes.
+func (h recordHeader) matches(scope extractScope) bool {
+	if h.ProjectKey != scope.ProjectKey {
+		return false
+	}
+	return scope.Branch == "" || h.Branch == scope.Branch
+}
+
+// scopedExtractItems streams the records of extractKey that belong to
+// scope, paying only a recordHeader decode for the ones that don't.
+//
+// Records that fail to parse are skipped, matching the pre-existing
+// per-loader behaviour.
+func scopedExtractItems(e *Executor, extractKey string, scope extractScope) func(yield func(structure.ExtractItem, recordHeader) bool) {
+	return func(yield func(structure.ExtractItem, recordHeader) bool) {
+		for item := range structure.ExtractItems(e.ExportDir, e.Mapping, extractKey) {
+			if item.ServerURL != scope.ServerURL {
+				continue
+			}
+			var hdr recordHeader
+			if err := json.Unmarshal(item.Data, &hdr); err != nil {
+				continue
+			}
+			if !hdr.matches(scope) {
+				continue
+			}
+			if !yield(item, hdr) {
+				return
+			}
+		}
+	}
+}
+
+// hotspotHeader is the stage-one decode for getProjectHotspotsFull, whose
+// records name their project differently from every other extract task:
+// "project" with a "projectKey" fallback. A record with no branch matches
+// any branch, which is why this cannot reuse recordHeader.
+type hotspotHeader struct {
+	Key        string `json:"key"`
+	Project    string `json:"project"`
+	ProjectKey string `json:"projectKey"`
+	Branch     string `json:"branch"`
+}
+
+// projectKey returns whichever of the two spellings the record carries.
+func (h hotspotHeader) projectKey() string {
+	if h.Project != "" {
+		return h.Project
+	}
+	return h.ProjectKey
+}
+
+// matches reports whether a hotspot record belongs to the given scope. A
+// record with no branch belongs to every branch.
+func (h hotspotHeader) matches(scope extractScope) bool {
+	if h.projectKey() != scope.ProjectKey {
+		return false
+	}
+	return h.Branch == "" || h.Branch == scope.Branch
+}
+
+// scopedHotspotItems is scopedExtractItems for getProjectHotspotsFull.
+func scopedHotspotItems(e *Executor, scope extractScope) func(yield func(structure.ExtractItem, hotspotHeader) bool) {
+	return func(yield func(structure.ExtractItem, hotspotHeader) bool) {
+		for item := range structure.ExtractItems(e.ExportDir, e.Mapping, "getProjectHotspotsFull") {
+			if item.ServerURL != scope.ServerURL {
+				continue
+			}
+			var hdr hotspotHeader
+			if err := json.Unmarshal(item.Data, &hdr); err != nil {
+				continue
+			}
+			if !hdr.matches(scope) {
+				continue
+			}
+			if !yield(item, hdr) {
+				return
+			}
+		}
+	}
 }
 
 // forEachMigrateItem reads items from a completed migrate task and calls fn

--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -166,6 +166,23 @@ func scopedExtractItems(e *Executor, extractKey string, scope extractScope) func
 	}
 }
 
+// serverExtractItems streams the records of extractKey belonging to one
+// source server, without any project or branch filter. For extract tasks
+// that are genuinely server-scoped (getActiveProfileRules), where the
+// filtering scopedExtractItems does would be wrong.
+func serverExtractItems(e *Executor, extractKey, serverURL string) func(yield func(structure.ExtractItem) bool) {
+	return func(yield func(structure.ExtractItem) bool) {
+		for item := range structure.ExtractItems(e.ExportDir, e.Mapping, extractKey) {
+			if item.ServerURL != serverURL {
+				continue
+			}
+			if !yield(item) {
+				return
+			}
+		}
+	}
+}
+
 // hotspotHeader is the stage-one decode for getProjectHotspotsFull, whose
 // records name their project differently from every other extract task:
 // "project" with a "projectKey" fallback. A record with no branch matches

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -23,6 +23,17 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// DefaultBuildConcurrency bounds how many scanner reports are built at
+// once. Report construction is where importProjectData's memory goes: the
+// branch's full source text, the protobuf messages built from it, and the
+// packaged ZIP are all live simultaneously.
+//
+// It is much lower than the default request concurrency of 25 on purpose.
+// The phase's wall clock is dominated by PollCETask, which polls every few
+// seconds for minutes, so throttling construction costs little while
+// cutting peak memory by roughly the ratio between the two.
+const DefaultBuildConcurrency = 4
+
 // MigrateConfig holds all parameters for a migrate run.
 type MigrateConfig struct {
 	Token         string
@@ -31,6 +42,9 @@ type MigrateConfig struct {
 	URL           string // Cloud URL (default: https://sonarcloud.io/)
 	RunID         string // Resume a prior run
 	Concurrency   int
+	// BuildConcurrency bounds concurrent scanner-report CONSTRUCTION during
+	// importProjectData, independently of Concurrency. See Executor.BuildSem.
+	BuildConcurrency int
 	// Timeout is the per-HTTP-request timeout in seconds applied to
 	// every SonarQube Cloud call the migrate phase makes (#383). When
 	// <= 0, applyDefaults sets it to 60 — matching the SDK default
@@ -88,19 +102,41 @@ type MigrateConfig struct {
 
 // Executor is the runtime context passed to every migrate task function.
 type Executor struct {
-	Cloud           *cloud.Client     // Standard Cloud API (sonarcloud.io)
-	CloudAPI        *cloud.Client     // Enterprise API (api.sonarcloud.io)
-	Raw             *common.RawClient // For reading from Cloud standard API
-	RawAPI          *common.RawClient // For reading from Cloud enterprise API
-	Extract         *common.DataStore // Reads extract data (across all extract runs)
-	Store           *common.DataStore // Writes migrate output to run directory
-	CloudURL        string            // e.g. "https://sonarcloud.io/"
-	APIURL          string            // e.g. "https://api.sonarcloud.io/"
-	EntKey          string            // Enterprise key
-	Edition         common.Edition
-	ExportDir       string // Root export directory
-	Mapping         structure.ExtractMapping
-	Sem             chan struct{}
+	Cloud     *cloud.Client     // Standard Cloud API (sonarcloud.io)
+	CloudAPI  *cloud.Client     // Enterprise API (api.sonarcloud.io)
+	Raw       *common.RawClient // For reading from Cloud standard API
+	RawAPI    *common.RawClient // For reading from Cloud enterprise API
+	Extract   *common.DataStore // Reads extract data (across all extract runs)
+	Store     *common.DataStore // Writes migrate output to run directory
+	CloudURL  string            // e.g. "https://sonarcloud.io/"
+	APIURL    string            // e.g. "https://api.sonarcloud.io/"
+	EntKey    string            // Enterprise key
+	Edition   common.Edition
+	ExportDir string // Root export directory
+	Mapping   structure.ExtractMapping
+	// Sem is a capacity carrier, NOT a semaphore. Nothing in this package
+	// ever sends to or receives from it; every reference reads cap(e.Sem)
+	// to size a per-task errgroup limit. Each task therefore gets its own
+	// independent limit rather than sharing one pool.
+	//
+	// Do not "fix" this by acquiring it. The fan-outs nest —
+	// runSyncIssueMetadata's forEachMigrateItem holds a slot for each of
+	// its 25 workers, and each of those calls runProjectSyncLoop, which
+	// limits on the same capacity. On one shared counting semaphore the
+	// outer holders would take every slot and no inner work could ever
+	// acquire: a permanent deadlock. Making it real requires restructuring
+	// the nested fan-outs first.
+	Sem chan struct{}
+	// BuildSem bounds concurrent scanner-report CONSTRUCTION, which is the
+	// memory-heavy part of importProjectData: a branch's full source text,
+	// its protobufs and the packaged ZIP are all live at once.
+	//
+	// Deliberately NOT the same bound as project fan-out. importProjectData
+	// spends most of its wall clock in PollCETask, so 25 branches can stay
+	// in flight against the CE while only a few are being built.
+	//
+	// May be nil (test fixtures); callers must nil-check.
+	BuildSem        chan struct{}
 	Logger          *slog.Logger
 	ExcludeBranches []string
 	Progress        *common.Tracker // run-wide progress/ETA estimator (#520)
@@ -194,6 +230,7 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 		ExportDir:            cfg.ExportDirectory,
 		Mapping:              mp.Mapping,
 		Sem:                  make(chan struct{}, cfg.Concurrency),
+		BuildSem:             make(chan struct{}, cfg.BuildConcurrency),
 		ExcludeBranches:      cfg.ExcludeBranches,
 		UnsupportedLanguages: cfg.UnsupportedLanguages,
 		FastSync:             cfg.FastSync,
@@ -463,6 +500,9 @@ func runPhase(ctx context.Context, e *Executor, taskNames []string, registry map
 func (cfg *MigrateConfig) applyDefaults() {
 	if cfg.Concurrency <= 0 {
 		cfg.Concurrency = 25
+	}
+	if cfg.BuildConcurrency <= 0 {
+		cfg.BuildConcurrency = DefaultBuildConcurrency
 	}
 	if cfg.Timeout <= 0 {
 		cfg.Timeout = 60

--- a/go/internal/migrate/scoped_extract_alloc_test.go
+++ b/go/internal/migrate/scoped_extract_alloc_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeSourceCorpus builds a getProjectSourceCode fixture with nProjects
+// projects, one of which is "target". Each record carries realistically
+// bulky source text and per-line highlighted HTML, because the whole point
+// of the two-stage decode is not to materialize those for records that
+// belong to another project.
+func writeSourceCorpus(t *testing.T, dir string, nProjects, filesPerProject int) {
+	t.Helper()
+	taskDir := filepath.Join(dir, "extract-01", "getProjectSourceCode")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	body := strings.Repeat("// a line of source code that takes up some room\n", 40)
+	highlighted := make([]string, 40)
+	for i := range highlighted {
+		highlighted[i] = "<span class=\"k\">// a line of source code that takes up some room</span>"
+	}
+
+	// One record per chunk file, which is what production does for this
+	// task: extract writes each source record with ChunkWriter.WriteOne,
+	// and WriteOne creates its own results.N.jsonl. That layout is why
+	// chunk-granular streaming is record-granular here.
+	chunk := 0
+	for p := 0; p < nProjects; p++ {
+		project := fmt.Sprintf("project-%03d", p)
+		if p == 0 {
+			project = "target"
+		}
+		for i := 0; i < filesPerProject; i++ {
+			chunk++
+			rec := map[string]any{
+				"key":              fmt.Sprintf("%s:file%d.go", project, i),
+				"projectKey":       project,
+				"branch":           "main",
+				"source":           body,
+				"highlightedLines": highlighted,
+			}
+			b, err := json.Marshal(rec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(taskDir, fmt.Sprintf("results.%d.jsonl", chunk))
+			if err := os.WriteFile(path, append(b, '\n'), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
+// BenchmarkLoadBranchSourceData is the repo's first benchmark. Run with
+// -benchmem to get the per-load allocation figure quoted in the PR:
+//
+//	go test ./internal/migrate/ -run '^$' -bench LoadBranchSourceData -benchmem
+func BenchmarkLoadBranchSourceData(b *testing.B) {
+	t := &testing.T{}
+	dir := b.TempDir()
+	writeSourceCorpus(t, dir, 50, 20)
+	e := newProjectDataExecutor(t, dir)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sources, highlights := loadBranchSourceData(e, testServerURL, "target", "main")
+		if len(sources) == 0 || len(highlights) == 0 {
+			b.Fatal("fixture produced no records")
+		}
+	}
+}

--- a/go/internal/migrate/scoped_extract_test.go
+++ b/go/internal/migrate/scoped_extract_test.go
@@ -1,0 +1,218 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// sourceCorpus writes a getProjectSourceCode fixture containing records for
+// two projects across two branches, so scoping can be observed rather than
+// assumed.
+func sourceCorpus(t *testing.T, dir string) {
+	t.Helper()
+	writeJSONL(filepath.Join(dir, "extract-01", "getProjectSourceCode"), []map[string]any{
+		{
+			"key": "proj1:a.go", "projectKey": "proj1", "branch": "main",
+			"source": "package a\n", "highlightedLines": []string{"<span>package a</span>"},
+		},
+		{
+			"key": "proj1:b.go", "projectKey": "proj1", "branch": "main",
+			"source": "package b\n", "highlightedLines": []string{"<span>package b</span>"},
+		},
+		// Same project, different branch — must not leak into main.
+		{
+			"key": "proj1:c.go", "projectKey": "proj1", "branch": "develop",
+			"source": "package c\n", "highlightedLines": []string{"<span>package c</span>"},
+		},
+		// Different project entirely — must not leak either.
+		{
+			"key": "proj2:d.go", "projectKey": "proj2", "branch": "main",
+			"source": "package d\n", "highlightedLines": []string{"<span>package d</span>"},
+		},
+	})
+}
+
+func TestLoadBranchSourceDataScopesToProjectAndBranch(t *testing.T) {
+	dir := t.TempDir()
+	sourceCorpus(t, dir)
+	e := newProjectDataExecutor(t, dir)
+
+	sources, highlights := loadBranchSourceData(e, testServerURL, "proj1", "main")
+
+	if len(sources) != 2 {
+		t.Fatalf("got %d sources, want 2 (proj1/main only): %+v", len(sources), sources)
+	}
+	if len(highlights) != 2 {
+		t.Fatalf("got %d highlights, want 2", len(highlights))
+	}
+	for _, s := range sources {
+		if s.Component != "proj1:a.go" && s.Component != "proj1:b.go" {
+			t.Errorf("unexpected component leaked into scope: %q", s.Component)
+		}
+	}
+}
+
+// The merged loader must return exactly what the two separate loaders did.
+// Those thin adapters delegate to it, so this pins the contract the existing
+// per-loader tests rely on.
+func TestLoadBranchSourceDataMatchesIndividualLoaders(t *testing.T) {
+	dir := t.TempDir()
+	sourceCorpus(t, dir)
+	e := newProjectDataExecutor(t, dir)
+
+	sources, highlights := loadBranchSourceData(e, testServerURL, "proj1", "main")
+	onlySources := loadExtractedSources(e, testServerURL, "proj1", "main")
+	onlyHighlights := loadExtractedSyntaxHighlighting(e, testServerURL, "proj1", "main")
+
+	if len(sources) != len(onlySources) {
+		t.Fatalf("sources: merged %d, individual %d", len(sources), len(onlySources))
+	}
+	for i := range sources {
+		if sources[i] != onlySources[i] {
+			t.Errorf("source %d: merged %+v, individual %+v", i, sources[i], onlySources[i])
+		}
+	}
+
+	if len(highlights) != len(onlyHighlights) {
+		t.Fatalf("highlights: merged %d, individual %d", len(highlights), len(onlyHighlights))
+	}
+	for i := range highlights {
+		if highlights[i].Component != onlyHighlights[i].Component {
+			t.Errorf("highlight %d: merged %q, individual %q",
+				i, highlights[i].Component, onlyHighlights[i].Component)
+		}
+	}
+}
+
+// The two original loaders disagreed on empty keys and that divergence is
+// load-bearing: a source record with no key still contributes its length to
+// the #425 purged-source decision, but cannot produce a HighlightInput
+// because highlighting is keyed by component. Merging them must not
+// accidentally align the two.
+func TestLoadBranchSourceDataKeepsEmptyKeySourceButNotHighlight(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(filepath.Join(dir, "extract-01", "getProjectSourceCode"), []map[string]any{
+		{
+			"key": "", "projectKey": "proj1", "branch": "main",
+			"source": "orphan source\n", "highlightedLines": []string{"<span>orphan</span>"},
+		},
+		{
+			"key": "proj1:a.go", "projectKey": "proj1", "branch": "main",
+			"source": "package a\n", "highlightedLines": []string{"<span>package a</span>"},
+		},
+	})
+	e := newProjectDataExecutor(t, dir)
+
+	sources, highlights := loadBranchSourceData(e, testServerURL, "proj1", "main")
+
+	if len(sources) != 2 {
+		t.Errorf("got %d sources, want 2 — the empty-key record still counts toward source length", len(sources))
+	}
+	if len(highlights) != 1 {
+		t.Fatalf("got %d highlights, want 1 — the empty-key record cannot be highlighted", len(highlights))
+	}
+	if highlights[0].Component != "proj1:a.go" {
+		t.Errorf("highlight component = %q, want proj1:a.go", highlights[0].Component)
+	}
+}
+
+// A record carrying source but no highlighting yields a source and no
+// highlight, rather than an empty-lines highlight entry.
+func TestLoadBranchSourceDataSkipsEmptyHighlighting(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(filepath.Join(dir, "extract-01", "getProjectSourceCode"), []map[string]any{
+		{"key": "proj1:a.go", "projectKey": "proj1", "branch": "main", "source": "package a\n"},
+	})
+	e := newProjectDataExecutor(t, dir)
+
+	sources, highlights := loadBranchSourceData(e, testServerURL, "proj1", "main")
+
+	if len(sources) != 1 {
+		t.Errorf("got %d sources, want 1", len(sources))
+	}
+	if len(highlights) != 0 {
+		t.Errorf("got %d highlights, want 0", len(highlights))
+	}
+}
+
+// Hotspot records name their project "project" rather than "projectKey",
+// and a record with no branch belongs to every branch. Both quirks are
+// pre-existing behaviour that the scoped reader has to keep.
+func TestScopedHotspotItemsHandlesProjectKeyFallbackAndEmptyBranch(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(filepath.Join(dir, "extract-01", "getProjectHotspotsFull"), []map[string]any{
+		{"key": "hs-project-field", "project": "proj1", "branch": "main"},
+		{"key": "hs-projectkey-fallback", "projectKey": "proj1", "branch": "main"},
+		{"key": "hs-no-branch", "project": "proj1"},
+		{"key": "hs-other-branch", "project": "proj1", "branch": "develop"},
+		{"key": "hs-other-project", "project": "proj2", "branch": "main"},
+	})
+	e := newProjectDataExecutor(t, dir)
+
+	seen := map[string]bool{}
+	scope := extractScope{ServerURL: testServerURL, ProjectKey: "proj1", Branch: "main"}
+	for _, hdr := range scopedHotspotItems(e, scope) {
+		seen[hdr.Key] = true
+	}
+
+	for _, want := range []string{"hs-project-field", "hs-projectkey-fallback", "hs-no-branch"} {
+		if !seen[want] {
+			t.Errorf("expected %q to be in scope", want)
+		}
+	}
+	for _, notWant := range []string{"hs-other-branch", "hs-other-project"} {
+		if seen[notWant] {
+			t.Errorf("%q must not be in scope", notWant)
+		}
+	}
+}
+
+// An empty scope Branch matches every branch; this is what run-scoped and
+// project-scoped readers rely on.
+func TestRecordHeaderMatches(t *testing.T) {
+	tests := []struct {
+		name  string
+		hdr   recordHeader
+		scope extractScope
+		want  bool
+	}{
+		{"exact", recordHeader{ProjectKey: "p", Branch: "main"},
+			extractScope{ProjectKey: "p", Branch: "main"}, true},
+		{"wrong project", recordHeader{ProjectKey: "other", Branch: "main"},
+			extractScope{ProjectKey: "p", Branch: "main"}, false},
+		{"wrong branch", recordHeader{ProjectKey: "p", Branch: "develop"},
+			extractScope{ProjectKey: "p", Branch: "main"}, false},
+		{"empty scope branch matches any", recordHeader{ProjectKey: "p", Branch: "develop"},
+			extractScope{ProjectKey: "p"}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.hdr.matches(tc.scope); got != tc.want {
+				t.Errorf("matches = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Records from another SonarQube server must never be in scope, even when
+// the project key and branch happen to coincide.
+func TestScopedExtractItemsFiltersByServerURL(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(filepath.Join(dir, "extract-01", "getProjectSourceCode"), []map[string]any{
+		{"key": "proj1:a.go", "projectKey": "proj1", "branch": "main", "source": "a"},
+	})
+	e := newProjectDataExecutor(t, dir)
+
+	scope := extractScope{ServerURL: "https://other.test/", ProjectKey: "proj1", Branch: "main"}
+	count := 0
+	for range scopedExtractItems(e, "getProjectSourceCode", scope) {
+		count++
+	}
+	if count != 0 {
+		t.Errorf("got %d records for a different server, want 0", count)
+	}
+}

--- a/go/internal/migrate/scoped_extract_test.go
+++ b/go/internal/migrate/scoped_extract_test.go
@@ -171,6 +171,35 @@ func TestScopedHotspotItemsHandlesProjectKeyFallbackAndEmptyBranch(t *testing.T)
 	}
 }
 
+// An empty scope Branch must span every branch of the project. This is how
+// loadMatchableHotspots reads: the metadata sync covers all branches, so
+// scoping it to one would silently drop hotspots.
+func TestScopedHotspotItemsEmptyScopeBranchSpansAllBranches(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(filepath.Join(dir, "extract-01", "getProjectHotspotsFull"), []map[string]any{
+		{"key": "hs-main", "project": "proj1", "branch": "main"},
+		{"key": "hs-develop", "project": "proj1", "branch": "develop"},
+		{"key": "hs-no-branch", "project": "proj1"},
+		{"key": "hs-other-project", "project": "proj2", "branch": "main"},
+	})
+	e := newProjectDataExecutor(t, dir)
+
+	seen := map[string]bool{}
+	scope := extractScope{ServerURL: testServerURL, ProjectKey: "proj1"}
+	for _, hdr := range scopedHotspotItems(e, scope) {
+		seen[hdr.Key] = true
+	}
+
+	for _, want := range []string{"hs-main", "hs-develop", "hs-no-branch"} {
+		if !seen[want] {
+			t.Errorf("expected %q in an unscoped-branch read", want)
+		}
+	}
+	if seen["hs-other-project"] {
+		t.Error("another project must never be in scope")
+	}
+}
+
 // An empty scope Branch matches every branch; this is what run-scoped and
 // project-scoped readers rely on.
 func TestRecordHeaderMatches(t *testing.T) {

--- a/go/internal/migrate/scoped_extract_test.go
+++ b/go/internal/migrate/scoped_extract_test.go
@@ -9,29 +9,53 @@ import (
 	"testing"
 )
 
+// Fixture field names and values, kept as constants so the literals are
+// not repeated across every record in every table.
+const (
+	fieldKey        = "key"
+	fieldProjectKey = "projectKey"
+	fieldProject    = "project"
+	fieldBranch     = "branch"
+	fieldSource     = "source"
+	fieldHighlights = "highlightedLines"
+
+	extractRun     = "extract-01"
+	taskSourceCode = "getProjectSourceCode"
+	taskHotspots   = "getProjectHotspotsFull"
+
+	projMain   = "proj1"
+	branchMain = "main"
+	branchDev  = "develop"
+	fileA      = "proj1:a.go"
+	srcA       = "package a\n"
+
+	hsNoBranch     = "hs-no-branch"
+	hsOtherProject = "hs-other-project"
+)
+
 // sourceCorpus writes a getProjectSourceCode fixture containing records for
 // two projects across two branches, so scoping can be observed rather than
 // assumed.
 func sourceCorpus(t *testing.T, dir string) {
 	t.Helper()
-	writeJSONL(filepath.Join(dir, "extract-01", "getProjectSourceCode"), []map[string]any{
+	writeJSONL(filepath.Join(dir, extractRun, taskSourceCode), []map[string]any{
 		{
-			"key": "proj1:a.go", "projectKey": "proj1", "branch": "main",
-			"source": "package a\n", "highlightedLines": []string{"<span>package a</span>"},
+			fieldKey: fileA, fieldProjectKey: projMain, fieldBranch: branchMain,
+			fieldSource: srcA, fieldHighlights: []string{"<span>package a</span>"},
 		},
 		{
-			"key": "proj1:b.go", "projectKey": "proj1", "branch": "main",
-			"source": "package b\n", "highlightedLines": []string{"<span>package b</span>"},
+			fieldKey: "proj1:b.go", fieldProjectKey: projMain, fieldBranch: branchMain,
+			fieldSource: "package b\n", fieldHighlights: []string{"<span>package b</span>"},
 		},
 		// Same project, different branch — must not leak into main.
 		{
-			"key": "proj1:c.go", "projectKey": "proj1", "branch": "develop",
-			"source": "package c\n", "highlightedLines": []string{"<span>package c</span>"},
+			fieldKey: "proj1:c.go", fieldProjectKey: projMain, fieldBranch: branchDev,
+			fieldSource: "package c\n", fieldHighlights: []string{"<span>package c</span>"},
 		},
 		// Different project entirely — must not leak either.
 		{
-			"key": "proj2:d.go", "projectKey": "proj2", "branch": "main",
-			"source": "package d\n", "highlightedLines": []string{"<span>package d</span>"},
+			fieldKey: "proj2:d.go", fieldProjectKey: "proj2", fieldBranch: branchMain,
+			fieldSource: "package d\n", fieldHighlights: []string{"<span>package d</span>"},
 		},
 	})
 }
@@ -41,7 +65,7 @@ func TestLoadBranchSourceDataScopesToProjectAndBranch(t *testing.T) {
 	sourceCorpus(t, dir)
 	e := newProjectDataExecutor(t, dir)
 
-	sources, highlights := loadBranchSourceData(e, testServerURL, "proj1", "main")
+	sources, highlights := loadBranchSourceData(e, testServerURL, projMain, branchMain)
 
 	if len(sources) != 2 {
 		t.Fatalf("got %d sources, want 2 (proj1/main only): %+v", len(sources), sources)
@@ -50,7 +74,7 @@ func TestLoadBranchSourceDataScopesToProjectAndBranch(t *testing.T) {
 		t.Fatalf("got %d highlights, want 2", len(highlights))
 	}
 	for _, s := range sources {
-		if s.Component != "proj1:a.go" && s.Component != "proj1:b.go" {
+		if s.Component != fileA && s.Component != "proj1:b.go" {
 			t.Errorf("unexpected component leaked into scope: %q", s.Component)
 		}
 	}
@@ -64,9 +88,9 @@ func TestLoadBranchSourceDataMatchesIndividualLoaders(t *testing.T) {
 	sourceCorpus(t, dir)
 	e := newProjectDataExecutor(t, dir)
 
-	sources, highlights := loadBranchSourceData(e, testServerURL, "proj1", "main")
-	onlySources := loadExtractedSources(e, testServerURL, "proj1", "main")
-	onlyHighlights := loadExtractedSyntaxHighlighting(e, testServerURL, "proj1", "main")
+	sources, highlights := loadBranchSourceData(e, testServerURL, projMain, branchMain)
+	onlySources := loadExtractedSources(e, testServerURL, projMain, branchMain)
+	onlyHighlights := loadExtractedSyntaxHighlighting(e, testServerURL, projMain, branchMain)
 
 	if len(sources) != len(onlySources) {
 		t.Fatalf("sources: merged %d, individual %d", len(sources), len(onlySources))
@@ -95,19 +119,19 @@ func TestLoadBranchSourceDataMatchesIndividualLoaders(t *testing.T) {
 // accidentally align the two.
 func TestLoadBranchSourceDataKeepsEmptyKeySourceButNotHighlight(t *testing.T) {
 	dir := t.TempDir()
-	writeJSONL(filepath.Join(dir, "extract-01", "getProjectSourceCode"), []map[string]any{
+	writeJSONL(filepath.Join(dir, extractRun, taskSourceCode), []map[string]any{
 		{
-			"key": "", "projectKey": "proj1", "branch": "main",
-			"source": "orphan source\n", "highlightedLines": []string{"<span>orphan</span>"},
+			fieldKey: "", fieldProjectKey: projMain, fieldBranch: branchMain,
+			fieldSource: "orphan source\n", fieldHighlights: []string{"<span>orphan</span>"},
 		},
 		{
-			"key": "proj1:a.go", "projectKey": "proj1", "branch": "main",
-			"source": "package a\n", "highlightedLines": []string{"<span>package a</span>"},
+			fieldKey: fileA, fieldProjectKey: projMain, fieldBranch: branchMain,
+			fieldSource: srcA, fieldHighlights: []string{"<span>package a</span>"},
 		},
 	})
 	e := newProjectDataExecutor(t, dir)
 
-	sources, highlights := loadBranchSourceData(e, testServerURL, "proj1", "main")
+	sources, highlights := loadBranchSourceData(e, testServerURL, projMain, branchMain)
 
 	if len(sources) != 2 {
 		t.Errorf("got %d sources, want 2 — the empty-key record still counts toward source length", len(sources))
@@ -115,7 +139,7 @@ func TestLoadBranchSourceDataKeepsEmptyKeySourceButNotHighlight(t *testing.T) {
 	if len(highlights) != 1 {
 		t.Fatalf("got %d highlights, want 1 — the empty-key record cannot be highlighted", len(highlights))
 	}
-	if highlights[0].Component != "proj1:a.go" {
+	if highlights[0].Component != fileA {
 		t.Errorf("highlight component = %q, want proj1:a.go", highlights[0].Component)
 	}
 }
@@ -124,12 +148,12 @@ func TestLoadBranchSourceDataKeepsEmptyKeySourceButNotHighlight(t *testing.T) {
 // highlight, rather than an empty-lines highlight entry.
 func TestLoadBranchSourceDataSkipsEmptyHighlighting(t *testing.T) {
 	dir := t.TempDir()
-	writeJSONL(filepath.Join(dir, "extract-01", "getProjectSourceCode"), []map[string]any{
-		{"key": "proj1:a.go", "projectKey": "proj1", "branch": "main", "source": "package a\n"},
+	writeJSONL(filepath.Join(dir, extractRun, taskSourceCode), []map[string]any{
+		{fieldKey: fileA, fieldProjectKey: projMain, fieldBranch: branchMain, fieldSource: srcA},
 	})
 	e := newProjectDataExecutor(t, dir)
 
-	sources, highlights := loadBranchSourceData(e, testServerURL, "proj1", "main")
+	sources, highlights := loadBranchSourceData(e, testServerURL, projMain, branchMain)
 
 	if len(sources) != 1 {
 		t.Errorf("got %d sources, want 1", len(sources))
@@ -144,27 +168,27 @@ func TestLoadBranchSourceDataSkipsEmptyHighlighting(t *testing.T) {
 // pre-existing behaviour that the scoped reader has to keep.
 func TestScopedHotspotItemsHandlesProjectKeyFallbackAndEmptyBranch(t *testing.T) {
 	dir := t.TempDir()
-	writeJSONL(filepath.Join(dir, "extract-01", "getProjectHotspotsFull"), []map[string]any{
-		{"key": "hs-project-field", "project": "proj1", "branch": "main"},
-		{"key": "hs-projectkey-fallback", "projectKey": "proj1", "branch": "main"},
-		{"key": "hs-no-branch", "project": "proj1"},
-		{"key": "hs-other-branch", "project": "proj1", "branch": "develop"},
-		{"key": "hs-other-project", "project": "proj2", "branch": "main"},
+	writeJSONL(filepath.Join(dir, extractRun, taskHotspots), []map[string]any{
+		{fieldKey: "hs-project-field", fieldProject: projMain, fieldBranch: branchMain},
+		{fieldKey: "hs-projectkey-fallback", fieldProjectKey: projMain, fieldBranch: branchMain},
+		{fieldKey: hsNoBranch, fieldProject: projMain},
+		{fieldKey: "hs-other-branch", fieldProject: projMain, fieldBranch: branchDev},
+		{fieldKey: hsOtherProject, fieldProject: "proj2", fieldBranch: branchMain},
 	})
 	e := newProjectDataExecutor(t, dir)
 
 	seen := map[string]bool{}
-	scope := extractScope{ServerURL: testServerURL, ProjectKey: "proj1", Branch: "main"}
+	scope := extractScope{ServerURL: testServerURL, ProjectKey: projMain, Branch: branchMain}
 	for _, hdr := range scopedHotspotItems(e, scope) {
 		seen[hdr.Key] = true
 	}
 
-	for _, want := range []string{"hs-project-field", "hs-projectkey-fallback", "hs-no-branch"} {
+	for _, want := range []string{"hs-project-field", "hs-projectkey-fallback", hsNoBranch} {
 		if !seen[want] {
 			t.Errorf("expected %q to be in scope", want)
 		}
 	}
-	for _, notWant := range []string{"hs-other-branch", "hs-other-project"} {
+	for _, notWant := range []string{"hs-other-branch", hsOtherProject} {
 		if seen[notWant] {
 			t.Errorf("%q must not be in scope", notWant)
 		}
@@ -176,26 +200,26 @@ func TestScopedHotspotItemsHandlesProjectKeyFallbackAndEmptyBranch(t *testing.T)
 // scoping it to one would silently drop hotspots.
 func TestScopedHotspotItemsEmptyScopeBranchSpansAllBranches(t *testing.T) {
 	dir := t.TempDir()
-	writeJSONL(filepath.Join(dir, "extract-01", "getProjectHotspotsFull"), []map[string]any{
-		{"key": "hs-main", "project": "proj1", "branch": "main"},
-		{"key": "hs-develop", "project": "proj1", "branch": "develop"},
-		{"key": "hs-no-branch", "project": "proj1"},
-		{"key": "hs-other-project", "project": "proj2", "branch": "main"},
+	writeJSONL(filepath.Join(dir, extractRun, taskHotspots), []map[string]any{
+		{fieldKey: "hs-main", fieldProject: projMain, fieldBranch: branchMain},
+		{fieldKey: "hs-develop", fieldProject: projMain, fieldBranch: branchDev},
+		{fieldKey: hsNoBranch, fieldProject: projMain},
+		{fieldKey: hsOtherProject, fieldProject: "proj2", fieldBranch: branchMain},
 	})
 	e := newProjectDataExecutor(t, dir)
 
 	seen := map[string]bool{}
-	scope := extractScope{ServerURL: testServerURL, ProjectKey: "proj1"}
+	scope := extractScope{ServerURL: testServerURL, ProjectKey: projMain}
 	for _, hdr := range scopedHotspotItems(e, scope) {
 		seen[hdr.Key] = true
 	}
 
-	for _, want := range []string{"hs-main", "hs-develop", "hs-no-branch"} {
+	for _, want := range []string{"hs-main", "hs-develop", hsNoBranch} {
 		if !seen[want] {
 			t.Errorf("expected %q in an unscoped-branch read", want)
 		}
 	}
-	if seen["hs-other-project"] {
+	if seen[hsOtherProject] {
 		t.Error("another project must never be in scope")
 	}
 }
@@ -209,13 +233,13 @@ func TestRecordHeaderMatches(t *testing.T) {
 		scope extractScope
 		want  bool
 	}{
-		{"exact", recordHeader{ProjectKey: "p", Branch: "main"},
-			extractScope{ProjectKey: "p", Branch: "main"}, true},
-		{"wrong project", recordHeader{ProjectKey: "other", Branch: "main"},
-			extractScope{ProjectKey: "p", Branch: "main"}, false},
-		{"wrong branch", recordHeader{ProjectKey: "p", Branch: "develop"},
-			extractScope{ProjectKey: "p", Branch: "main"}, false},
-		{"empty scope branch matches any", recordHeader{ProjectKey: "p", Branch: "develop"},
+		{"exact", recordHeader{ProjectKey: "p", Branch: branchMain},
+			extractScope{ProjectKey: "p", Branch: branchMain}, true},
+		{"wrong project", recordHeader{ProjectKey: "other", Branch: branchMain},
+			extractScope{ProjectKey: "p", Branch: branchMain}, false},
+		{"wrong branch", recordHeader{ProjectKey: "p", Branch: branchDev},
+			extractScope{ProjectKey: "p", Branch: branchMain}, false},
+		{"empty scope branch matches any", recordHeader{ProjectKey: "p", Branch: branchDev},
 			extractScope{ProjectKey: "p"}, true},
 	}
 	for _, tc := range tests {
@@ -231,14 +255,14 @@ func TestRecordHeaderMatches(t *testing.T) {
 // the project key and branch happen to coincide.
 func TestScopedExtractItemsFiltersByServerURL(t *testing.T) {
 	dir := t.TempDir()
-	writeJSONL(filepath.Join(dir, "extract-01", "getProjectSourceCode"), []map[string]any{
-		{"key": "proj1:a.go", "projectKey": "proj1", "branch": "main", "source": "a"},
+	writeJSONL(filepath.Join(dir, extractRun, taskSourceCode), []map[string]any{
+		{fieldKey: fileA, fieldProjectKey: projMain, fieldBranch: branchMain, fieldSource: "a"},
 	})
 	e := newProjectDataExecutor(t, dir)
 
-	scope := extractScope{ServerURL: "https://other.test/", ProjectKey: "proj1", Branch: "main"}
+	scope := extractScope{ServerURL: "https://other.test/", ProjectKey: projMain, Branch: branchMain}
 	count := 0
-	for range scopedExtractItems(e, "getProjectSourceCode", scope) {
+	for range scopedExtractItems(e, taskSourceCode, scope) {
 		count++
 	}
 	if count != 0 {

--- a/go/internal/migrate/tasks_configure.go
+++ b/go/internal/migrate/tasks_configure.go
@@ -82,8 +82,33 @@ func runSetProfileParent(ctx context.Context, e *Executor) error {
 	return err
 }
 
+// loadProfileBackups indexes every quality-profile XML backup by profile
+// key. A profile's backup is the complete ruleset, so this is multi-MB for
+// something like Sonar way for Java.
+//
+// Built ONCE up front and shared across all profiles: the index is
+// read-only after construction, so it is safe to fan out concurrently.
+// Reading it inside the per-profile callback instead meant every one of
+// the 25 workers held its own copy of every backup on the instance, and
+// turned profile restore into an O(profiles^2) scan.
+func loadProfileBackups(e *Executor) map[string]string {
+	backups := make(map[string]string)
+	for item := range serverAgnosticExtractItems(e, "getProfileBackups") {
+		key := extractField(item.Data, "profileKey")
+		if key == "" {
+			continue
+		}
+		// The backup data is stored as XML in the "backup" field.
+		if backup := extractField(item.Data, "backup"); backup != "" {
+			backups[key] = backup
+		}
+	}
+	return backups
+}
+
 func runRestoreProfiles(ctx context.Context, e *Executor) error {
 	counter := TaskCounterFromContext(ctx)
+	backups := loadProfileBackups(e)
 	err := forEachMigrateItem(ctx, e, "restoreProfiles", "getProfileBackups",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -92,26 +117,17 @@ func runRestoreProfiles(ctx context.Context, e *Executor) error {
 				return nil
 			}
 
-			// Read the XML backup from extract data.
-			items, _ := readExtractItems(e, "getProfileBackups")
-			for _, ei := range items {
-				eiKey := extractField(ei.Data, "profileKey")
-				if eiKey != profileKey {
-					continue
-				}
-				// The backup data is stored as XML in the "backup" field.
-				backup := extractField(ei.Data, "backup")
-				if backup == "" {
-					continue
-				}
-				_, err := e.Cloud.QualityProfiles.Restore(ctx, orgKey, []byte(backup))
-				if err != nil {
-					counter.Fail()
-					logAPIWarn(e.Logger, "restoreProfiles failed", err, "profile", profileKey)
-				} else {
-					counter.Success()
-				}
+			backup := backups[profileKey]
+			if backup == "" {
 				return nil
+			}
+
+			_, err := e.Cloud.QualityProfiles.Restore(ctx, orgKey, []byte(backup))
+			if err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "restoreProfiles failed", err, "profile", profileKey)
+			} else {
+				counter.Success()
 			}
 			return nil
 		})

--- a/go/internal/migrate/tasks_create_cov_test.go
+++ b/go/internal/migrate/tasks_create_cov_test.go
@@ -1,0 +1,179 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// --- extractAnyStr (was 84.6%) ---
+
+func TestExtractAnyStrEdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		key  string
+		want string
+	}{
+		{name: "string value", raw: `{"v":"hello"}`, key: "v", want: "hello"},
+		{name: "integer value", raw: `{"v":30}`, key: "v", want: "30"},
+		{name: "float value", raw: `{"v":1.5}`, key: "v", want: "1.5"},
+		{name: "missing key", raw: `{"v":"x"}`, key: "other", want: ""},
+		{name: "bad json", raw: `not json`, key: "v", want: ""},
+		{name: "bool value not coercible", raw: `{"v":true}`, key: "v", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractAnyStr(json.RawMessage(tc.raw), tc.key); got != tc.want {
+				t.Errorf("extractAnyStr(%s, %q) = %q, want %q", tc.raw, tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- resolveEnterpriseID (was 83.3%) ---
+
+func TestResolveEnterpriseID(t *testing.T) {
+	t.Run("array shape match", func(t *testing.T) {
+		e := newCreateExecutorOnly(t)
+		writeRawTask(t, e, "getEnterprises",
+			`[{"id":"ent-uuid","key":"test-enterprise"},{"id":"other","key":"nope"}]`)
+		id, err := resolveEnterpriseID(e)
+		if err != nil || id != "ent-uuid" {
+			t.Fatalf("got (%q, %v), want (ent-uuid, nil)", id, err)
+		}
+	})
+
+	t.Run("flat object shape match", func(t *testing.T) {
+		e := newCreateExecutorOnly(t)
+		writeRawTask(t, e, "getEnterprises", `{"id":"flat-uuid","key":"test-enterprise"}`)
+		id, err := resolveEnterpriseID(e)
+		if err != nil || id != "flat-uuid" {
+			t.Fatalf("got (%q, %v), want (flat-uuid, nil)", id, err)
+		}
+	})
+
+	t.Run("no match returns error", func(t *testing.T) {
+		e := newCreateExecutorOnly(t)
+		writeRawTask(t, e, "getEnterprises", `[{"id":"x","key":"different"}]`)
+		if _, err := resolveEnterpriseID(e); err == nil {
+			t.Fatal("expected error when no enterprise matches EntKey")
+		}
+	})
+}
+
+// --- create-task hard-failure branches (non-already-exists → counter.Fail) ---
+
+// A 403 (not "already exists") from every create endpoint must be swallowed
+// per-item; the tasks return nil and simply produce no output rows.
+func TestCreateTasksHardFailureProducesNoOutput(t *testing.T) {
+	cases := []struct{ mapping, create string }{
+		{"generateProjectMappings", "createProjects"},
+		{"generateProfileMappings", "createProfiles"},
+		{"generateGateMappings", "createGates"},
+		{"generateGroupMappings", "createGroups"},
+		{"generateTemplateMappings", "createPermissionTemplates"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.create, func(t *testing.T) {
+			cloudSrv := newFailingCloudServer() // 403 on every POST
+			t.Cleanup(cloudSrv.Close)
+			apiSrv := newMockAPIServer()
+			t.Cleanup(apiSrv.Close)
+			dir := t.TempDir()
+			setupExtractData(dir)
+			e := newTestExecutor(cloudSrv, apiSrv, dir)
+			setupCSVs(t, dir)
+			runTask(t, e, tc.mapping)
+
+			reg := BuildMigrateRegistry(RegisterAll())
+			if err := reg[tc.create].Run(context.Background(), e); err != nil {
+				t.Fatalf("%s: a per-item 403 must not fail the task, got %v", tc.create, err)
+			}
+			items, _ := e.Store.ReadAll(tc.create)
+			if len(items) != 0 {
+				t.Errorf("%s: expected no output on hard failure, got %d", tc.create, len(items))
+			}
+		})
+	}
+}
+
+// --- already-exists BUT lookup also fails (counter.Fail + no output) ---
+
+// When create returns "already exists" and the follow-up lookup also errors,
+// the profile/gate/group/template tasks record no output row.
+func TestCreateTasksAlreadyExistsLookupFails(t *testing.T) {
+	cases := []struct{ mapping, create string }{
+		{"generateProfileMappings", "createProfiles"},
+		{"generateGateMappings", "createGates"},
+		{"generateGroupMappings", "createGroups"},
+		{"generateTemplateMappings", "createPermissionTemplates"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.create, func(t *testing.T) {
+			cloudSrv := newAlreadyExistsButLookupFailsServer()
+			t.Cleanup(cloudSrv.Close)
+			apiSrv := newMockAPIServer()
+			t.Cleanup(apiSrv.Close)
+			dir := t.TempDir()
+			setupExtractData(dir)
+			e := newTestExecutor(cloudSrv, apiSrv, dir)
+			setupCSVs(t, dir)
+			runTask(t, e, tc.mapping)
+
+			reg := BuildMigrateRegistry(RegisterAll())
+			if err := reg[tc.create].Run(context.Background(), e); err != nil {
+				t.Fatalf("%s: lookup failure must not fail the task, got %v", tc.create, err)
+			}
+			items, _ := e.Store.ReadAll(tc.create)
+			if len(items) != 0 {
+				t.Errorf("%s: expected no output when lookup fails, got %d: %s",
+					tc.create, len(items), items)
+			}
+		})
+	}
+}
+
+// --- runCreatePortfolios: enterprise not resolvable → task returns error ---
+
+func TestRunCreatePortfoliosNoEnterprise(t *testing.T) {
+	e, dir := newCreateTest(t)
+	setupCSVs(t, dir)
+	runTask(t, e, "generatePortfolioMappings")
+	// getEnterprises output has a non-matching key, so resolveEnterpriseID fails.
+	writeRawTask(t, e, "getEnterprises", `[{"id":"x","key":"different-ent"}]`)
+
+	reg := BuildMigrateRegistry(RegisterAll())
+	if err := reg["createPortfolios"].Run(context.Background(), e); err == nil {
+		t.Fatal("expected createPortfolios to error when the enterprise can't be resolved")
+	}
+}
+
+// --- test-only helpers ---
+
+// newCreateExecutorOnly returns a minimal Executor with a run store and the
+// EntKey used by resolveEnterpriseID, without any mock HTTP servers.
+func newCreateExecutorOnly(t *testing.T) *Executor {
+	t.Helper()
+	cloudSrv := newMockCloudServer()
+	t.Cleanup(cloudSrv.Close)
+	apiSrv := newMockAPIServer()
+	t.Cleanup(apiSrv.Close)
+	return newTestExecutor(cloudSrv, apiSrv, t.TempDir())
+}
+
+// writeRawTask writes a single raw JSON blob as one JSONL record for a task.
+func writeRawTask(t *testing.T, e *Executor, task, raw string) {
+	t.Helper()
+	w, err := e.Store.Writer(task)
+	if err != nil {
+		t.Fatalf("writer(%s): %v", task, err)
+	}
+	if err := w.WriteOne(json.RawMessage(raw)); err != nil {
+		t.Fatalf("write(%s): %v", task, err)
+	}
+}

--- a/go/internal/migrate/tasks_delete_cov_test.go
+++ b/go/internal/migrate/tasks_delete_cov_test.go
@@ -1,0 +1,287 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"testing"
+)
+
+// --- runDeleteGroups (was 38.5%) ---
+
+// Enumerates via /api/user_groups/search and deletes every non-default group;
+// the default "Members" group is preserved.
+func TestRunDeleteGroupsDeletesNonDefault(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		deleted []string
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/user_groups/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"groups": []map[string]any{
+				{"id": 1, "name": "Members", "default": true},
+				{"id": 2, "name": "developers", "default": false},
+				{"id": 3, "name": "migration-scanners", "default": false},
+			},
+			"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 3},
+		})
+	})
+	mux.HandleFunc("POST /api/user_groups/delete", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		deleted = append(deleted, r.FormValue("name"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newDeleteTest(t, mux)
+
+	if err := runDeleteGroups(context.Background(), e); err != nil {
+		t.Fatalf("runDeleteGroups: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deleted) != 2 {
+		t.Fatalf("expected 2 deletes (developers, migration-scanners), got %d: %v", len(deleted), deleted)
+	}
+	got := map[string]bool{}
+	for _, n := range deleted {
+		got[n] = true
+	}
+	if !got["developers"] || !got["migration-scanners"] {
+		t.Errorf("unexpected delete set: %v", got)
+	}
+	if got["Members"] {
+		t.Error("the default \"Members\" group must never be deleted")
+	}
+}
+
+// A 404 from delete is treated as success (already gone / idempotent).
+func TestRunDeleteGroupsNotFoundCountsSuccess(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/user_groups/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"groups": []map[string]any{
+				{"id": 2, "name": "developers", "default": false},
+			},
+			"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 1},
+		})
+	})
+	mux.HandleFunc("POST /api/user_groups/delete", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"errors":[{"msg":"No group found"}]}`, http.StatusNotFound)
+	})
+	e := newDeleteTest(t, mux)
+	if err := runDeleteGroups(context.Background(), e); err != nil {
+		t.Fatalf("404 on delete must be swallowed as success, got %v", err)
+	}
+}
+
+// A non-404 delete failure hits the counter.Fail()/continue branch.
+func TestRunDeleteGroupsDeleteError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/user_groups/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"groups": []map[string]any{{"id": 2, "name": "developers", "default": false}},
+			"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 1},
+		})
+	})
+	mux.HandleFunc("POST /api/user_groups/delete", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"errors":[{"msg":"boom"}]}`, http.StatusForbidden)
+	})
+	e := newDeleteTest(t, mux)
+	if err := runDeleteGroups(context.Background(), e); err != nil {
+		t.Fatalf("delete 403 must be swallowed, got %v", err)
+	}
+}
+
+// The listing call itself failing hits the "listing groups failed" branch.
+func TestRunDeleteGroupsListError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/user_groups/search", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"errors":[{"msg":"boom"}]}`, http.StatusInternalServerError)
+	})
+	e := newDeleteTest(t, mux)
+	if err := runDeleteGroups(context.Background(), e); err != nil {
+		t.Fatalf("list failure must be swallowed per-org, got %v", err)
+	}
+}
+
+// --- runDeleteProjects (was 76.9%) ---
+
+func TestRunDeleteProjects(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		deleted []string
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/projects/delete", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		deleted = append(deleted, r.FormValue("project"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newDeleteTest(t, mux)
+
+	// deleteProjects reads getCreatedProjects, keyed by "key".
+	writeTaskJSONL(t, e, "getCreatedProjects", []map[string]any{
+		{"key": "cloud-proj-1"},
+		{"key": ""}, // blank key — skipped.
+		{"key": "cloud-proj-2"},
+	})
+
+	if err := runDeleteProjects(context.Background(), e); err != nil {
+		t.Fatalf("runDeleteProjects: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deleted) != 2 {
+		t.Fatalf("expected 2 project deletes, got %d: %v", len(deleted), deleted)
+	}
+}
+
+// A delete API failure exercises the counter.Fail() branch.
+func TestRunDeleteProjectsAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/projects/delete", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"errors":[{"msg":"boom"}]}`, http.StatusForbidden)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newDeleteTest(t, mux)
+	writeTaskJSONL(t, e, "getCreatedProjects", []map[string]any{{"key": "cloud-proj-1"}})
+	if err := runDeleteProjects(context.Background(), e); err != nil {
+		t.Fatalf("delete 403 must be swallowed, got %v", err)
+	}
+}
+
+// --- runDeletePortfolios (was 75.0%) ---
+
+func TestRunDeletePortfolios(t *testing.T) {
+	// The portfolio DELETE lands on the enterprise API host, which
+	// newMockAPIServer (wired by newDeleteTest) answers with 204 on
+	// "DELETE /enterprises/portfolios/". The cloud mux only needs the
+	// org-mapping no-op traffic.
+	cloudMux := http.NewServeMux()
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newDeleteTest(t, cloudMux)
+
+	// deletePortfolios reads createPortfolios, keyed by "cloud_portfolio_id".
+	writeTaskJSONL(t, e, "createPortfolios", []map[string]any{
+		{"cloud_portfolio_id": "pf-1"},
+		{"cloud_portfolio_id": ""}, // blank — skipped.
+		{"cloud_portfolio_id": "pf-2"},
+	})
+
+	if err := runDeletePortfolios(context.Background(), e); err != nil {
+		t.Fatalf("runDeletePortfolios: %v", err)
+	}
+
+	items, _ := e.Store.ReadAll("deletePortfolios")
+	// The task writes no output rows (it only calls the API), so we assert on
+	// the absence of an error above and that the run completed.
+	_ = items
+}
+
+// --- Reset/delete list-failure branches (drive the early counter.Fail path) ---
+
+// deleteProfiles: a failing /api/qualityprofiles/search hits the
+// "listing profiles failed" branch and returns nil per-org.
+func TestRunDeleteProfilesListError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualityprofiles/search", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"errors":[{"msg":"boom"}]}`, http.StatusInternalServerError)
+	})
+	e := newDeleteTest(t, mux)
+	if err := runDeleteProfiles(context.Background(), e); err != nil {
+		t.Fatalf("profile list failure must be swallowed, got %v", err)
+	}
+}
+
+// deleteGates: a failing /api/qualitygates/list hits the analogous branch.
+func TestRunDeleteGatesListError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualitygates/list", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"errors":[{"msg":"boom"}]}`, http.StatusInternalServerError)
+	})
+	e := newDeleteTest(t, mux)
+	if err := runDeleteGates(context.Background(), e); err != nil {
+		t.Fatalf("gate list failure must be swallowed, got %v", err)
+	}
+}
+
+// deleteTemplates: a failing /api/permissions/search_templates hits the
+// "listing templates failed" branch.
+func TestRunDeleteTemplatesListError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"errors":[{"msg":"boom"}]}`, http.StatusInternalServerError)
+	})
+	e := newDeleteTest(t, mux)
+	if err := runDeleteTemplates(context.Background(), e); err != nil {
+		t.Fatalf("template list failure must be swallowed, got %v", err)
+	}
+}
+
+// resetGlobalSettings: a failing /api/settings/values hits its list-failure
+// branch.
+func TestRunResetGlobalSettingsListError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/settings/values", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"errors":[{"msg":"boom"}]}`, http.StatusInternalServerError)
+	})
+	e := newDeleteTest(t, mux)
+	if err := runResetGlobalSettings(context.Background(), e); err != nil {
+		t.Fatalf("settings list failure must be swallowed, got %v", err)
+	}
+}
+
+// resetDefaultProfiles: no built-in profile for a language whose default is
+// custom hits the "no built-in profile found" warn+fail branch.
+func TestRunResetDefaultProfilesNoBuiltIn(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualityprofiles/search", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"profiles": []map[string]any{
+				// Custom is the default, and there is NO built-in for java.
+				{"key": "j2", "name": "Custom Java", "language": "java", "isBuiltIn": false, "isDefault": true},
+			},
+		})
+	})
+	e := newDeleteTest(t, mux)
+	if err := runResetDefaultProfiles(context.Background(), e); err != nil {
+		t.Fatalf("runResetDefaultProfiles: %v", err)
+	}
+}
+
+// resetPermissionTemplates: no built-in "Default Template" present hits the
+// "no built-in found" warn+fail branch.
+func TestRunResetPermissionTemplatesNoBuiltIn(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"permissionTemplates": []map[string]any{
+				{"id": "tpl-custom", "name": "Custom Only"},
+			},
+			"defaultTemplates": []map[string]any{
+				{"templateId": "tpl-custom", "qualifier": "TRK"},
+			},
+		})
+	})
+	e := newDeleteTest(t, mux)
+	if err := runResetPermissionTemplates(context.Background(), e); err != nil {
+		t.Fatalf("runResetPermissionTemplates: %v", err)
+	}
+}

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -844,26 +844,13 @@ const hotspotSourceLinkMarker = "Link to [Original hotspot]"
 // loadMatchableHotspots reads the getProjectHotspotsFull extract items and
 // converts them into normalised matchableHotspot structs.
 func loadMatchableHotspots(e *Executor, serverURL, serverKey string) ([]matchableHotspot, error) {
-	items, err := readExtractItems(e, "getProjectHotspotsFull")
-	if err != nil {
-		return nil, fmt.Errorf("loadMatchableHotspots: %w", err)
-	}
+	// Project-scoped across every branch. Streaming matters here: this runs
+	// once per project at concurrency 25, and syncHotspotMetadata shares a
+	// phase with syncIssueMetadata, so both corpora were resident at once.
+	scope := extractScope{ServerURL: serverURL, ProjectKey: serverKey}
 
 	var hotspots []matchableHotspot
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
-
-		// Filter by project key.
-		projKey := extractField(item.Data, "project")
-		if projKey == "" {
-			projKey = extractField(item.Data, "projectKey")
-		}
-		if projKey != serverKey {
-			continue
-		}
-
+	for item := range scopedHotspotItems(e, scope) {
 		h := parseMatchableHotspot(item.Data)
 		if h.Key == "" {
 			continue

--- a/go/internal/migrate/tasks_hotspotsync_cov_test.go
+++ b/go/internal/migrate/tasks_hotspotsync_cov_test.go
@@ -1,0 +1,378 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/scanreport"
+)
+
+// --- Pure exported-filter helpers (were 0.0%) ---
+
+func TestExportedHotspotHasManualChanges(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      string
+		resolution  string
+		hasComments bool
+		want        bool
+	}{
+		{name: "TO_REVIEW no comments — skip", status: "TO_REVIEW", want: false},
+		{name: "TO_REVIEW with comment — sync", status: "TO_REVIEW", hasComments: true, want: true},
+		{name: "REVIEWED SAFE — sync", status: "REVIEWED", resolution: "SAFE", want: true},
+		{name: "REVIEWED ACKNOWLEDGED — sync", status: "REVIEWED", resolution: "ACKNOWLEDGED", want: true},
+		{name: "REVIEWED FIXED — sync", status: "REVIEWED", resolution: "FIXED", want: true},
+		{name: "REVIEWED unknown — skip", status: "REVIEWED", resolution: "WHATEVER", want: false},
+		{name: "case-insensitive", status: "reviewed", resolution: "safe", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HotspotHasManualChanges(tc.status, tc.resolution, tc.hasComments); got != tc.want {
+				t.Errorf("HotspotHasManualChanges(%q,%q,%v) = %v, want %v",
+					tc.status, tc.resolution, tc.hasComments, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsAcknowledgedResolution now lives in tasks_hotspotsync_test.go
+// upstream, which covers the same cases as named subtests. Removed here
+// to avoid a redeclaration build failure.
+
+// --- Extract-parsing helpers (were 0.0%) ---
+
+func TestParseMatchableHotspotFullShape(t *testing.T) {
+	raw := json.RawMessage(`{
+		"key": "hs-1",
+		"component": "proj:src/Main.java",
+		"status": "REVIEWED",
+		"resolution": "SAFE",
+		"line": 42,
+		"textRange": {"startOffset": 17},
+		"rule": {"key": "java:S2092"},
+		"branch": "develop",
+		"comment": [
+			{"login": "alice", "htmlText": "<b>hi</b>", "markdown": "hi", "createdAt": "2024-01-01"},
+			{"login": "bob", "markdown": "", "htmlText": ""}
+		]
+	}`)
+	h := parseMatchableHotspot(raw)
+	if h.Key != "hs-1" || h.Component != "proj:src/Main.java" {
+		t.Fatalf("unexpected key/component: %+v", h)
+	}
+	if h.Status != "REVIEWED" || h.Resolution != "SAFE" {
+		t.Errorf("status/resolution = %q/%q", h.Status, h.Resolution)
+	}
+	if h.Line != 42 {
+		t.Errorf("line = %d, want 42", h.Line)
+	}
+	if h.Offset != 17 {
+		t.Errorf("offset = %d, want 17 (from textRange.startOffset)", h.Offset)
+	}
+	if h.RuleKey != "java:S2092" {
+		t.Errorf("ruleKey = %q, want java:S2092 (nested rule.key)", h.RuleKey)
+	}
+	if h.Branch != "develop" {
+		t.Errorf("branch = %q, want develop", h.Branch)
+	}
+	// The blank-body comment is dropped; only the alice comment survives.
+	if len(h.Comments) != 1 || h.Comments[0].Login != "alice" {
+		t.Errorf("comments = %+v, want a single alice comment", h.Comments)
+	}
+}
+
+// A top-level ruleKey (not nested) and a string-typed line must also parse.
+func TestParseMatchableHotspotTopLevelRuleAndStringLine(t *testing.T) {
+	raw := json.RawMessage(`{"key":"hs-2","ruleKey":"py:S4823","line":"7"}`)
+	h := parseMatchableHotspot(raw)
+	if h.RuleKey != "py:S4823" {
+		t.Errorf("ruleKey = %q, want py:S4823", h.RuleKey)
+	}
+	if h.Line != 7 {
+		t.Errorf("line = %d, want 7 (string coerced)", h.Line)
+	}
+}
+
+func TestExtractHotspotLineAndOffsetEdgeCases(t *testing.T) {
+	// Absent line/textRange → 0.
+	if got := extractHotspotLine(json.RawMessage(`{}`)); got != 0 {
+		t.Errorf("extractHotspotLine(missing) = %d, want 0", got)
+	}
+	if got := extractHotspotLine(json.RawMessage(`not json`)); got != 0 {
+		t.Errorf("extractHotspotLine(bad json) = %d, want 0", got)
+	}
+	if got := extractHotspotStartOffset(json.RawMessage(`{}`)); got != 0 {
+		t.Errorf("extractHotspotStartOffset(missing textRange) = %d, want 0", got)
+	}
+	if got := extractHotspotStartOffset(json.RawMessage(`{"textRange":{}}`)); got != 0 {
+		t.Errorf("extractHotspotStartOffset(no startOffset) = %d, want 0", got)
+	}
+	if got := extractHotspotStartOffset(json.RawMessage(`{"textRange":{"startOffset":9}}`)); got != 9 {
+		t.Errorf("extractHotspotStartOffset = %d, want 9", got)
+	}
+}
+
+func TestExtractNestedField(t *testing.T) {
+	if got := extractNestedField(json.RawMessage(`{"rule":{"key":"x"}}`), "rule", "key"); got != "x" {
+		t.Errorf("nested = %q, want x", got)
+	}
+	if got := extractNestedField(json.RawMessage(`{}`), "rule", "key"); got != "" {
+		t.Errorf("missing outer = %q, want empty", got)
+	}
+	if got := extractNestedField(json.RawMessage(`bad`), "rule", "key"); got != "" {
+		t.Errorf("bad json = %q, want empty", got)
+	}
+}
+
+func TestParseHotspotCommentsVariants(t *testing.T) {
+	// Plural "comments" fallback.
+	plural := json.RawMessage(`{"comments":[{"login":"a","markdown":"m"}]}`)
+	if c := parseHotspotComments(plural); len(c) != 1 || c[0].Markdown != "m" {
+		t.Errorf("plural comments = %+v", c)
+	}
+	// Neither key present.
+	if c := parseHotspotComments(json.RawMessage(`{}`)); c != nil {
+		t.Errorf("no comment key = %+v, want nil", c)
+	}
+	// Bad JSON.
+	if c := parseHotspotComments(json.RawMessage(`bad`)); c != nil {
+		t.Errorf("bad json = %+v, want nil", c)
+	}
+	// Comment array present but element bodies blank → dropped.
+	blank := json.RawMessage(`{"comment":[{"login":"a"}]}`)
+	if c := parseHotspotComments(blank); len(c) != 0 {
+		t.Errorf("blank-body comment must be dropped, got %+v", c)
+	}
+}
+
+// --- loadMatchableHotspots (was 0.0%) ---
+
+// writeHotspotExtract writes an extract.json + getProjectHotspotsFull feed
+// scoped to testServerURL so loadMatchableHotspots can read it.
+func writeHotspotExtract(t *testing.T, dir string, rows []map[string]any) {
+	t.Helper()
+	extractDir := filepath.Join(dir, "extract-01")
+	writeJSON(filepath.Join(extractDir, "extract.json"),
+		map[string]any{"url": testServerURL, "edition": "enterprise"})
+	writeJSONL(filepath.Join(extractDir, "getProjectHotspotsFull"), rows)
+}
+
+func TestLoadMatchableHotspotsFiltersByServerAndProject(t *testing.T) {
+	dir := t.TempDir()
+	writeHotspotExtract(t, dir, []map[string]any{
+		// Wanted: right server, right project.
+		{"key": "hs-1", "ruleKey": "java:S1", "component": "proj1:A.java",
+			"project": "proj1", "line": 10, "status": "REVIEWED", "resolution": "SAFE",
+			"serverUrl": testServerURL},
+		// Wrong project — filtered out.
+		{"key": "hs-2", "ruleKey": "java:S1", "component": "other:B.java",
+			"project": "other", "line": 11, "serverUrl": testServerURL},
+		// Uses projectKey (not project) as the key field.
+		{"key": "hs-4", "ruleKey": "java:S1", "component": "proj1:D.java",
+			"projectKey": "proj1", "line": 13, "serverUrl": testServerURL},
+		// No key → skipped by parse guard.
+		{"ruleKey": "java:S1", "component": "proj1:E.java",
+			"project": "proj1", "line": 14, "serverUrl": testServerURL},
+	})
+	e := newProjectDataExecutor(t, dir)
+
+	got, err := loadMatchableHotspots(e, testServerURL, "proj1")
+	if err != nil {
+		t.Fatalf("loadMatchableHotspots: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 hotspots (hs-1, hs-4), got %d: %+v", len(got), got)
+	}
+	keys := map[string]bool{}
+	for _, h := range got {
+		keys[h.Key] = true
+	}
+	if !keys["hs-1"] || !keys["hs-4"] {
+		t.Errorf("expected hs-1 and hs-4, got %v", keys)
+	}
+}
+
+// --- End-to-end syncProjectHotspots (was 0.0%) ---
+
+// newHotspotSyncCloud stands up a cloud mock that reports one indexed issue and
+// returns a single matching cloud counterpart on line 7 for the targeted
+// search, recording every write endpoint the sync drives.
+func newHotspotSyncCloud(t *testing.T) (*httptest.Server, *hotspotSyncRec) {
+	t.Helper()
+	rec := &hotspotSyncRec{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/issues/search", func(w http.ResponseWriter, r *http.Request) {
+		// The project-wide indexing probe (no rules) reports a non-zero total.
+		if r.URL.Query().Get("rules") == "" {
+			json.NewEncoder(w).Encode(map[string]any{
+				"issues": []map[string]any{},
+				"paging": map[string]any{"pageIndex": 1, "pageSize": 1, "total": 1},
+			})
+			return
+		}
+		// Targeted per-hotspot search: one counterpart on line 7.
+		json.NewEncoder(w).Encode(map[string]any{
+			"issues": []map[string]any{{
+				"key": "cloud-hs-1", "rule": "java:S2092",
+				"component": "cloud-proj:src/Main.java", "line": 7,
+				"tags":        []string{"secret"},
+				"transitions": []string{"accept", "confirm"},
+			}},
+			"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 1},
+		})
+	})
+	mux.HandleFunc("POST /api/issues/do_transition", func(w http.ResponseWriter, _ *http.Request) {
+		rec.transition++
+	})
+	mux.HandleFunc("POST /api/issues/add_comment", func(w http.ResponseWriter, _ *http.Request) {
+		rec.comment++
+	})
+	mux.HandleFunc("POST /api/issues/set_tags", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		rec.setTags = append(rec.setTags, r.Form.Get("tags"))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+type hotspotSyncRec struct {
+	transition int
+	comment    int
+	setTags    []string
+}
+
+func TestSyncProjectHotspotsEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	writeHotspotExtract(t, dir, []map[string]any{
+		{
+			"key": "hs-1", "ruleKey": "java:S2092", "component": "proj1:src/Main.java",
+			"project": "proj1", "line": 7, "branch": "main",
+			"status": "REVIEWED", "resolution": "SAFE",
+			"comment":   []map[string]any{{"login": "alice", "markdown": "safe here"}},
+			"serverUrl": testServerURL,
+		},
+	})
+	cloudSrv, rec := newHotspotSyncCloud(t)
+	apiSrv := newMockAPIServer()
+	t.Cleanup(apiSrv.Close)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	res := syncProjectHotspots(context.Background(), e, syncHotspotInput{
+		CloudKey:  "cloud-proj",
+		OrgKey:    "cloud-org",
+		ServerURL: testServerURL,
+		ServerKey: "proj1",
+	})
+	if res.Error != "" {
+		t.Fatalf("unexpected error: %s", res.Error)
+	}
+	if res.Stats.Actionable != 1 {
+		t.Errorf("actionable = %d, want 1", res.Stats.Actionable)
+	}
+	if res.Stats.A != 1 {
+		t.Errorf("synced (A) = %d, want 1", res.Stats.A)
+	}
+	// The sqs-hotspot tag must be written to the matched cloud issue.
+	if len(rec.setTags) != 1 {
+		t.Fatalf("expected 1 set_tags call, got %d: %v", len(rec.setTags), rec.setTags)
+	}
+	if got := rec.setTags[0]; !containsTag(got, scanreport.HotspotIssueTag) {
+		t.Errorf("set_tags payload %q missing %q", got, scanreport.HotspotIssueTag)
+	}
+}
+
+// No source hotspots at all → zeroed stats, no error, no cloud writes.
+func TestSyncProjectHotspotsNoSource(t *testing.T) {
+	dir := t.TempDir()
+	writeHotspotExtract(t, dir, nil)
+	cloudSrv, rec := newHotspotSyncCloud(t)
+	apiSrv := newMockAPIServer()
+	t.Cleanup(apiSrv.Close)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	res := syncProjectHotspots(context.Background(), e, syncHotspotInput{
+		CloudKey: "cloud-proj", OrgKey: "cloud-org",
+		ServerURL: testServerURL, ServerKey: "proj1",
+	})
+	if res.Error != "" || res.Stats.Actionable != 0 || res.Stats.A != 0 {
+		t.Errorf("want zeroed stats/no error, got %+v", res)
+	}
+	if len(rec.setTags) != 0 {
+		t.Errorf("no cloud writes expected, got %v", rec.setTags)
+	}
+}
+
+// --- runSyncHotspotMetadata task entry (was 0.0%) ---
+
+func TestRunSyncHotspotMetadataTask(t *testing.T) {
+	dir := t.TempDir()
+	writeHotspotExtract(t, dir, []map[string]any{
+		{
+			"key": "hs-1", "ruleKey": "java:S2092", "component": "proj1:src/Main.java",
+			"project": "proj1", "line": 7, "branch": "main",
+			"status": "REVIEWED", "resolution": "SAFE",
+			"serverUrl": testServerURL,
+		},
+	})
+	cloudSrv, _ := newHotspotSyncCloud(t)
+	apiSrv := newMockAPIServer()
+	t.Cleanup(apiSrv.Close)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	// createProjects is the dependency the task fans out over.
+	writeTaskJSONL(t, e, "createProjects", []map[string]any{
+		{"key": "proj1", "cloud_project_key": "cloud-proj",
+			"sonarcloud_org_key": "cloud-org", "server_url": testServerURL},
+		// A row missing the cloud key/org is skipped early.
+		{"key": "proj2", "server_url": testServerURL},
+	})
+
+	if err := runSyncHotspotMetadata(context.Background(), e); err != nil {
+		t.Fatalf("runSyncHotspotMetadata: %v", err)
+	}
+
+	items, _ := e.Store.ReadAll("syncHotspotMetadata")
+	if len(items) != 1 {
+		t.Fatalf("expected 1 result record (proj2 skipped), got %d: %s", len(items), items)
+	}
+	if got := extractField(items[0], "cloud_project_key"); got != "cloud-proj" {
+		t.Errorf("cloud_project_key = %q, want cloud-proj", got)
+	}
+}
+
+// containsTag reports whether a comma-joined set_tags payload contains tag.
+func containsTag(payload, tag string) bool {
+	for _, p := range splitCSV(payload) {
+		if p == tag {
+			return true
+		}
+	}
+	return false
+}
+
+func splitCSV(s string) []string {
+	var out []string
+	cur := ""
+	for _, r := range s {
+		if r == ',' {
+			out = append(out, cur)
+			cur = ""
+			continue
+		}
+		cur += string(r)
+	}
+	out = append(out, cur)
+	return out
+}

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -1098,21 +1098,14 @@ func (r *ruleTagDefaults) UserTagsOnly(serverURL, ruleKey string, allTags []stri
 // tag list so that matchableIssue.Tags holds only the user-added tags
 // — see the type doc on ruleTagDefaults.
 func loadMatchableIssues(e *Executor, serverURL, serverKey string, ruleDefaults *ruleTagDefaults) []matchableIssue {
-	items, err := readExtractItems(e, "getProjectIssuesFull")
-	if err != nil {
-		return nil
-	}
+	// Project-scoped with no branch filter. Streaming matters here: this
+	// runs once per project at concurrency 25, so materializing the whole
+	// instance's issue corpus meant 25 concurrent copies of it.
+	scope := extractScope{ServerURL: serverURL, ProjectKey: serverKey}
 
 	var issues []matchableIssue
 	var excludedFixed int
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
-		if extractField(item.Data, "projectKey") != serverKey {
-			continue
-		}
-
+	for item := range scopedExtractItems(e, "getProjectIssuesFull", scope) {
 		status := strings.ToUpper(extractField(item.Data, "status"))
 		resolution := strings.ToUpper(extractField(item.Data, "resolution"))
 		issueStatus := strings.ToUpper(extractField(item.Data, "issueStatus"))

--- a/go/internal/migrate/tasks_permissions_cov_test.go
+++ b/go/internal/migrate/tasks_permissions_cov_test.go
@@ -1,0 +1,249 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// newPermissionsTest wires an Executor against newMockCloudServer (which already
+// answers add_user / add_group / add_group_to_template with 204) plus the
+// standard extract data. Returns the executor for direct Run-function calls.
+func newPermissionsTest(t *testing.T) *Executor {
+	t.Helper()
+	cloudSrv := newMockCloudServer()
+	t.Cleanup(cloudSrv.Close)
+	apiSrv := newMockAPIServer()
+	t.Cleanup(apiSrv.Close)
+	dir := t.TempDir()
+	setupExtractData(dir)
+	return newTestExecutor(cloudSrv, apiSrv, dir)
+}
+
+// --- runGrantMigrationUserProjectPermissions (was 65.4%) ---
+
+// Happy path: one project + one migration user → four add_user calls (one per
+// permission in migrationUserProjectPermissions).
+func TestRunGrantMigrationUserProjectPermissions(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		perms []string
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/permissions/add_user", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		perms = append(perms, r.FormValue("permission"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newCustomCloudTest(t, mux)
+
+	writeTaskJSONL(t, e, "getMigrationUser", []map[string]any{{"login": "migration-user"}})
+	writeTaskJSONL(t, e, "createProjects", []map[string]any{
+		{"key": "proj1", "cloud_project_key": "cloud-proj", "sonarcloud_org_key": "cloud-org"},
+		// skipped org — no add_user calls for it.
+		{"key": "proj2", "cloud_project_key": "cloud-proj2", "sonarcloud_org_key": ""},
+		// missing cloud key — skipped.
+		{"key": "proj3", "sonarcloud_org_key": "cloud-org"},
+	})
+
+	if err := runGrantMigrationUserProjectPermissions(context.Background(), e); err != nil {
+		t.Fatalf("runGrantMigrationUserProjectPermissions: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(perms) != len(migrationUserProjectPermissions) {
+		t.Fatalf("expected %d add_user calls, got %d: %v",
+			len(migrationUserProjectPermissions), len(perms), perms)
+	}
+	got := map[string]bool{}
+	for _, p := range perms {
+		got[p] = true
+	}
+	for _, want := range migrationUserProjectPermissions {
+		if !got[want] {
+			t.Errorf("missing add_user for permission %q", want)
+		}
+	}
+}
+
+// No migration user record → nothing to grant, no error.
+func TestRunGrantMigrationUserProjectPermissionsNoUser(t *testing.T) {
+	e := newPermissionsTest(t)
+	// createProjects present but no getMigrationUser.
+	writeTaskJSONL(t, e, "createProjects", []map[string]any{
+		{"key": "proj1", "cloud_project_key": "cloud-proj", "sonarcloud_org_key": "cloud-org"},
+	})
+	if err := runGrantMigrationUserProjectPermissions(context.Background(), e); err != nil {
+		t.Fatalf("expected no error when no migration user, got %v", err)
+	}
+}
+
+// Migration user record present but blank login → nothing to grant.
+func TestRunGrantMigrationUserProjectPermissionsBlankLogin(t *testing.T) {
+	e := newPermissionsTest(t)
+	writeTaskJSONL(t, e, "getMigrationUser", []map[string]any{{"login": ""}})
+	writeTaskJSONL(t, e, "createProjects", []map[string]any{
+		{"key": "proj1", "cloud_project_key": "cloud-proj", "sonarcloud_org_key": "cloud-org"},
+	})
+	if err := runGrantMigrationUserProjectPermissions(context.Background(), e); err != nil {
+		t.Fatalf("expected no error for blank login, got %v", err)
+	}
+}
+
+// add_user failing (403) exercises the counter.Fail()/continue branch without
+// failing the task.
+func TestRunGrantMigrationUserProjectPermissionsAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/permissions/add_user", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"errors":[{"msg":"Insufficient privileges"}]}`, http.StatusForbidden)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newCustomCloudTest(t, mux)
+	writeTaskJSONL(t, e, "getMigrationUser", []map[string]any{{"login": "migration-user"}})
+	writeTaskJSONL(t, e, "createProjects", []map[string]any{
+		{"key": "proj1", "cloud_project_key": "cloud-proj", "sonarcloud_org_key": "cloud-org"},
+	})
+	if err := runGrantMigrationUserProjectPermissions(context.Background(), e); err != nil {
+		t.Fatalf("add_user 403 must be swallowed, got err %v", err)
+	}
+}
+
+// --- runSetTemplateGroupPermissions (was 0.0%) ---
+
+// setupTemplateGroupExtract writes the two template-group feeds plus the
+// createPermissionTemplates and createGroups migrate outputs the task joins on.
+func setupTemplateGroupExtract(t *testing.T, e *Executor) {
+	t.Helper()
+	writeTaskJSONL(t, e, "createPermissionTemplates", []map[string]any{
+		{"server_url": testServerURL, "source_template_key": "tpl-src-1",
+			"cloud_template_id": "tpl-cloud-1", "sonarcloud_org_key": "cloud-org"},
+	})
+	writeTaskJSONL(t, e, "createGroups", []map[string]any{
+		{"name": "developers", "sonarcloud_org_key": "cloud-org"},
+	})
+	// Extract feeds. These are structure.ExtractItem feeds read via
+	// forEachExtractItem, so they live in the extract dir.
+	writeJSONL(extractPath(e, "getTemplateGroupsScanners"), []map[string]any{
+		// Custom migrated group with scan+user — applied.
+		{"templateId": "tpl-src-1", "name": "developers",
+			"permissions": []string{"scan", "user"}, "serverUrl": testServerURL},
+		// Built-in alias sonar-users → Members (no groupExists check).
+		{"templateId": "tpl-src-1", "name": "sonar-users",
+			"permissions": []string{"user"}, "serverUrl": testServerURL},
+		// Skipped built-in.
+		{"templateId": "tpl-src-1", "name": "sonar-administrators",
+			"permissions": []string{"admin"}, "serverUrl": testServerURL},
+		// Unknown template id — no mapping, skipped.
+		{"templateId": "unknown", "name": "developers",
+			"permissions": []string{"scan"}, "serverUrl": testServerURL},
+	})
+	writeJSONL(extractPath(e, "getTemplateGroupsViewers"), []map[string]any{
+		// Same (tpl, developers, user) triple as the scanners feed — deduped.
+		{"templateId": "tpl-src-1", "name": "developers",
+			"permissions": []string{"user"}, "serverUrl": testServerURL},
+		// A group that never made it into createGroups — dropped.
+		{"templateId": "tpl-src-1", "name": "ghost",
+			"permissions": []string{"user"}, "serverUrl": testServerURL},
+	})
+}
+
+func TestRunSetTemplateGroupPermissions(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		adds []string // "<group>:<perm>"
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/permissions/add_group_to_template", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		adds = append(adds, r.FormValue("groupName")+":"+r.FormValue("permission"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newCustomCloudTest(t, mux)
+	setupTemplateGroupExtract(t, e)
+
+	if err := runSetTemplateGroupPermissions(context.Background(), e); err != nil {
+		t.Fatalf("runSetTemplateGroupPermissions: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	got := map[string]bool{}
+	for _, a := range adds {
+		got[a] = true
+	}
+	// developers gets scan + user (user deduped across both feeds).
+	if !got["developers:scan"] || !got["developers:user"] {
+		t.Errorf("expected developers scan+user, got %v", got)
+	}
+	// sonar-users is remapped to Members.
+	if !got["Members:user"] {
+		t.Errorf("expected sonar-users remapped to Members:user, got %v", got)
+	}
+	// Built-in / unknown / ghost groups must NOT be granted.
+	for _, bad := range []string{"sonar-administrators:admin", "ghost:user"} {
+		if got[bad] {
+			t.Errorf("did not expect %q to be granted", bad)
+		}
+	}
+	// Exactly three distinct grants (developers:scan, developers:user, Members:user).
+	if len(got) != 3 {
+		t.Errorf("expected 3 distinct grants, got %d: %v", len(got), got)
+	}
+}
+
+// No permission templates in scope → early return, no extract read.
+func TestRunSetTemplateGroupPermissionsNoTemplates(t *testing.T) {
+	e := newPermissionsTest(t)
+	// createPermissionTemplates absent → templateMap empty → early return.
+	if err := runSetTemplateGroupPermissions(context.Background(), e); err != nil {
+		t.Fatalf("expected clean early return, got %v", err)
+	}
+}
+
+// --- runSetOrgGroupPermissions error branch (add_group fails) ---
+
+func TestRunSetOrgGroupPermissionsAddGroupError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/permissions/add_group", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"errors":[{"msg":"boom"}]}`, http.StatusForbidden)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	t.Cleanup(cloudSrv.Close)
+	apiSrv := newMockAPIServer()
+	t.Cleanup(apiSrv.Close)
+	dir := t.TempDir()
+	setupExtractData(dir) // getGroups row: sonar-users (→ Members) with scan perm
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	if err := runSetOrgGroupPermissions(context.Background(), e); err != nil {
+		t.Fatalf("add_group 403 must be swallowed, got %v", err)
+	}
+}
+
+// extractPath returns the extract-run directory path for a feed name.
+func extractPath(e *Executor, feed string) string {
+	return filepath.Join(e.ExportDir, "extract-01", feed)
+}

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -325,7 +325,7 @@ func importBranch(ctx context.Context, e *Executor, input importBranchInput) (*i
 		targetBranch = input.Branch
 	}
 
-	report, skip, err := buildBranchReport(ctx, e, input, targetBranch)
+	zipBytes, meta, skip, err := buildBranchReport(ctx, e, input, targetBranch)
 	if err != nil {
 		return nil, err
 	}
@@ -338,15 +338,20 @@ func importBranch(ctx context.Context, e *Executor, input importBranchInput) (*i
 		ProjectKey:     input.CloudKey,
 		OrgKey:         input.OrgKey,
 		BranchName:     targetBranch,
-		ProjectVersion: report.ProjectVersion,
+		ProjectVersion: meta.ProjectVersion,
 		IsMain:         input.IsMain,
 	}
 
-	result, err := scanreport.SubmitReport(ctx, e.Raw.HTTPClient(), cfg, report.ZIP)
+	result, err := scanreport.SubmitReport(ctx, e.Raw.HTTPClient(), cfg, zipBytes)
 	if err != nil {
 		return nil, fmt.Errorf("submitting report: %w", err)
 	}
 
+	// zipBytes is dead from here on, so the GC can reclaim it during the
+	// poll below. That is the point of returning meta separately: PollCETask
+	// blocks for minutes, and when these fields lived on a struct alongside
+	// the ZIP, reading one of them after the poll kept the whole allocation
+	// -- ZIP included -- reachable in every concurrent branch import.
 	e.Logger.Info("CE task submitted", "project", input.CloudKey, "targetBranch", targetBranch, "taskId", result.TaskID)
 
 	if err := scanreport.PollCETask(ctx, e.Raw.HTTPClient(), e.CloudURL, result.TaskID, e.Logger); err != nil {
@@ -354,14 +359,21 @@ func importBranch(ctx context.Context, e *Executor, input importBranchInput) (*i
 	}
 
 	return &importResult{
-		Status: "success", TaskID: result.TaskID, SourcePurged: report.SourcePurged,
-		UnsupportedLanguages: report.UnsupportedLanguages, ExcludedFiles: report.ExcludedFiles,
+		Status: "success", TaskID: result.TaskID, SourcePurged: meta.SourcePurged,
+		UnsupportedLanguages: meta.UnsupportedLanguages, ExcludedFiles: meta.ExcludedFiles,
 	}, nil
 }
 
-// branchReport is a packaged scanner report for one branch, ready to submit.
-type branchReport struct {
-	ZIP            []byte
+// branchReportMeta is everything about a packaged report that outlives the
+// ZIP bytes.
+//
+// It is returned separately from the ZIP so importBranch can drop the ZIP
+// the moment SubmitReport returns. The CE poll that follows runs for
+// minutes, and with 25 projects in flight, holding 25 report ZIPs across it
+// was a large share of peak RSS. Keeping these fields on a struct alongside
+// the ZIP is what pinned it: reading any field after the poll keeps the
+// whole allocation, ZIP included, reachable.
+type branchReportMeta struct {
 	ProjectVersion string
 	// SourcePurged is true when this branch's source text was unavailable
 	// (purged by housekeeping) so the report carries measures + issues but no
@@ -378,7 +390,7 @@ type branchReport struct {
 // CE-compatibility fixes, and returns the packaged report. A non-nil skip
 // result means the branch must not be submitted (no components, or no source
 // to anchor its issues).
-func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput, targetBranch string) (*branchReport, *importResult, error) {
+func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput, targetBranch string) ([]byte, branchReportMeta, *importResult, error) {
 	issues := loadExtractedIssues(e, input.ServerURL, input.ServerKey, input.Branch)
 	hotspots := loadExtractedHotspots(e, input.ServerURL, input.ServerKey, input.Branch)
 	hotspotIssues := convertHotspotsForReport(e, input, hotspots)
@@ -398,7 +410,7 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	syntaxHighlighting := loadExtractedSyntaxHighlighting(e, input.ServerURL, input.ServerKey, input.Branch)
 
 	if len(components) == 0 {
-		return nil, &importResult{Status: "skipped"}, nil
+		return nil, branchReportMeta{}, &importResult{Status: "skipped"}, nil
 	}
 
 	// The source server returns no source TEXT for this branch even though line
@@ -443,7 +455,7 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	components, unsupportedLangKeys, unsupportedSkip := applyUnsupportedLanguagePolicy(
 		e, input.CloudKey, input.Branch, components, scProfileByLang)
 	if unsupportedSkip != nil {
-		return nil, unsupportedSkip, nil
+		return nil, branchReportMeta{}, unsupportedSkip, nil
 	}
 	// Zero unless mode "exclude" actually dropped components.
 	excludedFiles := componentsBeforePolicy - len(components)
@@ -560,7 +572,7 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 			BranchType: "long",
 		})
 		if hErr != nil {
-			return nil, nil, fmt.Errorf("create-analysis handshake (branch %s): %w", input.Branch, hErr)
+			return nil, branchReportMeta{}, nil, fmt.Errorf("create-analysis handshake (branch %s): %w", input.Branch, hErr)
 		}
 		analysisUUID = res.AnalysisUUID
 		e.Logger.Info("analysis pre-created (branch anchored on target)",
@@ -595,7 +607,7 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 
 	zipBytes, err := scanreport.PackageReport(reportData)
 	if err != nil {
-		return nil, nil, fmt.Errorf("packaging report: %w", err)
+		return nil, branchReportMeta{}, nil, fmt.Errorf("packaging report: %w", err)
 	}
 
 	if dumpDir := os.Getenv("SMT_DUMP_REPORT_DIR"); dumpDir != "" {
@@ -620,8 +632,8 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 		"activeRules", len(activeRules),
 	)
 
-	return &branchReport{
-		ZIP: zipBytes, ProjectVersion: projectVersion, SourcePurged: sourcePurged,
+	return zipBytes, branchReportMeta{
+		ProjectVersion: projectVersion, SourcePurged: sourcePurged,
 		UnsupportedLanguages: unsupportedLangKeys, ExcludedFiles: excludedFiles,
 	}, nil, nil
 }

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -414,6 +414,76 @@ type branchReportMeta struct {
 	ExcludedFiles        int
 }
 
+// buildProtoSources maps each file component's source text onto its
+// protobuf component ref, skipping files with no source.
+//
+// Source text is sanitized on the way in. Files like RCE-demo PHP scripts
+// may contain null bytes (U+0000) used in null-byte injection exploits.
+// The SonarCloud CE's Java component visitor and the underlying database
+// both reject null bytes in text, producing "Visit of Component failed" /
+// "Fail to process issues of component" CE task failures. Stripping them
+// here lets the file still migrate with its issues and measures intact.
+func buildProtoSources(sources []sourceRecord, cr *scanreport.ComponentRef) map[int32]string {
+	pbSources := make(map[int32]string, len(sources))
+	for _, s := range sources {
+		if ref, ok := cr.Refs()[s.Component]; ok && s.Source != "" {
+			pbSources[ref] = stripNullBytes(s.Source)
+		}
+	}
+	return pbSources
+}
+
+// changesetsByComponentKey re-keys changesets from protobuf component ref to
+// component key, sharing the same pointers. BackdateChangesets works in
+// component-key space, so it needs this alias view.
+func changesetsByComponentKey(changesets map[int32]*pb.Changesets, cr *scanreport.ComponentRef) map[string]*pb.Changesets {
+	byKey := make(map[string]*pb.Changesets, len(changesets))
+	for compKey, ref := range cr.Refs() {
+		if cs, ok := changesets[ref]; ok {
+			byKey[compKey] = cs
+		}
+	}
+	return byKey
+}
+
+// preCreateBranchAnalysis performs the SonarCloud "Create analysis"
+// handshake for a non-main branch, returning the analysis UUID to stamp
+// into the report metadata (analysis_uuid, field 19) so the CE binds the
+// report to the pre-created branch. Without it the CE accepts the report
+// (task SUCCESS) but never creates the branch.
+//
+// The main branch needs no handshake — its first analysis establishes it —
+// so this returns an empty UUID for it.
+func preCreateBranchAnalysis(ctx context.Context, e *Executor, input importBranchInput,
+	targetBranch, projectVersion string,
+) (string, error) {
+	if input.IsMain {
+		return "", nil
+	}
+	res, err := scanreport.PreCreateAnalysis(ctx, e.RawAPI.HTTPClient(), scanreport.AnalysisConfig{
+		APIURL:         e.APIURL,
+		OrgKey:         input.OrgKey,
+		ProjectKey:     input.CloudKey,
+		ProjectVersion: projectVersion,
+		BranchName:     targetBranch,
+		TargetBranch:   input.ReferenceBranch,
+		// Migrate every non-main branch as a long-lived branch so it keeps
+		// its full issue history (matches SonarQube Server, where all
+		// branches are long-lived). Without this, branches whose names don't
+		// match the target's long-lived-branch regex would be created as
+		// short-lived (PR-like, auto-deleted, no overall-code history).
+		BranchType: "long",
+	})
+	if err != nil {
+		return "", fmt.Errorf("create-analysis handshake (branch %s): %w", input.Branch, err)
+	}
+	e.Logger.Info("analysis pre-created (branch anchored on target)",
+		"project", input.CloudKey, "branch", targetBranch,
+		"analysisUuid", res.AnalysisUUID, "branchType", res.BranchType,
+		"referenceBranch", res.ReferenceBranchName)
+	return res.AnalysisUUID, nil
+}
+
 // buildBranchReport loads the extracted data for one branch, applies the
 // CE-compatibility fixes, and returns the packaged report. A non-nil skip
 // result means the branch must not be submitted (no components, or no source
@@ -528,19 +598,7 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	now := time.Now()
 
 	root, fileComps, cr := scanreport.BuildComponents(input.CloudKey, components)
-	pbSources := make(map[int32]string)
-	for _, s := range sources {
-		if ref, ok := cr.Refs()[s.Component]; ok && s.Source != "" {
-			// Sanitize source text before embedding in the scanner report.
-			// Files like RCE-demo PHP scripts may contain null bytes (U+0000)
-			// used in null-byte injection exploits. The SonarCloud CE's Java
-			// component visitor and the underlying database both reject null
-			// bytes in text, producing "Visit of Component failed" / "Fail to
-			// process issues of component" CE task failures. Strip them here so
-			// the file still migrates with its issues and measures intact.
-			pbSources[ref] = stripNullBytes(s.Source)
-		}
-	}
+	pbSources := buildProtoSources(sources, cr)
 	// #425 — the SonarCloud CE rejects any report containing a FILE component
 	// with no source text (it fails with "There was an issue whilst processing
 	// the report"), regardless of whether the file carries issues — every
@@ -565,12 +623,7 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 
 	// Backdate changesets so each issue gets its original SonarQube creation date.
 	// Build a component-key-keyed alias map (same pointers) for BackdateChangesets.
-	changesetsByKey := make(map[string]*pb.Changesets, len(changesets))
-	for compKey, ref := range cr.Refs() {
-		if cs, ok := changesets[ref]; ok {
-			changesetsByKey[compKey] = cs
-		}
-	}
+	changesetsByKey := changesetsByComponentKey(changesets, cr)
 	extracted := toExtractedIssues(issues)
 	extracted = append(extracted, extIssuesToExtracted(extIssues)...)
 	scanreport.BackdateChangesets(extracted, changesetsByKey, now)
@@ -583,29 +636,9 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	// this report to the pre-created branch. Without it, the CE accepts the
 	// report (task SUCCESS) but never creates the branch. The main branch needs
 	// no handshake — its first analysis establishes it.
-	var analysisUUID string
-	if !input.IsMain {
-		res, hErr := scanreport.PreCreateAnalysis(ctx, e.RawAPI.HTTPClient(), scanreport.AnalysisConfig{
-			APIURL:         e.APIURL,
-			OrgKey:         input.OrgKey,
-			ProjectKey:     input.CloudKey,
-			ProjectVersion: projectVersion,
-			BranchName:     targetBranch,
-			TargetBranch:   input.ReferenceBranch,
-			// Migrate every non-main branch as a long-lived branch so it keeps
-			// its full issue history (matches SonarQube Server, where all
-			// branches are long-lived). Without this, branches whose names don't
-			// match the target's long-lived-branch regex would be created as
-			// short-lived (PR-like, auto-deleted, no overall-code history).
-			BranchType: "long",
-		})
-		if hErr != nil {
-			return nil, branchReportMeta{}, nil, fmt.Errorf("create-analysis handshake (branch %s): %w", input.Branch, hErr)
-		}
-		analysisUUID = res.AnalysisUUID
-		e.Logger.Info("analysis pre-created (branch anchored on target)",
-			"project", input.CloudKey, "branch", targetBranch,
-			"analysisUuid", analysisUUID, "branchType", res.BranchType, "referenceBranch", res.ReferenceBranchName)
+	analysisUUID, err := preCreateBranchAnalysis(ctx, e, input, targetBranch, projectVersion)
+	if err != nil {
+		return nil, branchReportMeta{}, nil, err
 	}
 
 	reportData := &scanreport.ReportData{

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -325,11 +325,34 @@ func importBranch(ctx context.Context, e *Executor, input importBranchInput) (*i
 		targetBranch = input.Branch
 	}
 
+	// Bound concurrent report construction. Held across build + submit and
+	// released before the CE poll below, so the expensive window is short
+	// even though the branch stays in flight for minutes afterwards.
+	//
+	// The release flag is a local, not a field: e is shared by every
+	// concurrent branch import, so clearing e.BuildSem to mark "released"
+	// would switch the semaphore off for the whole run.
+	buildSem := e.BuildSem
+	if buildSem != nil {
+		if err := common.AcquireSem(ctx, buildSem); err != nil {
+			return nil, err
+		}
+	}
+	buildReleased := false
+	buildDone := func() {
+		if buildSem != nil && !buildReleased {
+			buildReleased = true
+			<-buildSem
+		}
+	}
+
 	zipBytes, meta, skip, err := buildBranchReport(ctx, e, input, targetBranch)
 	if err != nil {
+		buildDone()
 		return nil, err
 	}
 	if skip != nil {
+		buildDone()
 		return skip, nil
 	}
 
@@ -344,8 +367,13 @@ func importBranch(ctx context.Context, e *Executor, input importBranchInput) (*i
 
 	result, err := scanreport.SubmitReport(ctx, e.Raw.HTTPClient(), cfg, zipBytes)
 	if err != nil {
+		buildDone()
 		return nil, fmt.Errorf("submitting report: %w", err)
 	}
+
+	// The report is on the wire; let the next branch start building while
+	// this one waits on the CE.
+	buildDone()
 
 	// zipBytes is dead from here on, so the GC can reclaim it during the
 	// poll below. That is the point of returning meta separately: PollCETask

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -398,16 +398,16 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	// Include ALL FIL components, not just those with source code; external
 	// issues can reference files without source. CloudVoyager does the same.
 	components := loadExtractedComponents(e, input.ServerURL, input.ServerKey, input.Branch)
-	sources := loadExtractedSources(e, input.ServerURL, input.ServerKey, input.Branch)
+	// Source text and per-line syntax highlighting come from the same
+	// extract task, so one pass yields both. Without the highlighting the
+	// migrated source renders as raw, uncolored text (issue #420).
+	sources, syntaxHighlighting := loadBranchSourceData(e, input.ServerURL, input.ServerKey, input.Branch)
 	activeRules := loadExtractedActiveRules(e, input.ServerURL, input.ServerKey)
 	// Per-file measures (ncloc et al.) — without these the branch renders as
 	// "main branch is empty". Real per-line SCM blame — without it the Code
 	// view shows no author/date per line.
 	componentMeasures := loadComponentMeasures(e, input.ServerURL, input.ServerKey, input.Branch)
 	scmByComponent := loadExtractedSCM(e, input.ServerURL, input.ServerKey, input.Branch)
-	// Per-line syntax highlighting (colors in the Code view); without it the
-	// migrated source renders as raw, uncolored text (issue #420).
-	syntaxHighlighting := loadExtractedSyntaxHighlighting(e, input.ServerURL, input.ServerKey, input.Branch)
 
 	if len(components) == 0 {
 		return nil, branchReportMeta{}, &importResult{Status: "skipped"}, nil
@@ -811,84 +811,66 @@ type sourceRecord struct {
 	Source    string
 }
 
-func loadExtractedSources(e *Executor, serverURL, serverKey, branch string) []sourceRecord {
-	items, err := readExtractItems(e, "getProjectSourceCode")
-	if err != nil {
-		return nil
-	}
-	var sources []sourceRecord
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
-		if extractField(item.Data, "projectKey") != serverKey {
-			continue
-		}
-		if extractField(item.Data, "branch") != branch {
-			continue
-		}
-		sources = append(sources, sourceRecord{
-			Component: extractField(item.Data, "key"),
-			Source:    extractField(item.Data, "source"),
-		})
-	}
-	return sources
-}
+// loadBranchSourceData reads getProjectSourceCode once for a branch and
+// returns both the source text and the per-line highlighted HTML. The
+// highlighting is parsed into protobuf rules later by
+// scanreport.BuildSyntaxHighlighting so the migrated Code view renders with
+// colors (issue #420).
+//
+// This was two functions each doing a full pass over the whole instance's
+// source corpus. Reading once halves the I/O, and streaming with a
+// two-stage decode means a record belonging to another project costs a
+// three-field header rather than a copy of its full text and highlighting.
+func loadBranchSourceData(e *Executor, serverURL, serverKey, branch string) ([]sourceRecord, []scanreport.HighlightInput) {
+	scope := extractScope{ServerURL: serverURL, ProjectKey: serverKey, Branch: branch}
 
-// loadExtractedSyntaxHighlighting reads the per-line highlighted HTML captured
-// alongside source code (getProjectSourceCode → "highlightedLines") for the
-// given branch, returning one HighlightInput per file. The highlighting is
-// parsed into protobuf rules later by scanreport.BuildSyntaxHighlighting so the
-// migrated Code view renders with colors (issue #420).
-func loadExtractedSyntaxHighlighting(e *Executor, serverURL, serverKey, branch string) []scanreport.HighlightInput {
-	items, err := readExtractItems(e, "getProjectSourceCode")
-	if err != nil {
-		return nil
-	}
+	var sources []sourceRecord
 	var inputs []scanreport.HighlightInput
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
+
+	for item, hdr := range scopedExtractItems(e, "getProjectSourceCode", scope) {
 		var rec struct {
-			Key              string   `json:"key"`
-			ProjectKey       string   `json:"projectKey"`
-			Branch           string   `json:"branch"`
+			Source           string   `json:"source"`
 			HighlightedLines []string `json:"highlightedLines"`
 		}
 		if err := json.Unmarshal(item.Data, &rec); err != nil {
 			continue
 		}
-		if rec.ProjectKey != serverKey || rec.Branch != branch || rec.Key == "" {
-			continue
+
+		// Note the asymmetry, which is load-bearing: a record with an
+		// empty key still contributes a sourceRecord because its length
+		// feeds the #425 purged-source decision, but it cannot produce a
+		// HighlightInput because highlighting is keyed by component.
+		sources = append(sources, sourceRecord{Component: hdr.Key, Source: rec.Source})
+
+		if hdr.Key != "" && len(rec.HighlightedLines) > 0 {
+			inputs = append(inputs, scanreport.HighlightInput{
+				Component: hdr.Key,
+				Lines:     rec.HighlightedLines,
+			})
 		}
-		if len(rec.HighlightedLines) == 0 {
-			continue
-		}
-		inputs = append(inputs, scanreport.HighlightInput{
-			Component: rec.Key,
-			Lines:     rec.HighlightedLines,
-		})
 	}
+	return sources, inputs
+}
+
+// loadExtractedSources returns just the source text for a branch.
+// Retained so the existing per-loader tests keep exercising the same
+// contract; production goes through loadBranchSourceData.
+func loadExtractedSources(e *Executor, serverURL, serverKey, branch string) []sourceRecord {
+	sources, _ := loadBranchSourceData(e, serverURL, serverKey, branch)
+	return sources
+}
+
+// loadExtractedSyntaxHighlighting returns just the per-line highlighted
+// HTML for a branch. See loadExtractedSources on why this remains.
+func loadExtractedSyntaxHighlighting(e *Executor, serverURL, serverKey, branch string) []scanreport.HighlightInput {
+	_, inputs := loadBranchSourceData(e, serverURL, serverKey, branch)
 	return inputs
 }
 
 func loadExtractedIssues(e *Executor, serverURL, serverKey, branch string) []scanreport.IssueInput {
-	items, err := readExtractItems(e, "getProjectIssuesFull")
-	if err != nil {
-		return nil
-	}
+	scope := extractScope{ServerURL: serverURL, ProjectKey: serverKey, Branch: branch}
 	var issues []scanreport.IssueInput
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
-		if extractField(item.Data, "projectKey") != serverKey {
-			continue
-		}
-		if extractField(item.Data, "branch") != branch {
-			continue
-		}
+	for item := range scopedExtractItems(e, "getProjectIssuesFull", scope) {
 		// Exclude CLOSED issues and issues resolved by code fix (FIXED).
 		// These have no Cloud counterpart — the scanner report only creates
 		// them as OPEN, so recreating CLOSED/FIXED would create phantom issues.
@@ -928,24 +910,12 @@ func loadExtractedIssues(e *Executor, serverURL, serverKey, branch string) []sca
 // CloudVoyager's is-external-issue.js: issues from repos NOT in
 // sonarCloudRuleRepos or prefixed with "external_" are external.
 func loadExtractedExternalIssues(e *Executor, serverURL, serverKey, branch string) ([]scanreport.ExternalIssueInput, []scanreport.AdHocRuleInput) {
-	items, err := readExtractItems(e, "getProjectIssuesFull")
-	if err != nil {
-		return nil, nil
-	}
+	scope := extractScope{ServerURL: serverURL, ProjectKey: serverKey, Branch: branch}
 	seenRules := make(map[string]bool)
 	var extIssues []scanreport.ExternalIssueInput
 	var adHocRules []scanreport.AdHocRuleInput
 
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
-		if extractField(item.Data, "projectKey") != serverKey {
-			continue
-		}
-		if extractField(item.Data, "branch") != branch {
-			continue
-		}
+	for item := range scopedExtractItems(e, "getProjectIssuesFull", scope) {
 		issue, rule, ok := classifyExternalIssue(item.Data)
 		if !ok {
 			continue
@@ -1047,26 +1017,9 @@ func extractImpactInputs(data json.RawMessage, field string) []scanreport.Impact
 // The review state is carried through here so the metadata-sync phase can
 // reproduce it as issue triage.
 func loadExtractedHotspots(e *Executor, serverURL, serverKey, branch string) []scanreport.HotspotInput {
-	items, err := readExtractItems(e, "getProjectHotspotsFull")
-	if err != nil {
-		return nil
-	}
+	scope := extractScope{ServerURL: serverURL, ProjectKey: serverKey, Branch: branch}
 	var hotspots []scanreport.HotspotInput
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
-		projKey := extractField(item.Data, "project")
-		if projKey == "" {
-			projKey = extractField(item.Data, "projectKey")
-		}
-		if projKey != serverKey {
-			continue
-		}
-		br := extractField(item.Data, "branch")
-		if br != "" && br != branch {
-			continue
-		}
+	for item := range scopedHotspotItems(e, scope) {
 		ruleKey := extractField(item.Data, "ruleKey")
 		if ruleKey == "" {
 			// Try nested rule.key
@@ -1166,21 +1119,9 @@ func extractNestedRuleKey(data json.RawMessage) string {
 }
 
 func loadExtractedComponents(e *Executor, serverURL, serverKey, branch string) []scanreport.ComponentInput {
-	items, err := readExtractItems(e, "getProjectComponentTree")
-	if err != nil {
-		return nil
-	}
+	scope := extractScope{ServerURL: serverURL, ProjectKey: serverKey, Branch: branch}
 	var components []scanreport.ComponentInput
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
-		if extractField(item.Data, "projectKey") != serverKey {
-			continue
-		}
-		if extractField(item.Data, "branch") != branch {
-			continue
-		}
+	for item := range scopedExtractItems(e, "getProjectComponentTree", scope) {
 		lines := extractInt32Field(item.Data, "lines")
 		if lines == 0 {
 			lines = extractMeasureInt32(item.Data, "ncloc")
@@ -1202,22 +1143,10 @@ func loadExtractedComponents(e *Executor, serverURL, serverKey, branch string) [
 // packaged report carries no measures-*.pb, SonarCloud's CE computes a null
 // project ncloc, and the migrated branch renders as "main branch is empty".
 func loadComponentMeasures(e *Executor, serverURL, serverKey, branch string) []scanreport.MeasureInput {
-	items, err := readExtractItems(e, "getProjectComponentTree")
-	if err != nil {
-		return nil
-	}
+	scope := extractScope{ServerURL: serverURL, ProjectKey: serverKey, Branch: branch}
 	var measures []scanreport.MeasureInput
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
-		if extractField(item.Data, "projectKey") != serverKey {
-			continue
-		}
-		if extractField(item.Data, "branch") != branch {
-			continue
-		}
-		key := extractField(item.Data, "key")
+	for item, hdr := range scopedExtractItems(e, "getProjectComponentTree", scope) {
+		key := hdr.Key
 		if key == "" {
 			continue
 		}
@@ -1281,22 +1210,10 @@ type blameLine struct {
 // this data and shipped synthetic changesets; loading it lets the report carry
 // real per-line author/date/revision for the SonarCloud Code view.
 func loadExtractedSCM(e *Executor, serverURL, serverKey, branch string) map[string][]blameLine {
-	items, err := readExtractItems(e, "getProjectSCMData")
-	if err != nil {
-		return nil
-	}
+	scope := extractScope{ServerURL: serverURL, ProjectKey: serverKey, Branch: branch}
 	result := make(map[string][]blameLine)
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
-		if extractField(item.Data, "projectKey") != serverKey {
-			continue
-		}
-		if extractField(item.Data, "branch") != branch {
-			continue
-		}
-		key := extractField(item.Data, "key")
+	for item, hdr := range scopedExtractItems(e, "getProjectSCMData", scope) {
+		key := hdr.Key
 		if key == "" {
 			continue
 		}

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -719,19 +719,10 @@ type branchInfo struct {
 // collectBranchInfo reads extracted branch data for a project, returning
 // each LONG branch's name and whether it is the main branch.
 func collectBranchInfo(e *Executor, serverURL, serverKey string) []branchInfo {
-	items, err := readExtractItems(e, "getBranches")
-	if err != nil {
-		return nil
-	}
+	// No Branch in the scope: this collects every branch of the project.
+	scope := extractScope{ServerURL: serverURL, ProjectKey: serverKey}
 	var branches []branchInfo
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
-		projKey := extractField(item.Data, "projectKey")
-		if projKey != serverKey {
-			continue
-		}
+	for item := range scopedExtractItems(e, "getBranches", scope) {
 		branchType := strings.ToUpper(extractField(item.Data, "type"))
 		if branchType == "SHORT" {
 			continue
@@ -1344,20 +1335,10 @@ var sonarCloudRuleRepos = map[string]bool{
 // project+branch combination. Returns the version string, or empty if not found
 // (the caller's BuildMetadata defaults to "1.0.0").
 func resolveProjectVersion(e *Executor, serverURL, serverKey, branch string) string {
-	items, err := readExtractItems(e, "getProjectVersions")
-	if err != nil {
-		return ""
-	}
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
-		if extractField(item.Data, "projectKey") != serverKey {
-			continue
-		}
-		if extractField(item.Data, "branch") != branch {
-			continue
-		}
+	scope := extractScope{ServerURL: serverURL, ProjectKey: serverKey, Branch: branch}
+	// Streaming lets this stop at the first usable version rather than
+	// scanning the rest of the corpus.
+	for item := range scopedExtractItems(e, "getProjectVersions", scope) {
 		version := extractField(item.Data, "version")
 		if version != "" && version != "not provided" {
 			return version
@@ -1367,15 +1348,8 @@ func resolveProjectVersion(e *Executor, serverURL, serverKey, branch string) str
 }
 
 func loadExtractedActiveRules(e *Executor, serverURL, serverKey string) []scanreport.ActiveRuleInput {
-	items, err := readExtractItems(e, "getActiveProfileRules")
-	if err != nil {
-		return nil
-	}
 	var rules []scanreport.ActiveRuleInput
-	for _, item := range items {
-		if item.ServerURL != serverURL {
-			continue
-		}
+	for item := range serverExtractItems(e, "getActiveProfileRules", serverURL) {
 		rule := extractField(item.Data, "key")
 		repo, key := splitRule(rule)
 		// Only include rules from known SonarCloud repositories.

--- a/go/internal/migrate/zz_dumpreport_test.go
+++ b/go/internal/migrate/zz_dumpreport_test.go
@@ -73,19 +73,19 @@ func TestDumpOurReport(t *testing.T) {
 		IsMain:       true,
 	}
 
-	report, skip, err := buildBranchReport(context.Background(), e, input, mainName)
+	zipBytes, _, skip, err := buildBranchReport(context.Background(), e, input, mainName)
 	if err != nil {
 		t.Fatalf("buildBranchReport: %v", err)
 	}
 	if skip != nil {
 		t.Fatalf("branch was skipped: status=%q err=%q", skip.Status, skip.Error)
 	}
-	if report == nil || len(report.ZIP) == 0 {
+	if len(zipBytes) == 0 {
 		t.Fatal("empty report zip")
 	}
 
-	if err := os.WriteFile(out, report.ZIP, 0o644); err != nil {
+	if err := os.WriteFile(out, zipBytes, 0o644); err != nil {
 		t.Fatalf("write zip: %v", err)
 	}
-	t.Logf("wrote %d bytes to %s", len(report.ZIP), out)
+	t.Logf("wrote %d bytes to %s", len(zipBytes), out)
 }

--- a/go/internal/predict/branch_source_purged.go
+++ b/go/internal/predict/branch_source_purged.go
@@ -48,29 +48,29 @@ func synthesizeBranchSourcePurged(exportDir, runDir string, extractMapping struc
 	// "purged" from "source never extracted".
 	sourceBytes := make(map[branchKey]int)
 	sourceRecords := make(map[branchKey]int)
-	if items, err := structure.ReadExtractData(exportDir, extractMapping, "getProjectSourceCode"); err == nil {
-		for _, item := range items {
-			bk := branchKey{item.ServerURL, jsonStringField(item.Data, "projectKey"), jsonStringField(item.Data, "branch")}
-			sourceBytes[bk] += len(jsonStringField(item.Data, "source"))
-			sourceRecords[bk]++
-		}
+	// Streamed rather than slurped: this is a pure fold into two counters,
+	// but getProjectSourceCode is the largest thing the extract produces —
+	// full file text plus per-line highlighted HTML for every file on the
+	// instance — and none of it needs to be resident to count bytes.
+	for item := range structure.ExtractItems(exportDir, extractMapping, "getProjectSourceCode") {
+		bk := branchKey{item.ServerURL, jsonStringField(item.Data, "projectKey"), jsonStringField(item.Data, "branch")}
+		sourceBytes[bk] += len(jsonStringField(item.Data, "source"))
+		sourceRecords[bk]++
 	}
 
 	// Branches per project (LONG branches only). Projects with no recorded
 	// branches fall back to a lone "main" branch, matching migrate.
 	branchesByProject := make(map[projectKeyT][]string)
-	if items, err := structure.ReadExtractData(exportDir, extractMapping, "getBranches"); err == nil {
-		for _, item := range items {
-			if strings.ToUpper(jsonStringField(item.Data, "type")) == "SHORT" {
-				continue
-			}
-			name := jsonStringField(item.Data, "name")
-			if name == "" {
-				continue
-			}
-			pk := projectKeyT{item.ServerURL, jsonStringField(item.Data, "projectKey")}
-			branchesByProject[pk] = append(branchesByProject[pk], name)
+	for item := range structure.ExtractItems(exportDir, extractMapping, "getBranches") {
+		if strings.ToUpper(jsonStringField(item.Data, "type")) == "SHORT" {
+			continue
 		}
+		name := jsonStringField(item.Data, "name")
+		if name == "" {
+			continue
+		}
+		pk := projectKeyT{item.ServerURL, jsonStringField(item.Data, "projectKey")}
+		branchesByProject[pk] = append(branchesByProject[pk], name)
 	}
 
 	w, err := store.Writer("importProjectData")

--- a/go/internal/structure/extract.go
+++ b/go/internal/structure/extract.go
@@ -78,18 +78,51 @@ type ExtractItem struct {
 	Data      json.RawMessage
 }
 
+// ExtractItems streams every JSONL record of the named task across all
+// extract runs in the mapping, yielding (serverURL, rawObject) pairs one
+// chunk file at a time. Peak memory is one chunk file rather than the whole
+// task, which matters because getProjectSourceCode embeds full file text
+// and per-line highlighted HTML for every file on the instance.
+//
+// Error policy is identical to ReadExtractData, which is now a thin wrapper
+// over this:
+//   - an extract whose task directory is missing is skipped entirely (the
+//     extract may simply not have run that task);
+//   - a single unreadable JSONL file inside a task directory is logged as a
+//     warning and the records ReadJSONLFile parsed before the failure are
+//     still yielded (#312, #314).
+//
+// No error is yielded because none can escape: every failure mode above is
+// absorbed by design. Consumers stop early with break.
+//
+// Ordering matches ReadExtractData exactly — mapping iteration is Go map
+// order (nondeterministic across servers) and chunk files are visited in
+// os.ReadDir order within an extract.
+func ExtractItems(directory string, mapping ExtractMapping, key string) func(yield func(ExtractItem) bool) {
+	return func(yield func(ExtractItem) bool) {
+		for serverURL, extractID := range mapping {
+			taskDir := filepath.Join(directory, extractID, key)
+			completed, err := eachTaskDirRecord(taskDir, func(r json.RawMessage) bool {
+				return yield(ExtractItem{ServerURL: serverURL, Data: r})
+			})
+			if err != nil {
+				continue // task may not exist for this extract
+			}
+			if !completed {
+				return // consumer stopped early
+			}
+		}
+	}
+}
+
 // ReadExtractData reads all JSONL items for a given task key across all extracts.
+//
+// Prefer ExtractItems for anything whose size scales with the instance —
+// this materializes every record of every project at once.
 func ReadExtractData(directory string, mapping ExtractMapping, key string) ([]ExtractItem, error) {
 	var items []ExtractItem
-	for serverURL, extractID := range mapping {
-		taskDir := filepath.Join(directory, extractID, key)
-		raw, err := readTaskDir(taskDir)
-		if err != nil {
-			continue // task may not exist for this extract
-		}
-		for _, r := range raw {
-			items = append(items, ExtractItem{ServerURL: serverURL, Data: r})
-		}
+	for item := range ExtractItems(directory, mapping, key) {
+		items = append(items, item)
 	}
 	return items, nil
 }
@@ -104,11 +137,29 @@ func ReadExtractData(directory string, mapping ExtractMapping, key string) ([]Ex
 // Returns an error only when the task directory itself can't be
 // listed; per-file failures are visible via slog warnings.
 func readTaskDir(dir string) ([]json.RawMessage, error) {
-	entries, err := os.ReadDir(dir)
+	var all []json.RawMessage
+	_, err := eachTaskDirRecord(dir, func(r json.RawMessage) bool {
+		all = append(all, r)
+		return true
+	})
 	if err != nil {
 		return nil, err
 	}
-	var all []json.RawMessage
+	return all, nil
+}
+
+// eachTaskDirRecord yields every JSONL record under dir, one chunk file at
+// a time. It is the shared body of readTaskDir and ExtractItems, so both
+// observe exactly the same error policy (see readTaskDir's doc).
+//
+// Returns an error only when the directory itself can't be listed.
+// completed reports whether iteration ran to the end; false means the
+// consumer stopped early, so no further files were opened.
+func eachTaskDirRecord(dir string, yield func(json.RawMessage) bool) (completed bool, err error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".jsonl" {
 			continue
@@ -122,10 +173,12 @@ func readTaskDir(dir string) ([]json.RawMessage, error) {
 			// error — ReadJSONLFile returns the records it parsed
 			// up to the failure point, which is better than nothing
 			// for callers that downstream process per-record.
-			all = append(all, items...)
-			continue
 		}
-		all = append(all, items...)
+		for _, r := range items {
+			if !yield(r) {
+				return false, nil
+			}
+		}
 	}
-	return all, nil
+	return true, nil
 }

--- a/go/internal/structure/extract_stream_test.go
+++ b/go/internal/structure/extract_stream_test.go
@@ -1,0 +1,234 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package structure
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+const streamTestURL = "https://sq.test/"
+
+// writeChunks creates a task directory containing one results.N.jsonl file
+// per chunk. Production writes one chunk file per source-code record, so
+// multi-chunk tasks are the norm rather than the exception — every other
+// fixture in the repo hardcodes results.1.jsonl and so never exercised it.
+func writeChunks(t *testing.T, taskDir string, chunks [][]string) {
+	t.Helper()
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i, lines := range chunks {
+		name := filepath.Join(taskDir, "results."+strconv.Itoa(i+1)+".jsonl")
+		var buf []byte
+		for _, l := range lines {
+			buf = append(buf, l...)
+			buf = append(buf, '\n')
+		}
+		if err := os.WriteFile(name, buf, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// oneExtract builds <root>/extract-01/<task>/ with the given chunks and
+// returns the root plus a mapping pointing at it.
+func oneExtract(t *testing.T, task string, chunks [][]string) (string, ExtractMapping) {
+	t.Helper()
+	root := t.TempDir()
+	writeChunks(t, filepath.Join(root, "extract-01", task), chunks)
+	return root, ExtractMapping{streamTestURL: "extract-01"}
+}
+
+func collect(seq func(func(ExtractItem) bool)) []ExtractItem {
+	var out []ExtractItem
+	for it := range seq {
+		out = append(out, it)
+	}
+	return out
+}
+
+// The wrapper must return exactly what the iterator yields, in the same
+// order — that equivalence is what lets ~126 cold call sites keep using
+// ReadExtractData unchanged.
+func TestExtractItemsMatchesReadExtractDataAcrossChunks(t *testing.T) {
+	root, mapping := oneExtract(t, "getProjectSourceCode", [][]string{
+		{`{"k":"a1"}`, `{"k":"a2"}`},
+		{`{"k":"b1"}`},
+		{`{"k":"c1"}`, `{"k":"c2"}`, `{"k":"c3"}`},
+	})
+
+	streamed := collect(ExtractItems(root, mapping, "getProjectSourceCode"))
+	slurped, err := ReadExtractData(root, mapping, "getProjectSourceCode")
+	if err != nil {
+		t.Fatalf("ReadExtractData: %v", err)
+	}
+
+	if len(streamed) != 6 {
+		t.Fatalf("streamed %d records, want 6", len(streamed))
+	}
+	if len(slurped) != len(streamed) {
+		t.Fatalf("ReadExtractData returned %d, ExtractItems yielded %d", len(slurped), len(streamed))
+	}
+	for i := range streamed {
+		if string(streamed[i].Data) != string(slurped[i].Data) {
+			t.Errorf("record %d: streamed %s, slurped %s", i, streamed[i].Data, slurped[i].Data)
+		}
+		if streamed[i].ServerURL != slurped[i].ServerURL {
+			t.Errorf("record %d: serverURL %q vs %q", i, streamed[i].ServerURL, slurped[i].ServerURL)
+		}
+	}
+}
+
+// results.10.jsonl sorts lexically before results.2.jsonl. That ordering is
+// irrelevant for tasks that get sorted downstream, but not for the callers
+// that index element [0], so pin that streaming preserves it rather than
+// leaving the equivalence assumed.
+func TestExtractItemsPreservesReadDirOrdering(t *testing.T) {
+	chunks := make([][]string, 10)
+	for i := range chunks {
+		chunks[i] = []string{`{"chunk":` + strconv.Itoa(i+1) + `}`}
+	}
+	root, mapping := oneExtract(t, "task", chunks)
+
+	streamed := collect(ExtractItems(root, mapping, "task"))
+	slurped, err := ReadExtractData(root, mapping, "task")
+	if err != nil {
+		t.Fatalf("ReadExtractData: %v", err)
+	}
+	for i := range streamed {
+		if string(streamed[i].Data) != string(slurped[i].Data) {
+			t.Fatalf("order diverged at %d: %s vs %s", i, streamed[i].Data, slurped[i].Data)
+		}
+	}
+	// Sanity: confirm this fixture really does exercise the lexical quirk.
+	if string(streamed[1].Data) != `{"chunk":10}` {
+		t.Errorf("expected results.10 to sort second, got %s", streamed[1].Data)
+	}
+}
+
+// #314, at the iterator level: a single unreadable file must not abort the
+// task, and records from the readable files must still be yielded.
+func TestExtractItemsSkipsUnreadableFile(t *testing.T) {
+	root := t.TempDir()
+	taskDir := filepath.Join(root, "extract-01", "task")
+	writeChunks(t, taskDir, [][]string{{`{"k":"v1"}`, `{"k":"v2"}`}})
+
+	bad := filepath.Join(taskDir, "results.2.jsonl")
+	if err := os.WriteFile(bad, []byte(`{"k":"v3"}`+"\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(bad, 0o600) })
+
+	got := collect(ExtractItems(root, ExtractMapping{streamTestURL: "extract-01"}, "task"))
+	if len(got) != 2 {
+		t.Errorf("got %d records, want 2 from the readable file", len(got))
+	}
+}
+
+// An extract that never ran the task is skipped, and the other extract in
+// the mapping still contributes — this is why the missing-dir case must
+// stay an error internally rather than being silently treated as empty.
+func TestExtractItemsSkipsExtractMissingTaskDir(t *testing.T) {
+	root := t.TempDir()
+	writeChunks(t, filepath.Join(root, "extract-01", "task"), [][]string{{`{"k":"present"}`}})
+	// extract-02 exists but has no "task" directory.
+	if err := os.MkdirAll(filepath.Join(root, "extract-02", "other"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mapping := ExtractMapping{
+		streamTestURL:         "extract-01",
+		"https://other.test/": "extract-02",
+	}
+	got := collect(ExtractItems(root, mapping, "task"))
+	if len(got) != 1 {
+		t.Fatalf("got %d records, want 1", len(got))
+	}
+	if got[0].ServerURL != streamTestURL {
+		t.Errorf("serverURL = %q, want %q", got[0].ServerURL, streamTestURL)
+	}
+}
+
+// Breaking out must stop before the next chunk file is opened. The second
+// chunk is made unreadable: if iteration continued it would warn and the
+// record count would be wrong, so a clean early exit proves laziness — the
+// whole point of streaming.
+func TestExtractItemsStopsEarlyWithoutOpeningNextFile(t *testing.T) {
+	root := t.TempDir()
+	taskDir := filepath.Join(root, "extract-01", "task")
+	writeChunks(t, taskDir, [][]string{{`{"k":"first"}`}})
+
+	bad := filepath.Join(taskDir, "results.2.jsonl")
+	if err := os.WriteFile(bad, []byte(`{"k":"never-read"}`+"\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(bad, 0o600) })
+
+	var seen []string
+	for it := range ExtractItems(root, ExtractMapping{streamTestURL: "extract-01"}, "task") {
+		seen = append(seen, string(it.Data))
+		break
+	}
+
+	if len(seen) != 1 || seen[0] != `{"k":"first"}` {
+		t.Fatalf("got %v, want exactly the first record", seen)
+	}
+}
+
+// Stopping early must also abandon remaining extracts, not just remaining
+// files within one extract.
+func TestExtractItemsStopsEarlyAcrossExtracts(t *testing.T) {
+	root := t.TempDir()
+	writeChunks(t, filepath.Join(root, "extract-01", "task"), [][]string{{`{"n":1}`, `{"n":2}`}})
+	writeChunks(t, filepath.Join(root, "extract-02", "task"), [][]string{{`{"n":3}`, `{"n":4}`}})
+
+	mapping := ExtractMapping{
+		streamTestURL:         "extract-01",
+		"https://other.test/": "extract-02",
+	}
+
+	count := 0
+	for range ExtractItems(root, mapping, "task") {
+		count++
+		break
+	}
+	if count != 1 {
+		t.Errorf("yielded %d records after break, want 1", count)
+	}
+}
+
+// An empty mapping yields nothing rather than panicking.
+func TestExtractItemsEmptyMapping(t *testing.T) {
+	if got := collect(ExtractItems(t.TempDir(), ExtractMapping{}, "task")); len(got) != 0 {
+		t.Errorf("got %d records, want 0", len(got))
+	}
+}
+
+// The yielded Data must be usable as JSON, i.e. the raw message is not
+// aliased or truncated by chunk boundaries.
+func TestExtractItemsYieldsParseableRecords(t *testing.T) {
+	root, mapping := oneExtract(t, "task", [][]string{
+		{`{"key":"a","branch":"main"}`},
+		{`{"key":"b","branch":"dev"}`},
+	})
+
+	var keys []string
+	for it := range ExtractItems(root, mapping, "task") {
+		var rec struct {
+			Key string `json:"key"`
+		}
+		if err := json.Unmarshal(it.Data, &rec); err != nil {
+			t.Fatalf("unmarshal %s: %v", it.Data, err)
+		}
+		keys = append(keys, rec.Key)
+	}
+	if len(keys) != 2 || keys[0] != "a" || keys[1] != "b" {
+		t.Errorf("keys = %v, want [a b]", keys)
+	}
+}

--- a/go/internal/structure/extract_stream_test.go
+++ b/go/internal/structure/extract_stream_test.go
@@ -12,7 +12,16 @@ import (
 	"testing"
 )
 
-const streamTestURL = "https://sq.test/"
+const (
+	streamTestURL  = "https://sq.test/"
+	streamTestURL2 = "https://other.test/"
+
+	// Extract run directory names used by the fixtures.
+	extract01 = "extract-01"
+	extract02 = "extract-02"
+
+	taskSourceCode = "getProjectSourceCode"
+)
 
 // writeChunks creates a task directory containing one results.N.jsonl file
 // per chunk. Production writes one chunk file per source-code record, so
@@ -41,8 +50,8 @@ func writeChunks(t *testing.T, taskDir string, chunks [][]string) {
 func oneExtract(t *testing.T, task string, chunks [][]string) (string, ExtractMapping) {
 	t.Helper()
 	root := t.TempDir()
-	writeChunks(t, filepath.Join(root, "extract-01", task), chunks)
-	return root, ExtractMapping{streamTestURL: "extract-01"}
+	writeChunks(t, filepath.Join(root, extract01, task), chunks)
+	return root, ExtractMapping{streamTestURL: extract01}
 }
 
 func collect(seq func(func(ExtractItem) bool)) []ExtractItem {
@@ -57,14 +66,14 @@ func collect(seq func(func(ExtractItem) bool)) []ExtractItem {
 // order — that equivalence is what lets ~126 cold call sites keep using
 // ReadExtractData unchanged.
 func TestExtractItemsMatchesReadExtractDataAcrossChunks(t *testing.T) {
-	root, mapping := oneExtract(t, "getProjectSourceCode", [][]string{
+	root, mapping := oneExtract(t, taskSourceCode, [][]string{
 		{`{"k":"a1"}`, `{"k":"a2"}`},
 		{`{"k":"b1"}`},
 		{`{"k":"c1"}`, `{"k":"c2"}`, `{"k":"c3"}`},
 	})
 
-	streamed := collect(ExtractItems(root, mapping, "getProjectSourceCode"))
-	slurped, err := ReadExtractData(root, mapping, "getProjectSourceCode")
+	streamed := collect(ExtractItems(root, mapping, taskSourceCode))
+	slurped, err := ReadExtractData(root, mapping, taskSourceCode)
 	if err != nil {
 		t.Fatalf("ReadExtractData: %v", err)
 	}
@@ -116,7 +125,7 @@ func TestExtractItemsPreservesReadDirOrdering(t *testing.T) {
 // task, and records from the readable files must still be yielded.
 func TestExtractItemsSkipsUnreadableFile(t *testing.T) {
 	root := t.TempDir()
-	taskDir := filepath.Join(root, "extract-01", "task")
+	taskDir := filepath.Join(root, extract01, "task")
 	writeChunks(t, taskDir, [][]string{{`{"k":"v1"}`, `{"k":"v2"}`}})
 
 	bad := filepath.Join(taskDir, "results.2.jsonl")
@@ -125,7 +134,7 @@ func TestExtractItemsSkipsUnreadableFile(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(bad, 0o600) })
 
-	got := collect(ExtractItems(root, ExtractMapping{streamTestURL: "extract-01"}, "task"))
+	got := collect(ExtractItems(root, ExtractMapping{streamTestURL: extract01}, "task"))
 	if len(got) != 2 {
 		t.Errorf("got %d records, want 2 from the readable file", len(got))
 	}
@@ -136,15 +145,15 @@ func TestExtractItemsSkipsUnreadableFile(t *testing.T) {
 // stay an error internally rather than being silently treated as empty.
 func TestExtractItemsSkipsExtractMissingTaskDir(t *testing.T) {
 	root := t.TempDir()
-	writeChunks(t, filepath.Join(root, "extract-01", "task"), [][]string{{`{"k":"present"}`}})
+	writeChunks(t, filepath.Join(root, extract01, "task"), [][]string{{`{"k":"present"}`}})
 	// extract-02 exists but has no "task" directory.
-	if err := os.MkdirAll(filepath.Join(root, "extract-02", "other"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, extract02, "other"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	mapping := ExtractMapping{
-		streamTestURL:         "extract-01",
-		"https://other.test/": "extract-02",
+		streamTestURL:  extract01,
+		streamTestURL2: extract02,
 	}
 	got := collect(ExtractItems(root, mapping, "task"))
 	if len(got) != 1 {
@@ -161,7 +170,7 @@ func TestExtractItemsSkipsExtractMissingTaskDir(t *testing.T) {
 // whole point of streaming.
 func TestExtractItemsStopsEarlyWithoutOpeningNextFile(t *testing.T) {
 	root := t.TempDir()
-	taskDir := filepath.Join(root, "extract-01", "task")
+	taskDir := filepath.Join(root, extract01, "task")
 	writeChunks(t, taskDir, [][]string{{`{"k":"first"}`}})
 
 	bad := filepath.Join(taskDir, "results.2.jsonl")
@@ -171,7 +180,7 @@ func TestExtractItemsStopsEarlyWithoutOpeningNextFile(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(bad, 0o600) })
 
 	var seen []string
-	for it := range ExtractItems(root, ExtractMapping{streamTestURL: "extract-01"}, "task") {
+	for it := range ExtractItems(root, ExtractMapping{streamTestURL: extract01}, "task") {
 		seen = append(seen, string(it.Data))
 		break
 	}
@@ -185,12 +194,12 @@ func TestExtractItemsStopsEarlyWithoutOpeningNextFile(t *testing.T) {
 // files within one extract.
 func TestExtractItemsStopsEarlyAcrossExtracts(t *testing.T) {
 	root := t.TempDir()
-	writeChunks(t, filepath.Join(root, "extract-01", "task"), [][]string{{`{"n":1}`, `{"n":2}`}})
-	writeChunks(t, filepath.Join(root, "extract-02", "task"), [][]string{{`{"n":3}`, `{"n":4}`}})
+	writeChunks(t, filepath.Join(root, extract01, "task"), [][]string{{`{"n":1}`, `{"n":2}`}})
+	writeChunks(t, filepath.Join(root, extract02, "task"), [][]string{{`{"n":3}`, `{"n":4}`}})
 
 	mapping := ExtractMapping{
-		streamTestURL:         "extract-01",
-		"https://other.test/": "extract-02",
+		streamTestURL:  extract01,
+		streamTestURL2: extract02,
 	}
 
 	count := 0

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -12,6 +12,12 @@
       "default": 10,
       "description": "Default max parallel HTTP calls. Overridden per command by source.concurrency / target.concurrency."
     },
+    "project_data_build_concurrency": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 4,
+      "description": "Default max number of scanner reports built at once during project-data migration. Overridden by target.project_data_build_concurrency. Lower it if the migration runs out of memory on a large instance; raise it toward concurrency if report building is the bottleneck."
+    },
     "timeout": {
       "type": "integer",
       "minimum": 1,
@@ -155,6 +161,11 @@
           "type": ["integer", "null"],
           "minimum": 1,
           "description": "Override the top-level concurrency for migrate/reset calls."
+        },
+        "project_data_build_concurrency": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Override the top-level project_data_build_concurrency for migrate calls."
         },
         "timeout": {
           "type": ["integer", "null"],


### PR DESCRIPTION
This PR is to fix what appeared initially to be a memory leak but was later determined to be an issue with concurrency and go agent creation.

----
## Summary by Gitar

- **Memory management:**
    - Added automatic soft memory limit derivation from cgroup or system memory (`common.ApplyMemoryLimit` / `GOMEMLIMIT`) to prevent OOMs on large instances
    - Streamed project-data, metadata-sync, and predictive-report loaders chunk by chunk to reduce peak memory usage
    - Released report ZIP allocations immediately after submission before CE polling and separated branch metadata
- **Concurrency & scaling:**
    - Added `--project_data_build_concurrency` flag (default 4) to bound concurrent report construction during project-data migration
- **Testing:**
    - Added comprehensive test suites and benchmarks covering memory budget detection, streaming extracts, and task synchronization

<sub>This will update automatically on new commits.</sub>