### PR TITLE
Fix hunter-agent findings batch #1

### DIFF
--- a/go/cmd/reset.go
+++ b/go/cmd/reset.go
@@ -178,17 +178,10 @@ func confirmResetOrgs(exportDir string, autoYes bool, orgPattern string, presetO
 		return nil, err
 	}
 	if orgPattern != "" {
-		re, err := anchoredResetOrgPattern(orgPattern)
+		orgs, err = filterOrgsByPattern(orgs, orgPattern)
 		if err != nil {
-			return nil, fmt.Errorf("invalid --%s pattern %q: %w", flagResetOrganization, orgPattern, err)
+			return nil, err
 		}
-		var filtered []string
-		for _, o := range orgs {
-			if re.MatchString(o) {
-				filtered = append(filtered, o)
-			}
-		}
-		orgs = filtered
 		if len(orgs) == 0 {
 			return nil, fmt.Errorf("no SonarCloud organization key matches --%s %q in %s/organizations.csv", flagResetOrganization, orgPattern, exportDir)
 		}
@@ -203,35 +196,73 @@ func confirmResetOrgs(exportDir string, autoYes bool, orgPattern string, presetO
 		fmt.Fprintf(out, "  - %s (%d projects)\n", o, projCounts[o])
 	}
 
-	if autoYes {
-		if orgPattern == "" && len(presetOrgs) > 0 {
-			known := make(map[string]bool, len(orgs))
-			for _, o := range orgs {
-				known[o] = true
-			}
-			var confirmed, unknown []string
-			seen := make(map[string]bool, len(presetOrgs))
-			for _, p := range presetOrgs {
-				if seen[p] {
-					continue
-				}
-				seen[p] = true
-				if known[p] {
-					confirmed = append(confirmed, p)
-				} else {
-					unknown = append(unknown, p)
-				}
-			}
-			if len(unknown) > 0 {
-				return nil, fmt.Errorf("confirmed_orgs from config file contains unknown org key(s): %q — must be one of the listed orgs", strings.Join(unknown, ", "))
-			}
-			sort.Strings(confirmed)
-			fmt.Fprintf(out, "Using confirmed_orgs from config file: %s\n", strings.Join(confirmed, ", "))
-			return confirmed, nil
-		}
-		return orgs, nil
+	known := make(map[string]bool, len(orgs))
+	for _, o := range orgs {
+		known[o] = true
 	}
 
+	if autoYes {
+		return confirmResetOrgsAutoYes(orgs, orgPattern, presetOrgs, known, out)
+	}
+	return confirmResetOrgsInteractive(known, in, out)
+}
+
+// filterOrgsByPattern narrows orgs to those whose key fully matches the
+// anchored --organization regex pattern (#550).
+func filterOrgsByPattern(orgs []string, orgPattern string) ([]string, error) {
+	re, err := anchoredResetOrgPattern(orgPattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --%s pattern %q: %w", flagResetOrganization, orgPattern, err)
+	}
+	var filtered []string
+	for _, o := range orgs {
+		if re.MatchString(o) {
+			filtered = append(filtered, o)
+		}
+	}
+	return filtered, nil
+}
+
+// resolveOrgSelection deduplicates candidates (first-seen order) and
+// splits them into those present in known vs. not. Shared by the
+// interactive-typed-input path and the config-file presetOrgs path,
+// which otherwise repeat the identical dedupe-and-classify logic.
+func resolveOrgSelection(candidates []string, known map[string]bool) (confirmed, unknown []string) {
+	seen := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		if seen[c] {
+			continue
+		}
+		seen[c] = true
+		if known[c] {
+			confirmed = append(confirmed, c)
+		} else {
+			unknown = append(unknown, c)
+		}
+	}
+	return confirmed, unknown
+}
+
+// confirmResetOrgsAutoYes implements the --yes shortcut: honor a
+// config-file confirmed_orgs selection when present and --organization
+// didn't already narrow the list, else return every candidate org.
+func confirmResetOrgsAutoYes(orgs []string, orgPattern string, presetOrgs []string, known map[string]bool, out io.Writer) ([]string, error) {
+	if orgPattern == "" && len(presetOrgs) > 0 {
+		confirmed, unknown := resolveOrgSelection(presetOrgs, known)
+		if len(unknown) > 0 {
+			return nil, fmt.Errorf("confirmed_orgs from config file contains unknown org key(s): %q — must be one of the listed orgs", strings.Join(unknown, ", "))
+		}
+		sort.Strings(confirmed)
+		fmt.Fprintf(out, "Using confirmed_orgs from config file: %s\n", strings.Join(confirmed, ", "))
+		return confirmed, nil
+	}
+	return orgs, nil
+}
+
+// confirmResetOrgsInteractive prompts the operator to type the org keys
+// to reset, aborting cleanly on an empty line/EOF and erroring on any
+// unknown key.
+func confirmResetOrgsInteractive(known map[string]bool, in io.Reader, out io.Writer) ([]string, error) {
 	fmt.Fprint(out, "\nType the org keys to reset (whitespace-separated), or press [Enter] to abort: ")
 	reader := bufio.NewReader(in)
 	line, err := reader.ReadString('\n')
@@ -244,24 +275,7 @@ func confirmResetOrgs(exportDir string, autoYes bool, orgPattern string, presetO
 		return nil, nil
 	}
 
-	known := make(map[string]bool, len(orgs))
-	for _, o := range orgs {
-		known[o] = true
-	}
-
-	var confirmed, unknown []string
-	seen := make(map[string]bool, len(typed))
-	for _, t := range typed {
-		if seen[t] {
-			continue
-		}
-		seen[t] = true
-		if known[t] {
-			confirmed = append(confirmed, t)
-		} else {
-			unknown = append(unknown, t)
-		}
-	}
+	confirmed, unknown := resolveOrgSelection(typed, known)
 	if len(unknown) > 0 {
 		return nil, fmt.Errorf("unknown org key(s): %q — must be one of the listed orgs", strings.Join(unknown, ", "))
 	}

--- a/go/cmd/reset.go
+++ b/go/cmd/reset.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -18,6 +19,18 @@ import (
 )
 
 const flagResetYes = "yes"
+
+// flagResetOrganization narrows the candidate SonarCloud organizations
+// considered for reset to those whose key fully matches the given
+// pattern (#550). Applied before confirmResetOrgs's prompt / --yes
+// branch, mirroring --project_key's anchored-regex semantics on
+// transfer (see anchoredResetOrgPattern).
+const flagResetOrganization = "organization"
+
+// flagResetDryRun causes the reset command to build and print the
+// reset plan (organizations in scope, tasks that would run) without
+// making any destructive API call (#550).
+const flagResetDryRun = "dry-run"
 
 var resetCmd = &cobra.Command{
 	Use:   "reset [token] [enterprise_key]",
@@ -34,8 +47,15 @@ var resetCmd = &cobra.Command{
 		}
 
 		autoYes, _ := cmd.Flags().GetBool(flagResetYes)
+		orgPattern, _ := cmd.Flags().GetString(flagResetOrganization)
+		dryRun, _ := cmd.Flags().GetBool(flagResetDryRun)
+
 		fmt.Fprintln(os.Stdout, "WARNING: This will delete migrated entities from the listed SonarCloud organizations.")
-		confirmed, err := confirmResetOrgs(cfg.ExportDirectory, autoYes, os.Stdin, os.Stdout)
+		// cfg.ConfirmedOrgs may already carry a config-file-supplied
+		// confirmed_orgs list (#550) — pass it through as the preset so
+		// a --yes run without --organization can honor it instead of
+		// defaulting to "every mapped org".
+		confirmed, err := confirmResetOrgs(cfg.ExportDirectory, autoYes, orgPattern, cfg.ConfirmedOrgs, os.Stdin, os.Stdout)
 		if err != nil {
 			return err
 		}
@@ -46,11 +66,14 @@ var resetCmd = &cobra.Command{
 			return nil
 		}
 		cfg.ConfirmedOrgs = confirmed
+		cfg.DryRun = dryRun
 
 		if err := migrate.RunReset(cmd.Context(), cfg); err != nil {
 			return err
 		}
-		printExportDirNotice(cfg.ExportDirectory)
+		if !dryRun {
+			printExportDirNotice(cfg.ExportDirectory)
+		}
 		return nil
 	},
 }
@@ -66,6 +89,8 @@ func init() {
 	f.Int("concurrency", 25, "Maximum number of concurrent requests")
 	f.String("export_directory", DefaultExportDirectory, "Directory to place all interim files")
 	f.Bool(flagResetYes, false, "Skip the interactive confirmation prompt and reset every listed organization (intended for non-interactive / scripted use). #381.")
+	f.String(flagResetOrganization, "", "Regexp (anchored full-match) narrowing the candidate organizations to reset to those whose sonarcloud_org_key matches, applied before the confirmation prompt / --yes. E.g. \"BANKING_.+\" matches every org key starting with BANKING_. #550.")
+	f.Bool(flagResetDryRun, false, "Print which organizations are in scope and which tasks would run, without deleting anything. #550.")
 }
 
 func buildResetConfig(cmd *cobra.Command, args []string) (migrate.ResetConfig, error) {
@@ -108,6 +133,16 @@ func buildResetConfig(cmd *cobra.Command, args []string) (migrate.ResetConfig, e
 	return cfg, nil
 }
 
+// anchoredResetOrgPattern compiles pattern as a full-match regex,
+// implicitly anchored with ^ and $ (#550, mirroring #529's
+// anchoredProjectKeyPattern on transfer) — "BANKING_.+" matches only
+// org keys starting with "BANKING_", never a key with that substring
+// somewhere in the middle. A plain literal org key with no regex
+// metacharacters matches only itself.
+func anchoredResetOrgPattern(pattern string) (*regexp.Regexp, error) {
+	return regexp.Compile("^(?:" + pattern + ")$")
+}
+
 // confirmResetOrgs gates the destructive reset behind an interactive
 // confirmation prompt (#381). It lists every mapped SonarCloud org
 // with its project count and asks the operator to type the subset
@@ -119,13 +154,44 @@ func buildResetConfig(cmd *cobra.Command, args []string) (migrate.ResetConfig, e
 //   - (nil, err) on a malformed selection (unknown org key, etc.)
 //     or an underlying read / CSV failure.
 //
-// When autoYes is true, the helper prints the same list but skips
-// the prompt and returns every org — for non-interactive callers
-// (CI, scripts) that have already taken responsibility for the wipe.
-func confirmResetOrgs(exportDir string, autoYes bool, in io.Reader, out io.Writer) ([]string, error) {
+// orgPattern, when non-empty, is compiled as an anchored full-match
+// regex (#550, see anchoredResetOrgPattern) and narrows the candidate
+// org list down to matching keys BEFORE anything else in this function
+// runs — the prompt, the --yes shortcut, and presetOrgs all only ever
+// see the filtered set.
+//
+// presetOrgs is an optional config-file-supplied confirmed_orgs list
+// (#550). When autoYes is true and orgPattern is empty, a non-empty
+// presetOrgs is validated against the candidate list and used directly
+// instead of "every candidate org" — letting a config-driven --yes run
+// honor a scoped selection instead of defaulting to the whole
+// enterprise. presetOrgs is ignored in every other case (interactive
+// prompt, or when --organization already narrowed the list).
+//
+// When autoYes is true and neither orgPattern nor presetOrgs apply,
+// the helper prints the candidate list but skips the prompt and
+// returns every candidate org — for non-interactive callers (CI,
+// scripts) that have already taken responsibility for the wipe.
+func confirmResetOrgs(exportDir string, autoYes bool, orgPattern string, presetOrgs []string, in io.Reader, out io.Writer) ([]string, error) {
 	orgs, err := loadResetTargetOrgs(exportDir)
 	if err != nil {
 		return nil, err
+	}
+	if orgPattern != "" {
+		re, err := anchoredResetOrgPattern(orgPattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --%s pattern %q: %w", flagResetOrganization, orgPattern, err)
+		}
+		var filtered []string
+		for _, o := range orgs {
+			if re.MatchString(o) {
+				filtered = append(filtered, o)
+			}
+		}
+		orgs = filtered
+		if len(orgs) == 0 {
+			return nil, fmt.Errorf("no SonarCloud organization key matches --%s %q in %s/organizations.csv", flagResetOrganization, orgPattern, exportDir)
+		}
 	}
 	if len(orgs) == 0 {
 		return nil, fmt.Errorf("no SonarCloud organizations found in %s/organizations.csv — nothing to reset", exportDir)
@@ -138,6 +204,31 @@ func confirmResetOrgs(exportDir string, autoYes bool, in io.Reader, out io.Write
 	}
 
 	if autoYes {
+		if orgPattern == "" && len(presetOrgs) > 0 {
+			known := make(map[string]bool, len(orgs))
+			for _, o := range orgs {
+				known[o] = true
+			}
+			var confirmed, unknown []string
+			seen := make(map[string]bool, len(presetOrgs))
+			for _, p := range presetOrgs {
+				if seen[p] {
+					continue
+				}
+				seen[p] = true
+				if known[p] {
+					confirmed = append(confirmed, p)
+				} else {
+					unknown = append(unknown, p)
+				}
+			}
+			if len(unknown) > 0 {
+				return nil, fmt.Errorf("confirmed_orgs from config file contains unknown org key(s): %q — must be one of the listed orgs", strings.Join(unknown, ", "))
+			}
+			sort.Strings(confirmed)
+			fmt.Fprintf(out, "Using confirmed_orgs from config file: %s\n", strings.Join(confirmed, ", "))
+			return confirmed, nil
+		}
 		return orgs, nil
 	}
 

--- a/go/cmd/reset.go
+++ b/go/cmd/reset.go
@@ -50,12 +50,20 @@ var resetCmd = &cobra.Command{
 		orgPattern, _ := cmd.Flags().GetString(flagResetOrganization)
 		dryRun, _ := cmd.Flags().GetBool(flagResetDryRun)
 
-		fmt.Fprintln(os.Stdout, "WARNING: This will delete migrated entities from the listed SonarCloud organizations.")
+		if dryRun {
+			fmt.Fprintln(os.Stdout, "Dry run: no organizations will be modified.")
+		} else {
+			fmt.Fprintln(os.Stdout, "WARNING: This will delete migrated entities from the listed SonarCloud organizations.")
+		}
 		// cfg.ConfirmedOrgs may already carry a config-file-supplied
 		// confirmed_orgs list (#550) — pass it through as the preset so
 		// a --yes run without --organization can honor it instead of
-		// defaulting to "every mapped org".
-		confirmed, err := confirmResetOrgs(cfg.ExportDirectory, autoYes, orgPattern, cfg.ConfirmedOrgs, os.Stdin, os.Stdout)
+		// defaulting to "every mapped org". A dry run previews the plan
+		// without deleting anything, so it also skips the interactive
+		// "type the org keys to confirm" prompt — there's nothing to
+		// confirm — and takes the (possibly --organization-filtered)
+		// candidate list the same way --yes does.
+		confirmed, err := confirmResetOrgs(cfg.ExportDirectory, autoYes || dryRun, orgPattern, cfg.ConfirmedOrgs, os.Stdin, os.Stdout)
 		if err != nil {
 			return err
 		}

--- a/go/cmd/reset_test.go
+++ b/go/cmd/reset_test.go
@@ -272,7 +272,7 @@ func TestConfirmResetOrgs_HappyPathSubset(t *testing.T) {
 
 	var out bytes.Buffer
 	in := strings.NewReader("cloud-a cloud-b\n")
-	got, err := confirmResetOrgs(dir, false, in, &out)
+	got, err := confirmResetOrgs(dir, false, "", nil, in, &out)
 	if err != nil {
 		t.Fatalf("confirmResetOrgs: %v", err)
 	}
@@ -313,7 +313,7 @@ func TestConfirmResetOrgs_CollapsesWhitespace(t *testing.T) {
 	dir := writeResetFixture(t,
 		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,cloud-b\n", "")
 
-	got, err := confirmResetOrgs(dir, false, strings.NewReader("   cloud-a    cloud-b   \n"), io.Discard)
+	got, err := confirmResetOrgs(dir, false, "", nil, strings.NewReader("   cloud-a    cloud-b   \n"), io.Discard)
 	if err != nil {
 		t.Fatalf("confirmResetOrgs: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestConfirmResetOrgs_EmptyEnterAborts(t *testing.T) {
 		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\n", "")
 
 	var out bytes.Buffer
-	got, err := confirmResetOrgs(dir, false, strings.NewReader("\n"), &out)
+	got, err := confirmResetOrgs(dir, false, "", nil, strings.NewReader("\n"), &out)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestConfirmResetOrgs_EOFAborts(t *testing.T) {
 		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\n", "")
 
 	// Empty reader → immediate EOF; treated the same as Enter alone.
-	got, err := confirmResetOrgs(dir, false, strings.NewReader(""), io.Discard)
+	got, err := confirmResetOrgs(dir, false, "", nil, strings.NewReader(""), io.Discard)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -357,7 +357,7 @@ func TestConfirmResetOrgs_UnknownKeyError(t *testing.T) {
 	dir := writeResetFixture(t,
 		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\n", "")
 
-	_, err := confirmResetOrgs(dir, false, strings.NewReader("cloud-a typo-org\n"), io.Discard)
+	_, err := confirmResetOrgs(dir, false, "", nil, strings.NewReader("cloud-a typo-org\n"), io.Discard)
 	if err == nil {
 		t.Fatal("expected error for unknown key, got nil")
 	}
@@ -370,7 +370,7 @@ func TestConfirmResetOrgs_DedupsInput(t *testing.T) {
 	dir := writeResetFixture(t,
 		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,cloud-b\n", "")
 
-	got, err := confirmResetOrgs(dir, false, strings.NewReader("cloud-a cloud-a cloud-b cloud-a\n"), io.Discard)
+	got, err := confirmResetOrgs(dir, false, "", nil, strings.NewReader("cloud-a cloud-a cloud-b cloud-a\n"), io.Discard)
 	if err != nil {
 		t.Fatalf("confirmResetOrgs: %v", err)
 	}
@@ -386,7 +386,7 @@ func TestConfirmResetOrgs_AutoYesSkipsPrompt(t *testing.T) {
 	// Reader returns content that would normally be parsed; autoYes
 	// must take precedence and never read from it.
 	in := strings.NewReader("this-should-not-be-read\n")
-	got, err := confirmResetOrgs(dir, true, in, io.Discard)
+	got, err := confirmResetOrgs(dir, true, "", nil, in, io.Discard)
 	if err != nil {
 		t.Fatalf("confirmResetOrgs: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestConfirmResetOrgs_SkipsSkippedSentinel(t *testing.T) {
 		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,SKIPPED\norg3,\n", "")
 
 	var out bytes.Buffer
-	got, err := confirmResetOrgs(dir, true, strings.NewReader(""), &out)
+	got, err := confirmResetOrgs(dir, true, "", nil, strings.NewReader(""), &out)
 	if err != nil {
 		t.Fatalf("confirmResetOrgs: %v", err)
 	}
@@ -423,8 +423,142 @@ func TestConfirmResetOrgs_SkipsSkippedSentinel(t *testing.T) {
 func TestConfirmResetOrgs_EmptyOrgsCSVErrors(t *testing.T) {
 	// No organizations.csv → cannot continue.
 	dir := t.TempDir()
-	_, err := confirmResetOrgs(dir, false, strings.NewReader(""), io.Discard)
+	_, err := confirmResetOrgs(dir, false, "", nil, strings.NewReader(""), io.Discard)
 	if err == nil {
 		t.Fatal("expected error when organizations.csv is missing")
+	}
+}
+
+// #550: --organization narrows the candidate org list to those whose
+// key fully matches the pattern, BEFORE the prompt / --yes branch ever
+// runs — mirroring transfer's --project_key anchored-regex tests
+// (TestResolveTransferProjectKeys_PatternMatchesAnchored et al.).
+
+func TestConfirmResetOrgs_OrganizationFilterNarrowsCandidates(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,cloud-b\norg3,cloud-c\n", "")
+
+	var out bytes.Buffer
+	got, err := confirmResetOrgs(dir, true, "cloud-a|cloud-b", nil, strings.NewReader(""), &out)
+	if err != nil {
+		t.Fatalf("confirmResetOrgs: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"cloud-a", "cloud-b"}) {
+		t.Errorf("got %+v, want [cloud-a cloud-b]", got)
+	}
+	if strings.Contains(out.String(), "cloud-c") {
+		t.Errorf("cloud-c should have been filtered out by --organization before display, got:\n%s", out.String())
+	}
+}
+
+// A pattern is always compiled as a full-match anchored regex (#529's
+// convention, replicated for --organization): "cloud-a" must not also
+// match "cloud-ab" as a substring.
+func TestConfirmResetOrgs_OrganizationFilterIsAnchored(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,cloud-ab\n", "")
+
+	got, err := confirmResetOrgs(dir, true, "cloud-a", nil, strings.NewReader(""), io.Discard)
+	if err != nil {
+		t.Fatalf("confirmResetOrgs: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"cloud-a"}) {
+		t.Errorf("got %+v, want [cloud-a] (anchored match must exclude cloud-ab)", got)
+	}
+}
+
+func TestConfirmResetOrgs_OrganizationFilterInvalidRegexErrors(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\n", "")
+
+	_, err := confirmResetOrgs(dir, true, "(unterminated", nil, strings.NewReader(""), io.Discard)
+	if err == nil {
+		t.Fatal("expected error for invalid --organization regex")
+	}
+}
+
+func TestConfirmResetOrgs_OrganizationFilterNoMatchErrors(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\n", "")
+
+	_, err := confirmResetOrgs(dir, true, "no-such-org", nil, strings.NewReader(""), io.Discard)
+	if err == nil {
+		t.Fatal("expected error when --organization matches no mapped org")
+	}
+	if !strings.Contains(err.Error(), "no-such-org") {
+		t.Errorf("error %q should name the pattern", err.Error())
+	}
+}
+
+// #550: the --organization filter also narrows the interactive prompt's
+// candidate list, not just the --yes shortcut.
+func TestConfirmResetOrgs_OrganizationFilterAppliesToInteractivePrompt(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,cloud-b\n", "")
+
+	// Typing the filtered-out org must be treated as unknown, since it
+	// was never displayed as a candidate.
+	_, err := confirmResetOrgs(dir, false, "cloud-a", nil, strings.NewReader("cloud-b\n"), io.Discard)
+	if err == nil {
+		t.Fatal("expected error: cloud-b was filtered out by --organization and should be unknown")
+	}
+}
+
+// #550: when --yes is used, --organization is absent, and the config
+// file already supplied confirmed_orgs, the config-file selection wins
+// over "reset every mapped org."
+func TestConfirmResetOrgs_PresetOrgsUsedWithYesWhenNoOrganizationFlag(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,cloud-b\norg3,cloud-c\n", "")
+
+	got, err := confirmResetOrgs(dir, true, "", []string{"cloud-a", "cloud-c"}, strings.NewReader(""), io.Discard)
+	if err != nil {
+		t.Fatalf("confirmResetOrgs: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"cloud-a", "cloud-c"}) {
+		t.Errorf("got %+v, want [cloud-a cloud-c]", got)
+	}
+}
+
+// --organization takes precedence over a config-file confirmed_orgs
+// preset when both are present.
+func TestConfirmResetOrgs_OrganizationFlagWinsOverPresetOrgs(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,cloud-b\n", "")
+
+	got, err := confirmResetOrgs(dir, true, "cloud-b", []string{"cloud-a"}, strings.NewReader(""), io.Discard)
+	if err != nil {
+		t.Fatalf("confirmResetOrgs: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"cloud-b"}) {
+		t.Errorf("got %+v, want [cloud-b] (--organization should win over config confirmed_orgs)", got)
+	}
+}
+
+func TestConfirmResetOrgs_PresetOrgsUnknownKeyErrors(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\n", "")
+
+	_, err := confirmResetOrgs(dir, true, "", []string{"cloud-a", "typo-org"}, strings.NewReader(""), io.Discard)
+	if err == nil {
+		t.Fatal("expected error for unknown confirmed_orgs key from config file")
+	}
+	if !strings.Contains(err.Error(), "typo-org") {
+		t.Errorf("error %q does not mention the typo'd key", err.Error())
+	}
+}
+
+// presetOrgs only applies to the --yes shortcut; the interactive prompt
+// must still ask, ignoring any config-file preset.
+func TestConfirmResetOrgs_PresetOrgsIgnoredWhenNotAutoYes(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,cloud-b\n", "")
+
+	got, err := confirmResetOrgs(dir, false, "", []string{"cloud-a"}, strings.NewReader("cloud-b\n"), io.Discard)
+	if err != nil {
+		t.Fatalf("confirmResetOrgs: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"cloud-b"}) {
+		t.Errorf("got %+v, want [cloud-b] (interactive prompt wins; presetOrgs only applies to --yes)", got)
 	}
 }

--- a/go/internal/common/runid.go
+++ b/go/internal/common/runid.go
@@ -80,19 +80,24 @@ func splitRunSuffix(id string) (prefix string, num int, ok bool) {
 	return id[:i], n, true
 }
 
-// runIDPattern matches exactly the shape GenerateRunID produces:
-// "YYYY-MM-DD-N" where N is one or more digits (unpadded past 9999,
-// per the #542 fix — see GenerateRunID).
-var runIDPattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}-\d+$`)
+// runIDPattern matches the shape GenerateRunID produces today
+// ("YYYY-MM-DD-N", N unpadded past 9999 per the #542 fix) as well as
+// the historical "MM-DD-YYYY-N" naming used before issue #108, which
+// still exists in export directories on users' disks — see the
+// identical pattern in internal/gui/history.go and
+// internal/regtest/suite.go. A directory in either shape is a
+// legitimate candidate; anything else is not.
+var runIDPattern = regexp.MustCompile(`^(\d{2}-\d{2}-\d{4}|\d{4}-\d{2}-\d{2})-\d+$`)
 
-// IsValidRunID reports whether id has exactly the shape GenerateRunID
-// produces. Callers that treat directory names as candidate run IDs
-// (e.g. structure.buildURLMappings) should use this to reject anything
-// else before it ever reaches RunIDAfter: since real run IDs always
-// start with a digit and any letter sorts above any digit in ASCII, a
-// non-conforming name (e.g. a directory an attacker planted, like
-// "zzz-evil") would otherwise win RunIDAfter's plain-string-compare
-// fallback over every legitimate dated run (#550).
+// IsValidRunID reports whether id has the shape GenerateRunID produces
+// today, or the legacy pre-#108 shape still found on disk (see
+// runIDPattern). Callers that treat directory names as candidate run
+// IDs (e.g. structure.buildURLMappings) should use this to reject
+// anything else before it ever reaches RunIDAfter: since every
+// legitimate run ID shape starts with a digit and any letter sorts
+// above any digit in ASCII, a non-conforming name (e.g. a directory an
+// attacker planted, like "zzz-evil") would otherwise win RunIDAfter's
+// plain-string-compare fallback over every legitimate dated run (#550).
 func IsValidRunID(id string) bool {
 	return runIDPattern.MatchString(id)
 }

--- a/go/internal/common/runid.go
+++ b/go/internal/common/runid.go
@@ -7,6 +7,7 @@ package common
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -77,4 +78,21 @@ func splitRunSuffix(id string) (prefix string, num int, ok bool) {
 		return "", 0, false
 	}
 	return id[:i], n, true
+}
+
+// runIDPattern matches exactly the shape GenerateRunID produces:
+// "YYYY-MM-DD-N" where N is one or more digits (unpadded past 9999,
+// per the #542 fix — see GenerateRunID).
+var runIDPattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}-\d+$`)
+
+// IsValidRunID reports whether id has exactly the shape GenerateRunID
+// produces. Callers that treat directory names as candidate run IDs
+// (e.g. structure.buildURLMappings) should use this to reject anything
+// else before it ever reaches RunIDAfter: since real run IDs always
+// start with a digit and any letter sorts above any digit in ASCII, a
+// non-conforming name (e.g. a directory an attacker planted, like
+// "zzz-evil") would otherwise win RunIDAfter's plain-string-compare
+// fallback over every legitimate dated run (#550).
+func IsValidRunID(id string) bool {
+	return runIDPattern.MatchString(id)
 }

--- a/go/internal/common/runid_test.go
+++ b/go/internal/common/runid_test.go
@@ -183,6 +183,10 @@ func TestIsValidRunID(t *testing.T) {
 	}{
 		{"2026-08-27-0001", true},
 		{"2026-08-27-101", true},
+		// Legacy pre-#108 MM-DD-YYYY-N naming still exists in export
+		// directories on users' disks and must still be accepted (#551
+		// follow-up — the ISO-only pattern silently dropped these).
+		{"08-27-2026-0001", true},
 		{"zzz-evil", false},
 		{"", false},
 		{"2026-08-27", false},

--- a/go/internal/common/runid_test.go
+++ b/go/internal/common/runid_test.go
@@ -172,6 +172,28 @@ func testGenerateRunID_CrossesPast99(t *testing.T) {
 	}
 }
 
+// TestIsValidRunID exercises the format guard added for #550: a
+// directory name accepted as a run-ID candidate must be shaped exactly
+// like GenerateRunID's output, or it can hijack RunIDAfter's
+// plain-string-compare fallback (see IsValidRunID's doc).
+func TestIsValidRunID(t *testing.T) {
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"2026-08-27-0001", true},
+		{"2026-08-27-101", true},
+		{"zzz-evil", false},
+		{"", false},
+		{"2026-08-27", false},
+	}
+	for _, c := range cases {
+		if got := IsValidRunID(c.id); got != c.want {
+			t.Errorf("IsValidRunID(%q) = %v, want %v", c.id, got, c.want)
+		}
+	}
+}
+
 // TestGenerateRunID_ISOFormatShape pins the overall shape produced for
 // a fresh directory: an ISO YYYY-MM-DD date prefix (not the historical
 // MM-DD-YYYY format), followed by a four-digit, zero-padded sequence

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -58,6 +58,14 @@ type configFileShape struct {
 	// and back-linked, current behavior). Same FlexibleBool semantics as
 	// skip_issue_sync.
 	FastSync *FlexibleBool `json:"fast_sync"`
+	// ConfirmedOrgs is reset-only: it additively pre-populates
+	// ResetConfig.ConfirmedOrgs (#550) for config-driven / programmatic
+	// callers that don't go through cmd/reset.go's interactive
+	// confirmation prompt or --organization flag. Ignored by
+	// toMigrateConfig / MigrateConfig. See toResetConfig for the
+	// outer-wins-else-nested-"migrate" resolution (mirrors
+	// skip_issue_sync's precedence).
+	ConfirmedOrgs []string `json:"confirmed_orgs"`
 
 	// Shape 2 (command-sectioned).
 	Migrate *configFileShape `json:"migrate"`
@@ -309,7 +317,7 @@ func (sc sonarCloudBlock) toMigrateConfig(settings *settingsBlock) MigrateConfig
 
 func (s configFileShape) toResetConfig() ResetConfig {
 	m := s.toMigrateConfig()
-	return ResetConfig{
+	cfg := ResetConfig{
 		Token:           m.Token,
 		EnterpriseKey:   m.EnterpriseKey,
 		Edition:         m.Edition,
@@ -318,6 +326,18 @@ func (s configFileShape) toResetConfig() ResetConfig {
 		ExportDirectory: m.ExportDirectory,
 		Debug:           m.Debug,
 	}
+	// #550 — confirmed_orgs is additive and reset-only (see the field's
+	// doc comment on configFileShape); it does not flow through
+	// MigrateConfig. Outer-level value wins when set, mirroring
+	// skip_issue_sync's outer-wins-else-inner semantics; otherwise fall
+	// back to a nested "migrate" section's value (shape 2).
+	switch {
+	case len(s.ConfirmedOrgs) > 0:
+		cfg.ConfirmedOrgs = s.ConfirmedOrgs
+	case s.Migrate != nil && len(s.Migrate.ConfirmedOrgs) > 0:
+		cfg.ConfirmedOrgs = s.Migrate.ConfirmedOrgs
+	}
+	return cfg
 }
 
 // LoadSonarCloudOrgsFromConfigFile returns the organizations list from a

--- a/go/internal/migrate/config_file_test.go
+++ b/go/internal/migrate/config_file_test.go
@@ -511,6 +511,78 @@ func TestLoadResetConfigFileUnifiedShape(t *testing.T) {
 	}
 }
 
+// #550: toResetConfig must populate ResetConfig.ConfirmedOrgs from a
+// flat config file's top-level confirmed_orgs field — an additive path
+// for config-driven / programmatic callers that don't go through
+// cmd/reset.go's interactive confirmation prompt.
+func TestLoadResetConfigFile_ConfirmedOrgsFlatShape(t *testing.T) {
+	content := `{
+  "token": "tok",
+  "enterprise_key": "ent",
+  "confirmed_orgs": ["cloud-a", "cloud-b"]
+}`
+	cfg, err := LoadResetConfigFile(writeConfigFixture(t, content))
+	if err != nil {
+		t.Fatalf("LoadResetConfigFile: %v", err)
+	}
+	want := []string{"cloud-a", "cloud-b"}
+	if !reflect.DeepEqual(cfg.ConfirmedOrgs, want) {
+		t.Errorf("ConfirmedOrgs: got %+v, want %+v", cfg.ConfirmedOrgs, want)
+	}
+}
+
+// confirmed_orgs is also honored inside a shape-2 "migrate" section.
+func TestLoadResetConfigFile_ConfirmedOrgsFromNestedMigrateSection(t *testing.T) {
+	content := `{
+  "migrate": {
+    "token": "tok",
+    "enterprise_key": "ent",
+    "confirmed_orgs": ["inner-org"]
+  }
+}`
+	cfg, err := LoadResetConfigFile(writeConfigFixture(t, content))
+	if err != nil {
+		t.Fatalf("LoadResetConfigFile: %v", err)
+	}
+	if !reflect.DeepEqual(cfg.ConfirmedOrgs, []string{"inner-org"}) {
+		t.Errorf("ConfirmedOrgs: got %+v, want [inner-org]", cfg.ConfirmedOrgs)
+	}
+}
+
+// An outer-level confirmed_orgs wins over a nested "migrate" section's
+// value, mirroring skip_issue_sync's outer-wins-else-inner precedence.
+func TestLoadResetConfigFile_ConfirmedOrgsOuterWinsOverNestedMigrate(t *testing.T) {
+	content := `{
+  "confirmed_orgs": ["outer-org"],
+  "migrate": {
+    "token": "tok",
+    "enterprise_key": "ent",
+    "confirmed_orgs": ["inner-org"]
+  }
+}`
+	cfg, err := LoadResetConfigFile(writeConfigFixture(t, content))
+	if err != nil {
+		t.Fatalf("LoadResetConfigFile: %v", err)
+	}
+	if !reflect.DeepEqual(cfg.ConfirmedOrgs, []string{"outer-org"}) {
+		t.Errorf("ConfirmedOrgs: got %+v, want [outer-org]", cfg.ConfirmedOrgs)
+	}
+}
+
+// Absent confirmed_orgs leaves ResetConfig.ConfirmedOrgs nil — RunReset
+// fails closed on that (#550), which this parser-level test does not
+// itself exercise, but the zero value must round-trip as nil, not an
+// empty-but-non-nil slice, so callers can distinguish "unset" cleanly.
+func TestLoadResetConfigFile_ConfirmedOrgsAbsentIsNil(t *testing.T) {
+	cfg, err := LoadResetConfigFile(writeConfigFixture(t, flatShapeJSON))
+	if err != nil {
+		t.Fatalf("LoadResetConfigFile: %v", err)
+	}
+	if cfg.ConfirmedOrgs != nil {
+		t.Errorf("ConfirmedOrgs: got %+v, want nil", cfg.ConfirmedOrgs)
+	}
+}
+
 // Issue #303: top-level `skip_project_data_migration` parses into
 // MigrateConfig.SkipProjectDataMigration one-for-one (no inversion).
 // Defaults to false (data is migrated). Every FlexibleBool alias is

--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -735,3 +735,14 @@ var extractField = common.ExtractField
 
 // extractBool is a convenience alias.
 var extractBool = common.ExtractBool
+
+// isFailedMigrateRecord reports whether a task output record was written
+// as an explicit failure (e.g. createProjects' #525 cross-org-collision
+// and #550 empty-key branches, tasks_create.go): such a record still
+// carries the originally requested identifier fields (like
+// cloud_project_key) even though the entity was never created, so every
+// downstream task that iterates it must skip it rather than attempt API
+// calls against something that doesn't exist (#551).
+func isFailedMigrateRecord(item json.RawMessage) bool {
+	return extractField(item, "status") == "failed"
+}

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -178,16 +178,24 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 	base := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
 	logger := slog.New(newEventHandler(base, collector))
 
-	appliedDefault, err := validateMigrateConfig(cfg, logger)
-	if err != nil {
-		return "", err
-	}
-
 	// Installed on the HTTP clients now and pointed at the run directory
 	// once it exists; entries are buffered until then.
 	reqLog := newRequestLogWriter()
 	defer reqLog.Close()
 	clients := newMigrateClients(cfg, logger, reqLog)
+
+	// Built ahead of validateMigrateConfig (issue #550) so
+	// --default_organization can be checked against the live SonarQube
+	// Cloud API BEFORE applyOrgMapping ever writes it to
+	// organizations.csv. Previously the value was persisted first and
+	// only validated afterwards by validateMigrateOrgs below, so a wrong
+	// --default_organization on a failed run got written to disk; a
+	// retry with a corrected value then found organizations.csv already
+	// "mapped" and silently ignored the correction.
+	appliedDefault, err := validateMigrateConfig(ctx, clients.Cloud, cfg, logger)
+	if err != nil {
+		return "", err
+	}
 
 	// Verify every SQC organization the migration will touch exists and
 	// is visible to the token, and that the project-key pattern doesn't
@@ -274,13 +282,14 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 
 // validateMigrateConfig validates the project-key renaming pattern syntax
 // and the SQC org mapping, applying the --default_organization fallback if
-// requested (issues #138, #279, #281). Both checks run before any API
-// client setup so a config error surfaces immediately.
-func validateMigrateConfig(cfg MigrateConfig, logger *slog.Logger) (appliedDefault bool, err error) {
+// requested (issues #138, #279, #281). cc is used by applyOrgMapping to
+// validate --default_organization against the live SonarQube Cloud API
+// before it is ever persisted to organizations.csv (issue #550).
+func validateMigrateConfig(ctx context.Context, cc *cloud.Client, cfg MigrateConfig, logger *slog.Logger) (appliedDefault bool, err error) {
 	if err := ValidateProjectKeyPattern(cfg.ProjectKeyPattern); err != nil {
 		return false, common.NewExitError(2, fmt.Errorf("invalid project_key_pattern: %w", err))
 	}
-	return applyOrgMapping(cfg.ExportDirectory, cfg.DefaultOrganization, logger)
+	return applyOrgMapping(ctx, cc.Organizations, cfg.ExportDirectory, cfg.DefaultOrganization, cfg.EnterpriseKey, logger)
 }
 
 // validateMigrateOrgs verifies every SQC organization the migration will

--- a/go/internal/migrate/org_mapping.go
+++ b/go/internal/migrate/org_mapping.go
@@ -40,7 +40,16 @@ const orgCSVFileName = "organizations.csv"
 // Returns appliedDefault=true when the CSV was rewritten with the
 // default; this drives the message variant produced by
 // validateOrgsExist for issue #283.
-func applyOrgMapping(exportDir, defaultOrg string, logger *slog.Logger) (appliedDefault bool, err error) {
+//
+// Before writing defaultOrg anywhere, it is checked against the live
+// SonarQube Cloud API via validateOrgExists (issue #550). If the org
+// doesn't exist, this returns that error and organizations.csv is left
+// completely untouched — a prior bug validated defaultOrg only AFTER
+// writeOrgCSVWithDefault had already persisted it, so a wrong
+// --default_organization on a failed run got written to disk, and a
+// retry with a corrected value then found the file already "mapped"
+// (hasMapping above) and silently ignored the correction.
+func applyOrgMapping(ctx context.Context, lookup orgLookup, exportDir, defaultOrg, enterpriseKey string, logger *slog.Logger) (appliedDefault bool, err error) {
 	rows, loadErr := structure.LoadCSV(exportDir, orgCSVFileName)
 	if loadErr != nil {
 		return false, fmt.Errorf("loading organizations.csv: %w", loadErr)
@@ -73,6 +82,12 @@ func applyOrgMapping(exportDir, defaultOrg string, logger *slog.Logger) (applied
 	// No mapping defined.
 	if defaultOrg == "" {
 		return false, missingMappingError(csvPath)
+	}
+
+	// Validate defaultOrg against the live SonarQube Cloud API BEFORE
+	// writing anything to organizations.csv (issue #550).
+	if err := validateOrgExists(ctx, lookup, defaultOrg, enterpriseKey); err != nil {
+		return false, err
 	}
 
 	// Apply defaultOrg to every row and write back.
@@ -143,6 +158,28 @@ type orgLookup interface {
 	Search(ctx context.Context, keys ...string) ([]sqcTypes.Organization, error)
 }
 
+// validateOrgExists checks that a single SonarQube Cloud organization key
+// exists and is visible to the authenticated token, returning
+// defaultOrgMissingError (exit code 3) naming enterpriseKey if not. An
+// empty orgKey is treated as a no-op (nothing to check).
+//
+// Factored out of validateOrgsExist's appliedDefault branch (issue #283)
+// so applyOrgMapping can run the identical check on --default_organization
+// BEFORE it is ever persisted to organizations.csv (issue #550).
+func validateOrgExists(ctx context.Context, lookup orgLookup, orgKey, enterpriseKey string) error {
+	if orgKey == "" {
+		return nil
+	}
+	known, err := orgsByKey(ctx, lookup, []string{orgKey})
+	if err != nil {
+		return fmt.Errorf("looking up organization %q in SonarQube Cloud: %w", orgKey, err)
+	}
+	if _, ok := known[orgKey]; !ok {
+		return defaultOrgMissingError(orgKey, enterpriseKey)
+	}
+	return nil
+}
+
 // validateOrgsExist checks that every SonarQube Cloud organization the
 // migration is about to use actually exists / is visible to the
 // authenticated token. The two failure modes from issue #283:
@@ -158,17 +195,7 @@ func validateOrgsExist(ctx context.Context, lookup orgLookup, exportDir, enterpr
 	csvPath := filepath.Join(exportDir, orgCSVFileName)
 
 	if appliedDefault {
-		if defaultOrg == "" {
-			return nil
-		}
-		known, err := orgsByKey(ctx, lookup, []string{defaultOrg})
-		if err != nil {
-			return fmt.Errorf("looking up default organization in SonarQube Cloud: %w", err)
-		}
-		if _, ok := known[defaultOrg]; !ok {
-			return defaultOrgMissingError(defaultOrg, enterpriseKey)
-		}
-		return nil
+		return validateOrgExists(ctx, lookup, defaultOrg, enterpriseKey)
 	}
 
 	rows, err := structure.LoadCSV(exportDir, orgCSVFileName)

--- a/go/internal/migrate/org_mapping_test.go
+++ b/go/internal/migrate/org_mapping_test.go
@@ -6,6 +6,7 @@ package migrate
 
 import (
 	"bytes"
+	"context"
 	"encoding/csv"
 	"errors"
 	"log/slog"
@@ -38,7 +39,7 @@ org-a,
 org-b,
 org-c,
 `)
-	_, err := applyOrgMapping(dir, "", discardLogger())
+	_, err := applyOrgMapping(context.Background(), newFakeOrgs(), dir, "", "ent", discardLogger())
 	if err == nil {
 		t.Fatal("expected an error when no mapping is defined and no default")
 	}
@@ -59,7 +60,7 @@ func TestApplyOrgMapping_AllEmptyWithDefaultFillsRows(t *testing.T) {
 org-a,,https://sqs-a.example.com
 org-b,,https://sqs-b.example.com
 `)
-	applied, err := applyOrgMapping(dir, "my-cloud-org", discardLogger())
+	applied, err := applyOrgMapping(context.Background(), newFakeOrgs("my-cloud-org"), dir, "my-cloud-org", "ent", discardLogger())
 	if err != nil {
 		t.Fatalf("expected success with default_organization, got %v", err)
 	}
@@ -101,7 +102,7 @@ org-b,
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	applied, err := applyOrgMapping(dir, "default-cloud-org", logger)
+	applied, err := applyOrgMapping(context.Background(), newFakeOrgs(), dir, "default-cloud-org", "ent", logger)
 	if err != nil {
 		t.Fatalf("expected nil with mapped CSV + default, got %v", err)
 	}
@@ -132,7 +133,7 @@ org-b,real-cloud-org
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	if _, err := applyOrgMapping(dir, "", logger); err != nil {
+	if _, err := applyOrgMapping(context.Background(), newFakeOrgs(), dir, "", "ent", logger); err != nil {
 		t.Errorf("expected nil for partial mapping, got %v", err)
 	}
 	if strings.Contains(buf.String(), "level=WARN") {
@@ -147,7 +148,7 @@ func TestApplyOrgMapping_OnlySkippedRowsPass(t *testing.T) {
 org-a,SKIPPED
 org-b,SKIPPED
 `)
-	if _, err := applyOrgMapping(dir, "", discardLogger()); err != nil {
+	if _, err := applyOrgMapping(context.Background(), newFakeOrgs(), dir, "", "ent", discardLogger()); err != nil {
 		t.Errorf("expected nil when all rows are SKIPPED, got %v", err)
 	}
 }
@@ -156,7 +157,112 @@ org-b,SKIPPED
 // without rows).
 func TestApplyOrgMapping_MissingFileReturnsExit2(t *testing.T) {
 	dir := t.TempDir()
-	if _, err := applyOrgMapping(dir, "any-default", discardLogger()); err == nil {
+	if _, err := applyOrgMapping(context.Background(), newFakeOrgs(), dir, "any-default", "ent", discardLogger()); err == nil {
 		t.Fatal("expected error when organizations.csv is missing")
+	}
+}
+
+// Issue #550: a purely-numeric sonarcloud_org_key (e.g. "12345") used to
+// be silently coerced to float64 by structure.LoadCSV, so hasMapping's
+// `val, _ := row["sonarcloud_org_key"].(string)` type assertion failed
+// and read back "" — treating a perfectly-mapped organization as
+// unmapped and dropping it from the migration with no error or warning.
+// With the fix, LoadCSV keeps "*_key" columns as raw strings, so a
+// numeric-looking org key is still recognized as "already mapped".
+func TestApplyOrgMapping_NumericOrgKeyRecognizedAsMapped(t *testing.T) {
+	dir := t.TempDir()
+	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
+org-a,12345
+org-b,67890
+`)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	applied, err := applyOrgMapping(context.Background(), newFakeOrgs(), dir, "", "ent", logger)
+	if err != nil {
+		t.Fatalf("expected nil error for a numeric-looking but valid org mapping, got %v", err)
+	}
+	if applied {
+		t.Error("appliedDefault must be false when the CSV already has a (numeric-looking) mapping")
+	}
+
+	// The CSV must be left untouched: it must not have been rewritten
+	// with a default because it was misread as unmapped.
+	got, readErr := os.ReadFile(filepath.Join(dir, "organizations.csv"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	want := "sonarqube_org_key,sonarcloud_org_key\norg-a,12345\norg-b,67890\n"
+	if string(got) != want {
+		t.Errorf("CSV must not be modified when a numeric-looking mapping is already defined.\ngot:  %q\nwant: %q", string(got), want)
+	}
+}
+
+// Issue #550: a wrong --default_organization used to be validated against
+// SonarQube Cloud only AFTER writeOrgCSVWithDefault had already persisted
+// it to organizations.csv (validateOrgsExist ran later, in RunMigrate). A
+// retry with a corrected --default_organization then found the CSV already
+// "mapped" by the failed attempt's leftover value, so hasMapping silently
+// ignored the correction with just a WARN.
+//
+// With the fix, applyOrgMapping validates defaultOrg against the live API
+// (via the injected orgLookup) BEFORE writing anything. This reproduces the
+// exact two-attempt scenario: first with a bogus org (must fail without
+// touching the file), then immediately with a corrected org (must apply
+// cleanly, proving the first failed attempt left no residue behind).
+func TestApplyOrgMapping_InvalidDefaultThenCorrectedRetryApplies(t *testing.T) {
+	dir := t.TempDir()
+	original := `sonarqube_org_key,sonarcloud_org_key
+org-a,
+org-b,
+`
+	writeOrgCSV(t, dir, original)
+
+	// Only "real-cloud-org" exists on the (mock) target — "bogus-org" does not.
+	lookup := newFakeOrgs("real-cloud-org")
+
+	// First attempt: wrong --default_organization.
+	applied, err := applyOrgMapping(context.Background(), lookup, dir, "bogus-org", "ent", discardLogger())
+	if err == nil {
+		t.Fatal("expected an error for a --default_organization that does not exist on the target")
+	}
+	if applied {
+		t.Error("appliedDefault must be false when the default organization failed validation")
+	}
+	var ec *common.ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != 3 {
+		t.Errorf("expected exit code 3 error, got %v (%T)", err, err)
+	}
+
+	// The CSV must be completely untouched by the failed attempt.
+	got, readErr := os.ReadFile(filepath.Join(dir, "organizations.csv"))
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != original {
+		t.Fatalf("organizations.csv must not be modified by a failed --default_organization.\ngot:  %q\nwant: %q", string(got), original)
+	}
+
+	// Second attempt (retry): corrected --default_organization must apply
+	// cleanly, because the first failed attempt left hasMapping false.
+	applied, err = applyOrgMapping(context.Background(), lookup, dir, "real-cloud-org", "ent", discardLogger())
+	if err != nil {
+		t.Fatalf("expected the corrected retry to succeed, got %v", err)
+	}
+	if !applied {
+		t.Error("appliedDefault must be true once the corrected default_organization is applied")
+	}
+
+	f, err := os.Open(filepath.Join(dir, "organizations.csv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	records, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if records[1][1] != "real-cloud-org" || records[2][1] != "real-cloud-org" {
+		t.Errorf("expected real-cloud-org in every row after the corrected retry, got %v", records)
 	}
 }

--- a/go/internal/migrate/reset.go
+++ b/go/internal/migrate/reset.go
@@ -105,24 +105,7 @@ func RunReset(ctx context.Context, cfg ResetConfig) error {
 	registry := BuildMigrateRegistry(allDefs)
 	registry = FilterByEdition(registry, edition)
 
-	// Target the delete* tasks plus the curated set of reset* tasks
-	// whose dependency chains do not pull migrate-only create*/set*
-	// work back into the plan. The other reset* tasks
-	// (resetDefaultProfiles, resetDefaultGates, resetPermissionTemplates)
-	// are pulled into the plan as dependencies of the corresponding
-	// delete* tasks (so they run first to clear the current default
-	// before the destroy call) and are intentionally NOT named here.
-	resetPrefixTargets := map[string]bool{
-		"resetGlobalSettings": true,
-	}
-	var targets []string
-	for name := range registry {
-		if strings.HasPrefix(name, "delete") || resetPrefixTargets[name] {
-			targets = append(targets, name)
-		}
-	}
-
-	taskSet := ResolveDependencies(targets, registry)
+	taskSet := ResolveDependencies(resetTargets(registry), registry)
 	if taskSet == nil {
 		return fmt.Errorf("cannot resolve dependencies for delete tasks")
 	}
@@ -168,10 +151,7 @@ func RunReset(ctx context.Context, cfg ResetConfig) error {
 		Logger:    logger,
 	}
 	if len(cfg.ConfirmedOrgs) > 0 {
-		executor.ResetConfirmedOrgs = make(map[string]bool, len(cfg.ConfirmedOrgs))
-		for _, o := range cfg.ConfirmedOrgs {
-			executor.ResetConfirmedOrgs[o] = true
-		}
+		executor.ResetConfirmedOrgs = toSet(cfg.ConfirmedOrgs)
 	}
 
 	for i, phase := range plan {
@@ -186,6 +166,35 @@ func RunReset(ctx context.Context, cfg ResetConfig) error {
 
 	fmt.Printf("%s v%s - Reset Complete: %s\n", version.ToolName, version.Version, runID)
 	return nil
+}
+
+// resetTargets selects the delete* tasks plus the curated set of reset*
+// tasks whose dependency chains do not pull migrate-only create*/set*
+// work back into the plan. The other reset* tasks
+// (resetDefaultProfiles, resetDefaultGates, resetPermissionTemplates)
+// are pulled into the plan as dependencies of the corresponding
+// delete* tasks (so they run first to clear the current default before
+// the destroy call) and are intentionally not named here.
+func resetTargets(registry map[string]*TaskDef) []string {
+	resetPrefixTargets := map[string]bool{
+		"resetGlobalSettings": true,
+	}
+	var targets []string
+	for name := range registry {
+		if strings.HasPrefix(name, "delete") || resetPrefixTargets[name] {
+			targets = append(targets, name)
+		}
+	}
+	return targets
+}
+
+// toSet returns items as a set for O(1) membership checks.
+func toSet(items []string) map[string]bool {
+	set := make(map[string]bool, len(items))
+	for _, item := range items {
+		set[item] = true
+	}
+	return set
 }
 
 // printResetDryRunPlan renders the reset plan for --dry-run (#550):

--- a/go/internal/migrate/reset.go
+++ b/go/internal/migrate/reset.go
@@ -14,10 +14,10 @@ import (
 	"strings"
 	"time"
 
-	sqapi "github.com/sonar-solutions/sq-api-go"
-	"github.com/sonar-solutions/sq-api-go/cloud"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/version"
+	sqapi "github.com/sonar-solutions/sq-api-go"
+	"github.com/sonar-solutions/sq-api-go/cloud"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -33,16 +33,38 @@ type ResetConfig struct {
 
 	// ConfirmedOrgs is the operator-confirmed subset of mapped
 	// SonarCloud organizations to actually wipe (#381). Populated by
-	// the reset command's interactive confirmation prompt or by the
-	// --yes flag for non-interactive runs. When empty / nil, no
-	// filter is applied (all mapped orgs get reset — the legacy
-	// behaviour for callers that don't go through cmd/reset.go).
+	// the reset command's interactive confirmation prompt, the
+	// --organization flag, the --yes flag for non-interactive runs, or
+	// a config file's confirmed_orgs field (#550, see
+	// configFileShape.ConfirmedOrgs / toResetConfig).
+	//
+	// Fail-closed (#550): when empty / nil, RunReset returns an error
+	// instead of resetting every mapped org. cmd/reset.go is the only
+	// current caller and it always populates this field (via
+	// confirmResetOrgs) before calling RunReset, so this is safe for
+	// the one real caller; any future non-CLI caller must explicitly
+	// opt in to a scope rather than silently wiping everything.
 	ConfirmedOrgs []string
+
+	// DryRun, when true, makes RunReset build and print the reset plan
+	// — which organizations are in scope and which tasks would run —
+	// without issuing any destructive API call, then return nil before
+	// the phase-execution loop starts (#550).
+	DryRun bool
 }
 
 // RunReset deletes all migrated entities from SonarQube Cloud.
 func RunReset(ctx context.Context, cfg ResetConfig) error {
 	cfg.applyDefaults()
+
+	// #550 — fail closed: an empty/nil ConfirmedOrgs used to mean "no
+	// filter, reset every mapped org." cmd/reset.go always populates it
+	// (via confirmResetOrgs) before calling RunReset, so a genuinely
+	// empty value here means some caller skipped confirmation entirely
+	// — refuse rather than silently wiping the whole enterprise.
+	if len(cfg.ConfirmedOrgs) == 0 {
+		return fmt.Errorf("no organizations confirmed for reset — pass --organization/confirm via the CLI prompt, or set confirmed_orgs in the config file")
+	}
 
 	cmdStart := time.Now()
 
@@ -121,6 +143,14 @@ func RunReset(ctx context.Context, cfg ResetConfig) error {
 	data, _ := json.MarshalIndent(meta, "", "  ")
 	_ = os.WriteFile(filepath.Join(runDir, "clear.json"), data, 0o644)
 
+	// #550 — dry run: the plan is already fully built and written to
+	// disk above; print it and return before the executor (and any
+	// destructive HTTP call) is even constructed.
+	if cfg.DryRun {
+		printResetDryRunPlan(cfg, plan, runDir)
+		return nil
+	}
+
 	store := common.NewDataStore(runDir)
 
 	executor := &Executor{
@@ -156,6 +186,29 @@ func RunReset(ctx context.Context, cfg ResetConfig) error {
 
 	fmt.Printf("%s v%s - Reset Complete: %s\n", version.ToolName, version.Version, runID)
 	return nil
+}
+
+// printResetDryRunPlan renders the reset plan for --dry-run (#550):
+// which organizations are in scope, how many migrate-created projects
+// each carries (reusing the same createProjects-JSONL-derived counts
+// cmd/reset.go's confirmation prompt shows, via
+// MigrateCreatedProjectCounts), and the task phases that would run —
+// without making any destructive API call.
+func printResetDryRunPlan(cfg ResetConfig, plan [][]string, runDir string) {
+	fmt.Println("Dry run: no organizations were modified.")
+	fmt.Printf("Organizations in scope (%d): %s\n", len(cfg.ConfirmedOrgs), strings.Join(cfg.ConfirmedOrgs, ", "))
+
+	if counts, err := MigrateCreatedProjectCounts(cfg.ExportDirectory); err == nil && counts != nil {
+		for _, org := range cfg.ConfirmedOrgs {
+			fmt.Printf("  - %s (%d projects would be deleted)\n", org, counts[org])
+		}
+	}
+
+	fmt.Println("Planned tasks, in execution order:")
+	for i, phase := range plan {
+		fmt.Printf("  Phase %d: %s\n", i+1, strings.Join(phase, ", "))
+	}
+	fmt.Printf("Plan written to %s\n", filepath.Join(runDir, "clear.json"))
 }
 
 func runResetPhase(ctx context.Context, e *Executor, taskNames []string, registry map[string]*TaskDef) error {

--- a/go/internal/migrate/reset_test.go
+++ b/go/internal/migrate/reset_test.go
@@ -6,6 +6,12 @@ package migrate
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -34,6 +40,10 @@ func TestRunResetIntegration(t *testing.T) {
 		Token: "test-token", EnterpriseKey: "test-enterprise",
 		Edition: "enterprise", URL: cloudSrv.URL + "/",
 		Concurrency: 5, ExportDirectory: dir,
+		// #550: RunReset now fails closed on an empty ConfirmedOrgs, so
+		// this orchestration-exercising test must confirm the one org
+		// the fixture data uses.
+		ConfirmedOrgs: []string{testCloudOrg},
 	}
 
 	// RunReset targets delete* tasks, which depend on createX outputs.
@@ -70,5 +80,75 @@ func TestResetConfigTrailingSlash(t *testing.T) {
 	cfg.applyDefaults()
 	if cfg.URL != "https://example.com/" {
 		t.Errorf("expected trailing slash, got %q", cfg.URL)
+	}
+}
+
+// #550: RunReset must fail closed when no organization has been
+// confirmed, rather than falling back to "reset every mapped org."
+// cmd/reset.go is the only current caller and it always populates
+// ConfirmedOrgs (via confirmResetOrgs) before calling RunReset, so this
+// only guards against a future non-CLI caller skipping confirmation.
+func TestRunReset_ErrorsWhenNoConfirmedOrgs(t *testing.T) {
+	cfg := ResetConfig{
+		Token: "test-token", EnterpriseKey: "test-enterprise",
+		Edition: "enterprise", ExportDirectory: t.TempDir(),
+	}
+	err := RunReset(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error when ConfirmedOrgs is empty")
+	}
+	if !strings.Contains(err.Error(), "no organizations confirmed") {
+		t.Errorf("error %q does not mention the missing confirmation", err.Error())
+	}
+}
+
+// #550: --dry-run must never touch the network. RunReset should build
+// and print the plan, then return before the executor (and therefore
+// any delete/destroy HTTP call) is even constructed.
+func TestRunReset_DryRunSkipsExecution(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		t.Errorf("unexpected HTTP call during dry run: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	setupCSVs(t, dir)
+
+	cfg := ResetConfig{
+		Token: "test-token", EnterpriseKey: "test-enterprise",
+		Edition: "enterprise", URL: srv.URL + "/",
+		Concurrency: 5, ExportDirectory: dir,
+		ConfirmedOrgs: []string{testCloudOrg},
+		DryRun:        true,
+	}
+
+	if err := RunReset(context.Background(), cfg); err != nil {
+		t.Fatalf("RunReset (dry run): %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Errorf("expected 0 HTTP calls during dry run, got %d", got)
+	}
+
+	// The plan must still be written to disk so it's inspectable, even
+	// though execution was skipped.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading export dir: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, statErr := os.Stat(filepath.Join(dir, e.Name(), "clear.json")); statErr == nil {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected clear.json to be written even in dry-run mode")
 	}
 }

--- a/go/internal/migrate/sync_issues_standalone.go
+++ b/go/internal/migrate/sync_issues_standalone.go
@@ -123,11 +123,6 @@ func RunSyncIssues(ctx context.Context, cfg SyncIssuesConfig) (SyncIssuesSummary
 		return summary, common.NewExitError(2, fmt.Errorf("invalid project_key_pattern: %w", err))
 	}
 
-	appliedDefault, err := applyOrgMapping(cfg.ExportDirectory, cfg.DefaultOrganization, logger)
-	if err != nil {
-		return summary, err
-	}
-
 	cloudURL := cfg.URL
 	clientOpts := []sqapi.Option{sqapi.WithTimeout(cfg.Timeout)}
 	if cfg.Debug {
@@ -136,6 +131,15 @@ func RunSyncIssues(ctx context.Context, cfg SyncIssuesConfig) (SyncIssuesSummary
 	cloudClient := sqapi.NewCloudClient(cloudURL, cfg.Token, clientOpts...)
 	cc := cloud.New(cloudClient)
 	raw := common.NewRawClient(cloudClient.HTTPClient(), cloudClient.BaseURL())
+
+	// Built ahead of applyOrgMapping (issue #550) so --default_organization
+	// is checked against the live SonarQube Cloud API before it is ever
+	// written to organizations.csv — see the identical reordering in
+	// RunMigrate for the full rationale.
+	appliedDefault, err := applyOrgMapping(ctx, cc.Organizations, cfg.ExportDirectory, cfg.DefaultOrganization, cfg.EnterpriseKey, logger)
+	if err != nil {
+		return summary, err
+	}
 
 	if err := validateOrgsExist(ctx, cc.Organizations, cfg.ExportDirectory, cfg.EnterpriseKey, cfg.DefaultOrganization, appliedDefault); err != nil {
 		return summary, err

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -153,6 +153,9 @@ func runSetProjectProfiles(ctx context.Context, e *Executor) error {
 	projects, _ := e.Store.ReadAll("createProjects")
 	projectLookup := make(map[string]projTarget, len(projects))
 	for _, p := range projects {
+		if isFailedMigrateRecord(p) {
+			continue
+		}
 		server := extractField(p, "server_url")
 		srcKey := extractField(p, "key")
 		cloudKey := extractField(p, "cloud_project_key")
@@ -215,6 +218,9 @@ func runSetProjectGates(ctx context.Context, e *Executor) error {
 	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "setProjectGates", "createProjects",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+			if isFailedMigrateRecord(item) {
+				return nil
+			}
 			orgKey := extractField(item, "sonarcloud_org_key")
 			projectKey := extractField(item, "cloud_project_key")
 			gateName := extractField(item, "gate_name")
@@ -270,6 +276,9 @@ func runSetProjectGroupPermissions(ctx context.Context, e *Executor) error {
 	projects, _ := e.Store.ReadAll("createProjects")
 	projectKeyMap := make(map[string]projectMapping) // serverURL+key -> mapping
 	for _, p := range projects {
+		if isFailedMigrateRecord(p) {
+			continue
+		}
 		serverURL := extractField(p, "server_url")
 		key := extractField(p, "key")
 		projectKeyMap[serverURL+key] = projectMapping{
@@ -346,6 +355,9 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 	projectKeyMap := make(map[string]projectMapping)
 	orgs := make(map[string]struct{})
 	for _, p := range projects {
+		if isFailedMigrateRecord(p) {
+			continue
+		}
 		serverURL := extractField(p, "server_url")
 		key := extractField(p, "key")
 		pm := projectMapping{
@@ -693,6 +705,9 @@ func runSetNewCodePeriods(ctx context.Context, e *Executor) error {
 	projects, _ := e.Store.ReadAll("createProjects")
 	projectKeyMap := make(map[string]projectInfo, len(projects))
 	for _, p := range projects {
+		if isFailedMigrateRecord(p) {
+			continue
+		}
 		serverURL := extractField(p, "server_url")
 		key := extractField(p, "key")
 		main := extractField(p, "main_branch")
@@ -1041,6 +1056,9 @@ func runSetProjectTags(ctx context.Context, e *Executor) error {
 	projects, _ := e.Store.ReadAll("createProjects")
 	projectKeyMap := make(map[string]projectMapping)
 	for _, p := range projects {
+		if isFailedMigrateRecord(p) {
+			continue
+		}
 		serverURL := extractField(p, "server_url")
 		key := extractField(p, "key")
 		projectKeyMap[serverURL+key] = projectMapping{
@@ -1101,6 +1119,9 @@ func runSetProjectLinks(ctx context.Context, e *Executor) error {
 	projects, _ := e.Store.ReadAll("createProjects")
 	projectKeyMap := make(map[string]projectMapping)
 	for _, p := range projects {
+		if isFailedMigrateRecord(p) {
+			continue
+		}
 		serverURL := extractField(p, "server_url")
 		key := extractField(p, "key")
 		projectKeyMap[serverURL+key] = projectMapping{CloudKey: extractField(p, "cloud_project_key")}
@@ -1225,6 +1246,9 @@ func runSetProjectSourceLink(ctx context.Context, e *Executor) error {
 	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "setProjectSourceLink", "createProjects",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+			if isFailedMigrateRecord(item) {
+				return nil
+			}
 			cloudKey := extractField(item, "cloud_project_key")
 			if cloudKey == "" {
 				return nil
@@ -1282,6 +1306,9 @@ func runSetProjectWebhooks(ctx context.Context, e *Executor) error {
 	projects, _ := e.Store.ReadAll("createProjects")
 	projectKeyMap := make(map[string]projectMapping)
 	for _, p := range projects {
+		if isFailedMigrateRecord(p) {
+			continue
+		}
 		serverURL := extractField(p, "server_url")
 		key := extractField(p, "key")
 		projectKeyMap[serverURL+key] = projectMapping{

--- a/go/internal/migrate/tasks_create.go
+++ b/go/internal/migrate/tasks_create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	sqapi "github.com/sonar-solutions/sq-api-go"
 	"github.com/sonar-solutions/sq-api-go/cloud"
+	"github.com/sonar-solutions/sq-api-go/types"
 )
 
 // createTasks returns tasks that create entities in SonarQube Cloud.
@@ -82,98 +83,103 @@ func runCreateProjects(ctx context.Context, e *Executor) error {
 					failAPI(counter, e.Logger, "createProjects: create failed", err, "key", key)
 					return nil
 				}
-				// SonarQube Cloud project keys are GLOBALLY unique, not
-				// org-scoped, so "key already exists" doesn't guarantee
-				// the existing project is in OUR target org. If it
-				// isn't, downstream tasks (setProjectSettings,
-				// setGlobalSettings fan-out, etc.) will issue PATCHes
-				// against a phantom project and get 404s. Verify the
-				// project is actually accessible in orgKey before
-				// recording it (issue #193).
-				exists, verifyErr := e.Cloud.Projects.ExistsInOrg(ctx, cloudKey, orgKey)
-				if verifyErr != nil {
-					failAPI(counter, e.Logger, "createProjects: could not verify already-existing project belongs to target org",
-						verifyErr, "source_key", key, "cloud_key", cloudKey, "org", orgKey)
-					return nil
-				}
-				if !exists {
-					counter.Fail()
-					e.Logger.Warn("createProjects: key already exists but project is not in target org",
-						"source_key", key, "cloud_key", cloudKey, "org", orgKey)
-					// #525: write an explicit failure record instead of
-					// silently dropping the project. Without this, the
-					// project only ends up in the report's Failed bucket
-					// incidentally (via a generic requests.log HTTP-status
-					// scan) with SonarQube Cloud's raw "already exists"
-					// string, which doesn't explain that the conflict is
-					// cross-organization or what to do about it.
-					msg := fmt.Sprintf(
-						"project key %q already exists under a different SonarQube Cloud organization than %q — "+
-							"SonarQube Cloud project keys must be unique across the entire SonarQube Cloud instance "+
-							"(not just within one enterprise or organization); "+
-							"rename the conflicting project on the target, or choose a different --project_key_pattern",
-						cloudKey, orgKey)
-					result := common.EnrichRaw(item, map[string]any{
-						"cloud_project_key":  cloudKey,
-						"sonarcloud_org_key": orgKey,
-						"status":             "failed",
-						"error":              msg,
-					})
-					return w.WriteOne(result)
-				}
-				counter.Success()
-				e.Logger.Info("createProjects: already exists", "source_key", key, "cloud_key", cloudKey, "org", orgKey)
-			} else {
-				requestedKey := cloudKey
-				cloudKey = proj.Key
-				if cloudKey == "" {
-					// Defensive-correctness guard (#550): Organization is a
-					// required parameter of the Create API call, so a
-					// successful create is structurally guaranteed to be in
-					// the requested org — there's no ExistsInOrg-style
-					// ambiguity on this branch. But nothing otherwise
-					// guarantees proj.Key is non-empty, and an empty
-					// cloud_project_key would silently propagate into every
-					// downstream task that reads this task's output
-					// (permission grants, settings, quality profile/gate
-					// wiring, etc.), each issuing calls against a blank
-					// project key. Fail loudly instead, mirroring the
-					// already-exists-but-wrong-org failure record shape
-					// above (#525) so consumers of this task's JSONL see a
-					// consistent "failed" shape either way.
-					counter.Fail()
-					e.Logger.Warn("createProjects: create succeeded but server returned an empty project key",
-						"source_key", key, "requested_key", requestedKey, "name", name, "org", orgKey)
-					msg := fmt.Sprintf(
-						"project %q: SonarQube Cloud returned a successful create response with an empty project key; "+
-							"refusing to record cloud_project_key as empty",
-						requestedKey)
-					result := common.EnrichRaw(item, map[string]any{
-						"cloud_project_key":  requestedKey,
-						"sonarcloud_org_key": orgKey,
-						"status":             "failed",
-						"error":              msg,
-					})
-					return w.WriteOne(result)
-				}
-				counter.Success()
-				if cloudKey != requestedKey {
-					// Not a bug — the API is allowed to normalize/rewrite
-					// the requested key. Audit trail only.
-					e.Logger.Debug("createProjects: server returned a different key than requested",
-						"source_key", key, "requested", requestedKey, "actual", cloudKey, "org", orgKey)
-				}
-				e.Logger.Debug("project operation: created new project",
-					"source_key", key, "cloud_key", cloudKey, "name", name, "org", orgKey)
+				return handleExistingProject(ctx, e, counter, w, item, key, cloudKey, orgKey)
 			}
-
-			result := common.EnrichRaw(item, map[string]any{
-				"cloud_project_key":  cloudKey,
-				"sonarcloud_org_key": orgKey,
-			})
-			return w.WriteOne(result)
+			return handleFreshProject(e, counter, w, item, key, cloudKey, name, orgKey, proj)
 		})
 	return err
+}
+
+// handleExistingProject handles the "already exists" branch of
+// runCreateProjects. SonarQube Cloud project keys are GLOBALLY unique,
+// not org-scoped, so "key already exists" doesn't guarantee the
+// existing project is in OUR target org. If it isn't, downstream tasks
+// (setProjectSettings, setGlobalSettings fan-out, etc.) will issue
+// PATCHes against a phantom project and get 404s — verify the project
+// is actually accessible in orgKey before recording it (issue #193).
+func handleExistingProject(ctx context.Context, e *Executor, counter *TaskCounter, w *common.ChunkWriter, item json.RawMessage, key, cloudKey, orgKey string) error {
+	exists, verifyErr := e.Cloud.Projects.ExistsInOrg(ctx, cloudKey, orgKey)
+	if verifyErr != nil {
+		failAPI(counter, e.Logger, "createProjects: could not verify already-existing project belongs to target org",
+			verifyErr, "source_key", key, "cloud_key", cloudKey, "org", orgKey)
+		return nil
+	}
+	if !exists {
+		counter.Fail()
+		e.Logger.Warn("createProjects: key already exists but project is not in target org",
+			"source_key", key, "cloud_key", cloudKey, "org", orgKey)
+		// #525: write an explicit failure record instead of silently
+		// dropping the project. Without this, the project only ends up
+		// in the report's Failed bucket incidentally (via a generic
+		// requests.log HTTP-status scan) with SonarQube Cloud's raw
+		// "already exists" string, which doesn't explain that the
+		// conflict is cross-organization or what to do about it.
+		msg := fmt.Sprintf(
+			"project key %q already exists under a different SonarQube Cloud organization than %q — "+
+				"SonarQube Cloud project keys must be unique across the entire SonarQube Cloud instance "+
+				"(not just within one enterprise or organization); "+
+				"rename the conflicting project on the target, or choose a different --project_key_pattern",
+			cloudKey, orgKey)
+		result := common.EnrichRaw(item, map[string]any{
+			"cloud_project_key":  cloudKey,
+			"sonarcloud_org_key": orgKey,
+			"status":             "failed",
+			"error":              msg,
+		})
+		return w.WriteOne(result)
+	}
+	counter.Success()
+	e.Logger.Info("createProjects: already exists", "source_key", key, "cloud_key", cloudKey, "org", orgKey)
+	result := common.EnrichRaw(item, map[string]any{
+		"cloud_project_key":  cloudKey,
+		"sonarcloud_org_key": orgKey,
+	})
+	return w.WriteOne(result)
+}
+
+// handleFreshProject handles the fresh-success branch of
+// runCreateProjects. Organization is a required parameter of the
+// Create API call, so a successful create is structurally guaranteed
+// to be in the requested org — there's no ExistsInOrg-style ambiguity
+// here. But nothing otherwise guarantees proj.Key is non-empty, and an
+// empty cloud_project_key would silently propagate into every
+// downstream task that reads this task's output (permission grants,
+// settings, quality profile/gate wiring, etc.). Fail loudly instead,
+// mirroring the already-exists-but-wrong-org failure record shape
+// above (#525) so consumers of this task's JSONL see a consistent
+// "failed" shape either way (issue #550).
+func handleFreshProject(e *Executor, counter *TaskCounter, w *common.ChunkWriter, item json.RawMessage, key, requestedKey, name, orgKey string, proj *types.Project) error {
+	cloudKey := proj.Key
+	if cloudKey == "" {
+		counter.Fail()
+		e.Logger.Warn("createProjects: create succeeded but server returned an empty project key",
+			"source_key", key, "requested_key", requestedKey, "name", name, "org", orgKey)
+		msg := fmt.Sprintf(
+			"project %q: SonarQube Cloud returned a successful create response with an empty project key; "+
+				"refusing to record cloud_project_key as empty",
+			requestedKey)
+		result := common.EnrichRaw(item, map[string]any{
+			"cloud_project_key":  requestedKey,
+			"sonarcloud_org_key": orgKey,
+			"status":             "failed",
+			"error":              msg,
+		})
+		return w.WriteOne(result)
+	}
+	counter.Success()
+	if cloudKey != requestedKey {
+		// Not a bug — the API is allowed to normalize/rewrite the
+		// requested key. Audit trail only.
+		e.Logger.Debug("createProjects: server returned a different key than requested",
+			"source_key", key, "requested", requestedKey, "actual", cloudKey, "org", orgKey)
+	}
+	e.Logger.Debug("project operation: created new project",
+		"source_key", key, "cloud_key", cloudKey, "name", name, "org", orgKey)
+	result := common.EnrichRaw(item, map[string]any{
+		"cloud_project_key":  cloudKey,
+		"sonarcloud_org_key": orgKey,
+	})
+	return w.WriteOne(result)
 }
 
 func runCreateProfiles(ctx context.Context, e *Executor) error {

--- a/go/internal/migrate/tasks_create.go
+++ b/go/internal/migrate/tasks_create.go
@@ -124,8 +124,45 @@ func runCreateProjects(ctx context.Context, e *Executor) error {
 				counter.Success()
 				e.Logger.Info("createProjects: already exists", "source_key", key, "cloud_key", cloudKey, "org", orgKey)
 			} else {
-				counter.Success()
+				requestedKey := cloudKey
 				cloudKey = proj.Key
+				if cloudKey == "" {
+					// Defensive-correctness guard (#550): Organization is a
+					// required parameter of the Create API call, so a
+					// successful create is structurally guaranteed to be in
+					// the requested org — there's no ExistsInOrg-style
+					// ambiguity on this branch. But nothing otherwise
+					// guarantees proj.Key is non-empty, and an empty
+					// cloud_project_key would silently propagate into every
+					// downstream task that reads this task's output
+					// (permission grants, settings, quality profile/gate
+					// wiring, etc.), each issuing calls against a blank
+					// project key. Fail loudly instead, mirroring the
+					// already-exists-but-wrong-org failure record shape
+					// above (#525) so consumers of this task's JSONL see a
+					// consistent "failed" shape either way.
+					counter.Fail()
+					e.Logger.Warn("createProjects: create succeeded but server returned an empty project key",
+						"source_key", key, "requested_key", requestedKey, "name", name, "org", orgKey)
+					msg := fmt.Sprintf(
+						"project %q: SonarQube Cloud returned a successful create response with an empty project key; "+
+							"refusing to record cloud_project_key as empty",
+						requestedKey)
+					result := common.EnrichRaw(item, map[string]any{
+						"cloud_project_key":  requestedKey,
+						"sonarcloud_org_key": orgKey,
+						"status":             "failed",
+						"error":              msg,
+					})
+					return w.WriteOne(result)
+				}
+				counter.Success()
+				if cloudKey != requestedKey {
+					// Not a bug — the API is allowed to normalize/rewrite
+					// the requested key. Audit trail only.
+					e.Logger.Debug("createProjects: server returned a different key than requested",
+						"source_key", key, "requested", requestedKey, "actual", cloudKey, "org", orgKey)
+				}
 				e.Logger.Debug("project operation: created new project",
 					"source_key", key, "cloud_key", cloudKey, "name", name, "org", orgKey)
 			}

--- a/go/internal/migrate/tasks_create_test.go
+++ b/go/internal/migrate/tasks_create_test.go
@@ -358,7 +358,7 @@ func TestCreateProjects_EmptyKeyOnCreate(t *testing.T) {
 	// No record should ever carry an empty cloud_project_key dressed up as
 	// a normal (non-failed) entry — downstream tasks key their lookups off
 	// this field.
-	if key := extractField(items[0], "cloud_project_key"); key == "" {
+	if extractField(items[0], "cloud_project_key") == "" {
 		t.Error("expected cloud_project_key to fall back to the originally-requested key, not be empty")
 	}
 	if status := extractField(items[0], "status"); status != "failed" {

--- a/go/internal/migrate/tasks_create_test.go
+++ b/go/internal/migrate/tasks_create_test.go
@@ -308,6 +308,68 @@ func TestCreateProjects_AlreadyExistsInDifferentOrg(t *testing.T) {
 	}
 }
 
+// TestCreateProjects_EmptyKeyOnCreate covers issue #550: the fresh-success
+// branch of runCreateProjects trusts the API's returned proj.Key over the
+// locally-derived key (correct — Organization is a required Create param, so
+// a successful create is structurally guaranteed to be in the target org,
+// unlike the already-exists collision case above). But nothing else
+// guarantees that returned key is non-empty, and an empty cloud_project_key
+// would silently propagate into every downstream task that reads this task's
+// output (permission grants, settings, quality profile/gate wiring, etc.).
+// This asserts createProjects instead fails loudly and writes an explicit
+// failure record, mirroring the shape used by
+// TestCreateProjects_AlreadyExistsInDifferentOrg (#525) for consistency.
+func TestCreateProjects_EmptyKeyOnCreate(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/projects/create", func(w http.ResponseWriter, r *http.Request) {
+		// Simulate a "successful" create response with a missing/empty key.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"project": map[string]any{
+				"key":  "",
+				"name": r.FormValue("name"),
+			},
+		})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	setupCSVs(t, dir)
+	runTask(t, e, "generateProjectMappings")
+
+	reg := BuildMigrateRegistry(RegisterAll())
+	if err := reg["createProjects"].Run(context.Background(), e); err != nil {
+		t.Fatalf("createProjects: %v", err)
+	}
+
+	items, _ := e.Store.ReadAll("createProjects")
+	if len(items) != 1 {
+		t.Fatalf("expected exactly 1 createProjects record when the API returns an empty key, got %d: %s",
+			len(items), items)
+	}
+	// No record should ever carry an empty cloud_project_key dressed up as
+	// a normal (non-failed) entry — downstream tasks key their lookups off
+	// this field.
+	if key := extractField(items[0], "cloud_project_key"); key == "" {
+		t.Error("expected cloud_project_key to fall back to the originally-requested key, not be empty")
+	}
+	if status := extractField(items[0], "status"); status != "failed" {
+		t.Errorf(`expected status "failed", got %q: %s`, status, items[0])
+	}
+	errMsg := extractField(items[0], "error")
+	if !strings.Contains(errMsg, "empty project key") {
+		t.Errorf("error message %q does not mention the empty key", errMsg)
+	}
+}
+
 func TestCreateProfiles_AlreadyExists(t *testing.T) {
 	items := runAlreadyExistsTask(t, "generateProfileMappings", "createProfiles")
 	if profKey := extractField(items[0], "cloud_profile_key"); profKey != "existing-prof-key" {
@@ -359,7 +421,7 @@ func setupCSVs(t *testing.T, dir string) {
 			"new_code_definition_value": 30, "alm": "github",
 			"repository": "myorg/myrepo", "slug": "", "monorepo": false,
 			"summary_comment_enabled": false,
-			"profiles": []map[string]any{{"key": "prof1", "name": "Custom", "language": "java"}}},
+			"profiles":                []map[string]any{{"key": "prof1", "name": "Custom", "language": "java"}}},
 	}
 	writeCSVFromMaps(t, dir, "projects", projects)
 

--- a/go/internal/migrate/tasks_delete.go
+++ b/go/internal/migrate/tasks_delete.go
@@ -655,10 +655,19 @@ func runResetPermissionTemplates(ctx context.Context, e *Executor) error {
 				}
 			}
 			if builtIn == nil {
-				e.Logger.Error("resetPermissionTemplates: no built-in \"Default Template\" found; refusing to proceed with template reset for this org",
+				// Fail this org, not the whole run: forEachMigrateItem fans
+				// out over an errgroup, so returning an error here would
+				// cancel every other confirmed org's reset too — one
+				// renamed built-in shouldn't block the rest.
+				// deleteTemplates' isCurrentDefaultTemplate net (see
+				// runDeleteTemplates) already refuses to delete whatever
+				// this org's actual current default is, named "Default
+				// Template" or not, so skipping the promotion here
+				// doesn't reopen that risk.
+				e.Logger.Error("resetPermissionTemplates: no built-in \"Default Template\" found; skipping template-default reset for this org",
 					"org", orgKey, "templates_returned", summarisePermissionTemplates(templates))
-				return fmt.Errorf("resetPermissionTemplates: no built-in %q found in org %s; refusing to proceed with template reset for this org",
-					defaultPermissionTemplateName, orgKey)
+				counter.Fail()
+				return nil
 			}
 
 			for _, q := range resetPermissionTemplateQualifiers {

--- a/go/internal/migrate/tasks_delete.go
+++ b/go/internal/migrate/tasks_delete.go
@@ -361,10 +361,30 @@ func runDeleteGroups(ctx context.Context, e *Executor) error {
 // qualifier and any previously-default custom template is deletable.
 func runDeleteTemplates(ctx context.Context, e *Executor) error {
 	counter := TaskCounterFromContext(ctx)
+	// #551: resetPermissionTemplates (this task's dependency) writes a
+	// "failed" record for any org where the built-in "Default Template"
+	// couldn't be found and promoted. isCurrentDefaultTemplate below only
+	// protects whatever IS currently the org's default — it can't tell a
+	// renamed built-in apart from any other non-default custom template
+	// once resetPermissionTemplates has been skipped for that org — so
+	// skip template deletion entirely there rather than risk destroying
+	// the renamed built-in.
+	unresetOrgs := make(map[string]bool)
+	resetResults, _ := e.Store.ReadAll("resetPermissionTemplates")
+	for _, r := range resetResults {
+		if isFailedMigrateRecord(r) {
+			unresetOrgs[extractField(r, "sonarcloud_org_key")] = true
+		}
+	}
 	err := forEachMigrateItem(ctx, e, "deleteTemplates", "generateOrganizationMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
 			if shouldSkipOrg(orgKey) {
+				return nil
+			}
+			if unresetOrgs[orgKey] {
+				e.Logger.Warn("deleteTemplates: skipping template deletion — resetPermissionTemplates could not confirm the built-in default for this org",
+					"org", orgKey)
 				return nil
 			}
 			templates, defaults, err := searchPermissionTemplates(ctx, e, orgKey)
@@ -659,15 +679,24 @@ func runResetPermissionTemplates(ctx context.Context, e *Executor) error {
 				// out over an errgroup, so returning an error here would
 				// cancel every other confirmed org's reset too — one
 				// renamed built-in shouldn't block the rest.
-				// deleteTemplates' isCurrentDefaultTemplate net (see
-				// runDeleteTemplates) already refuses to delete whatever
-				// this org's actual current default is, named "Default
-				// Template" or not, so skipping the promotion here
-				// doesn't reopen that risk.
+				//
+				// isCurrentDefaultTemplate only protects whichever template
+				// is *currently* the org's default for some qualifier — a
+				// renamed built-in that migration already demoted (because
+				// a custom template was promoted to default) matches
+				// neither that check nor isBuiltInPermissionTemplate, so it
+				// is NOT safe against deleteTemplates on its own (#551).
+				// Write an explicit failed record so runDeleteTemplates can
+				// skip template deletion entirely for this org instead.
 				e.Logger.Error("resetPermissionTemplates: no built-in \"Default Template\" found; skipping template-default reset for this org",
 					"org", orgKey, "templates_returned", summarisePermissionTemplates(templates))
 				counter.Fail()
-				return nil
+				result, _ := json.Marshal(map[string]any{
+					"sonarcloud_org_key": orgKey,
+					"status":             "failed",
+					"error":              "no built-in \"Default Template\" found",
+				})
+				return w.WriteOne(result)
 			}
 
 			for _, q := range resetPermissionTemplateQualifiers {

--- a/go/internal/migrate/tasks_delete.go
+++ b/go/internal/migrate/tasks_delete.go
@@ -71,6 +71,24 @@ func isBuiltInPermissionTemplate(name string) bool {
 	return strings.EqualFold(strings.TrimSpace(name), defaultPermissionTemplateName)
 }
 
+// isCurrentDefaultTemplate reports whether templateID is the org's
+// current default for any qualifier, per the defaultTemplates map
+// returned by searchPermissionTemplates (qualifier -> templateId). This
+// is a second, independent safety net alongside isBuiltInPermissionTemplate
+// (#550): permission templates carry no isBuiltIn API flag, so an admin
+// who renames the org's built-in "Default Template" would otherwise make
+// it indistinguishable from a custom template by name alone. Checking
+// current-default status catches that case even when the name check
+// doesn't.
+func isCurrentDefaultTemplate(templateID string, defaults map[string]string) bool {
+	for _, id := range defaults {
+		if id == templateID {
+			return true
+		}
+	}
+	return false
+}
+
 // deleteTasks returns tasks for deleting/resetting entities in Cloud.
 func deleteTasks() []TaskDef {
 	entEditions := []common.Edition{common.EditionEnterprise, common.EditionDatacenter}
@@ -349,7 +367,7 @@ func runDeleteTemplates(ctx context.Context, e *Executor) error {
 			if shouldSkipOrg(orgKey) {
 				return nil
 			}
-			templates, _, err := searchPermissionTemplates(ctx, e, orgKey)
+			templates, defaults, err := searchPermissionTemplates(ctx, e, orgKey)
 			if err != nil {
 				failAPI(counter, e.Logger, "deleteTemplates: listing templates failed", err, "org", orgKey)
 				return nil
@@ -360,6 +378,19 @@ func runDeleteTemplates(ctx context.Context, e *Executor) error {
 				if isBuiltInPermissionTemplate(tpl.Name) {
 					e.Logger.Debug("deleteTemplates: keeping built-in template",
 						"org", orgKey, "template", tpl.Name)
+					continue
+				}
+				// Second, independent safety net (#550): even when a
+				// renamed built-in fails the name check above, never
+				// delete a template that is still the org's current
+				// default for some qualifier — SQC would reject the
+				// delete_template call anyway, but more importantly a
+				// template institutionally treated as "the default" must
+				// not be destroyed just because it lost its canonical
+				// name.
+				if isCurrentDefaultTemplate(tpl.ID, defaults) {
+					e.Logger.Debug("deleteTemplates: keeping current-default template",
+						"org", orgKey, "template", tpl.Name, "template_id", tpl.ID)
 					continue
 				}
 				e.Logger.Info("deleteTemplates: deleting template",
@@ -624,10 +655,10 @@ func runResetPermissionTemplates(ctx context.Context, e *Executor) error {
 				}
 			}
 			if builtIn == nil {
-				e.Logger.Warn("resetPermissionTemplates: no built-in \"Default Template\" found; deleteTemplates may fail to delete the current default",
+				e.Logger.Error("resetPermissionTemplates: no built-in \"Default Template\" found; refusing to proceed with template reset for this org",
 					"org", orgKey, "templates_returned", summarisePermissionTemplates(templates))
-				counter.Fail()
-				return nil
+				return fmt.Errorf("resetPermissionTemplates: no built-in %q found in org %s; refusing to proceed with template reset for this org",
+					defaultPermissionTemplateName, orgKey)
 			}
 
 			for _, q := range resetPermissionTemplateQualifiers {

--- a/go/internal/migrate/tasks_delete_cov_test.go
+++ b/go/internal/migrate/tasks_delete_cov_test.go
@@ -295,3 +295,57 @@ func TestRunResetPermissionTemplatesNoBuiltIn(t *testing.T) {
 		t.Fatalf("runResetPermissionTemplates: expected nil (fail the org, not the run) when no built-in \"Default Template\" is found, got %v", err)
 	}
 }
+
+// #551 (Gitar round 2): when resetPermissionTemplates can't find the
+// built-in "Default Template" for an org, it now writes a "failed"
+// record instead of just logging. deleteTemplates (its dependent) must
+// read that record and skip template deletion entirely for that org —
+// isCurrentDefaultTemplate alone only protects whatever template is
+// CURRENTLY the org's default, which does not cover a renamed built-in
+// that migration already demoted in favor of a promoted custom
+// template. Without the propagated skip, "Custom Only" below (renamed
+// from "Default Template" and no longer any qualifier's default) would
+// be deleted.
+func TestRunDeleteTemplatesSkipsOrgWhereResetCouldNotFindBuiltIn(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		deleted []string
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"permissionTemplates": []map[string]any{
+				// Renamed built-in: no template here is named "Default
+				// Template", and none is any qualifier's current default
+				// (a custom template, not modeled here, holds that) — so
+				// neither isBuiltInPermissionTemplate nor
+				// isCurrentDefaultTemplate protects it.
+				{"id": "tpl-renamed-builtin", "name": "Custom Only"},
+			},
+			"defaultTemplates": []map[string]any{
+				{"templateId": "tpl-some-other-custom", "qualifier": "TRK"},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/permissions/delete_template", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		deleted = append(deleted, r.FormValue("templateId"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newDeleteTest(t, mux)
+
+	if err := runResetPermissionTemplates(context.Background(), e); err != nil {
+		t.Fatalf("runResetPermissionTemplates: %v", err)
+	}
+	if err := runDeleteTemplates(context.Background(), e); err != nil {
+		t.Fatalf("runDeleteTemplates: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deleted) != 0 {
+		t.Errorf("expected no template deletions for an org whose built-in reset failed, got %v", deleted)
+	}
+}

--- a/go/internal/migrate/tasks_delete_cov_test.go
+++ b/go/internal/migrate/tasks_delete_cov_test.go
@@ -266,8 +266,11 @@ func TestRunResetDefaultProfilesNoBuiltIn(t *testing.T) {
 	}
 }
 
-// resetPermissionTemplates: no built-in "Default Template" present hits the
-// "no built-in found" warn+fail branch.
+// resetPermissionTemplates: no built-in "Default Template" present must now
+// hard-fail the task (#550) rather than warn-and-continue. Silently
+// proceeding let deleteTemplates run against an org whose built-in was
+// renamed (so it never got promoted to default), risking deletion of
+// whatever template legitimately IS the current default.
 func TestRunResetPermissionTemplatesNoBuiltIn(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, _ *http.Request) {
@@ -281,7 +284,8 @@ func TestRunResetPermissionTemplatesNoBuiltIn(t *testing.T) {
 		})
 	})
 	e := newDeleteTest(t, mux)
-	if err := runResetPermissionTemplates(context.Background(), e); err != nil {
-		t.Fatalf("runResetPermissionTemplates: %v", err)
+	err := runResetPermissionTemplates(context.Background(), e)
+	if err == nil {
+		t.Fatal("runResetPermissionTemplates: expected an error when no built-in \"Default Template\" is found, got nil")
 	}
 }

--- a/go/internal/migrate/tasks_delete_cov_test.go
+++ b/go/internal/migrate/tasks_delete_cov_test.go
@@ -271,6 +271,12 @@ func TestRunResetDefaultProfilesNoBuiltIn(t *testing.T) {
 // proceeding let deleteTemplates run against an org whose built-in was
 // renamed (so it never got promoted to default), risking deletion of
 // whatever template legitimately IS the current default.
+// #551: a renamed built-in must fail only the affected org, not the
+// whole reset run — forEachMigrateItem fans out over an errgroup, and
+// this task is a dependency of deleteTemplates, so an error here would
+// have cancelled every other confirmed org's reset too.
+// deleteTemplates' isCurrentDefaultTemplate net independently protects
+// against destroying the real current default regardless of name.
 func TestRunResetPermissionTemplatesNoBuiltIn(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, _ *http.Request) {
@@ -285,7 +291,7 @@ func TestRunResetPermissionTemplatesNoBuiltIn(t *testing.T) {
 	})
 	e := newDeleteTest(t, mux)
 	err := runResetPermissionTemplates(context.Background(), e)
-	if err == nil {
-		t.Fatal("runResetPermissionTemplates: expected an error when no built-in \"Default Template\" is found, got nil")
+	if err != nil {
+		t.Fatalf("runResetPermissionTemplates: expected nil (fail the org, not the run) when no built-in \"Default Template\" is found, got %v", err)
 	}
 }

--- a/go/internal/migrate/tasks_delete_test.go
+++ b/go/internal/migrate/tasks_delete_test.go
@@ -316,8 +316,8 @@ func TestRunResetDefaultGatesSkipsWhenAlreadyDefault(t *testing.T) {
 // restoring. Issue #214.
 func TestRunResetDefaultProfilesPerLanguage(t *testing.T) {
 	var (
-		mu          sync.Mutex
-		setDefault  []map[string]string
+		mu         sync.Mutex
+		setDefault []map[string]string
 	)
 
 	mux := http.NewServeMux()
@@ -383,8 +383,8 @@ func TestRunResetDefaultProfilesPerLanguage(t *testing.T) {
 // never touches a built-in. Issue #214.
 func TestRunDeleteProfilesDeletesOnlyNonBuiltIn(t *testing.T) {
 	var (
-		mu       sync.Mutex
-		deleted  []map[string]string
+		mu      sync.Mutex
+		deleted []map[string]string
 	)
 
 	mux := http.NewServeMux()
@@ -477,7 +477,7 @@ func TestRunResetPermissionTemplatesPromotesBuiltInForEveryQualifier(t *testing.
 	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"permissionTemplates": []map[string]any{
-				{"id": "tpl-default", "name": "Default Template"},
+				{"id": "tpl-default", "name": defaultPermissionTemplateName},
 				{"id": "tpl-custom-proj", "name": "Custom Project Template"},
 				{"id": "tpl-custom-app", "name": "Mobile Apps"},
 			},
@@ -541,7 +541,7 @@ func TestRunResetPermissionTemplatesSkipsWhenAlreadyDefault(t *testing.T) {
 	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"permissionTemplates": []map[string]any{
-				{"id": "tpl-default", "name": "Default Template"},
+				{"id": "tpl-default", "name": defaultPermissionTemplateName},
 			},
 			"defaultTemplates": []map[string]any{
 				{"templateId": "tpl-default", "qualifier": "TRK"},
@@ -578,7 +578,7 @@ func TestRunDeleteTemplatesEnumeratesAndDeletes(t *testing.T) {
 	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"permissionTemplates": []map[string]any{
-				{"id": "tpl-default", "name": "Default Template"},
+				{"id": "tpl-default", "name": defaultPermissionTemplateName},
 				{"id": "tpl-1", "name": "DEFAULT"},
 				{"id": "tpl-2", "name": "Mobile Apps"},
 				// Trimmed + alternate case must still match the built-in.
@@ -618,5 +618,62 @@ func TestRunDeleteTemplatesEnumeratesAndDeletes(t *testing.T) {
 	}
 	if deletedSet["tpl-default"] || deletedSet["tpl-default-alt"] {
 		t.Error("built-in \"Default Template\" must never be deleted (case-insensitive name match)")
+	}
+}
+
+// TestRunDeleteTemplatesKeepsRenamedCurrentDefault pins the #550 fix: a
+// permission template renamed away from "Default Template" fails the
+// name-based built-in check, but if it is still listed as the org's
+// current default for some qualifier in the defaultTemplates map, it
+// must NOT be deleted. This is the scenario an admin renaming the org's
+// built-in template produces — without this second safety net,
+// isBuiltInPermissionTemplate's pure name match would let the renamed
+// built-in be destroyed even though it's still institutionally "the
+// default".
+func TestRunDeleteTemplatesKeepsRenamedCurrentDefault(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		deleted []string
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"permissionTemplates": []map[string]any{
+				// Renamed away from "Default Template" — fails the name
+				// check — but still the current default for TRK.
+				{"id": "tpl-1", "name": "Company Default"},
+				{"id": "tpl-2", "name": "Mobile Apps"},
+			},
+			"defaultTemplates": []map[string]any{
+				{"templateId": "tpl-1", "qualifier": "TRK"},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/permissions/delete_template", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		deleted = append(deleted, r.FormValue("templateId"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newDeleteTest(t, mux)
+
+	if err := runDeleteTemplates(context.Background(), e); err != nil {
+		t.Fatalf("runDeleteTemplates: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deleted) != 1 {
+		t.Fatalf("expected exactly 1 delete (\"Mobile Apps\"), got %d: %v", len(deleted), deleted)
+	}
+	if deleted[0] != "tpl-2" {
+		t.Errorf("expected \"Mobile Apps\" (tpl-2) deleted, got %v", deleted)
+	}
+	for _, id := range deleted {
+		if id == "tpl-1" {
+			t.Error("renamed built-in still listed as current default (tpl-1) must never be deleted")
+		}
 	}
 }

--- a/go/internal/migrate/tasks_flow_test.go
+++ b/go/internal/migrate/tasks_flow_test.go
@@ -1436,7 +1436,6 @@ func TestTasksWithFailingServer(t *testing.T) {
 		"setProjectSettings",
 		"setProjectTags",
 		// Permission tasks.
-		"setOrgGroupPermissions",
 		"setProfileGroupPermissions",
 		"createMigrationGroups",
 		"addMigrationGroupToTemplates",
@@ -1474,6 +1473,28 @@ func TestTasksWithFailingServer(t *testing.T) {
 		err := def.Run(context.Background(), e)
 		if err != nil {
 			t.Errorf("task %q should warn-and-swallow, but returned error: %v", taskName, err)
+		}
+	}
+
+	// Issue #550 (Fix B): a handful of permission-grant tasks now surface
+	// a real task error when EVERY grant they attempted failed, instead
+	// of silently swallowing a 100% failure like the tasks above (partial
+	// failure is still swallowed — only total failure changed). Against
+	// this fully-failing server, setOrgGroupPermissions attempts exactly
+	// one grant (sonar-users→Members "scan", from setupExtractData) and
+	// it fails, so it must now report the error so the DAG halts instead
+	// of proceeding as if the group had been granted anything.
+	totalFailureTasks := []string{
+		"setOrgGroupPermissions",
+	}
+	for _, taskName := range totalFailureTasks {
+		def, ok := reg[taskName]
+		if !ok {
+			t.Errorf("task %q not found in registry", taskName)
+			continue
+		}
+		if err := def.Run(context.Background(), e); err == nil {
+			t.Errorf("task %q should surface an error when every grant fails (issue #550), got nil", taskName)
 		}
 	}
 }

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -385,6 +385,9 @@ func distinctRuleKeys(hotspots []matchableHotspot) []string {
 func runSyncHotspotMetadata(ctx context.Context, e *Executor) error {
 	return forEachMigrateItem(ctx, e, "syncHotspotMetadata", "createProjects",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+			if isFailedMigrateRecord(item) {
+				return nil
+			}
 			cloudKey := extractField(item, "cloud_project_key")
 			orgKey := extractField(item, "sonarcloud_org_key")
 			serverURL := extractField(item, "server_url")

--- a/go/internal/migrate/tasks_hotspotsync_test.go
+++ b/go/internal/migrate/tasks_hotspotsync_test.go
@@ -562,3 +562,35 @@ func TestRunSyncHotspotMetadataWritesRecord(t *testing.T) {
 		t.Errorf("synced = %d, want 1", got.Synced)
 	}
 }
+
+// #551 (Gitar round 2): a createProjects record written with
+// status:"failed" (#525 cross-org collision, #550 empty-key branch)
+// still carries a non-empty cloud_project_key for the project SonarQube
+// Cloud never actually created. runSyncHotspotMetadata is one of
+// several createProjects consumers that has no reason to know the
+// project doesn't exist unless it checks — confirm it's skipped
+// entirely rather than being synced against (and reported as if it
+// were a real project).
+func TestRunSyncHotspotMetadataSkipsFailedCreateProjectsRecord(t *testing.T) {
+	rec := &hotspotIssueSyncRecorder{}
+	mux := http.NewServeMux()
+	rec.mount(mux)
+	e := newCustomCloudTest(t, mux)
+
+	writeTaskJSONL(t, e, "createProjects", []map[string]any{
+		{"cloud_project_key": "cloud_proj1", "sonarcloud_org_key": "org1", "server_url": testServerURL,
+			"key": "proj1", "status": "failed", "error": "empty project key"},
+	})
+
+	if err := runSyncHotspotMetadata(context.Background(), e); err != nil {
+		t.Fatalf("runSyncHotspotMetadata: %v", err)
+	}
+
+	items, err := e.Store.ReadAll("syncHotspotMetadata")
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("expected 0 syncHotspotMetadata records for a failed createProjects record, got %d: %s", len(items), items)
+	}
+}

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -15,9 +15,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	sqapi "github.com/sonar-solutions/sq-api-go"
 	sqtypes "github.com/sonar-solutions/sq-api-go/types"
-	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 )
 
 const resolutionFalsePositive = "FALSE-POSITIVE"
@@ -451,6 +451,9 @@ func runSyncIssueMetadata(ctx context.Context, e *Executor) error {
 	ruleDefaults := loadRuleTagDefaults(e)
 	err := forEachMigrateItem(ctx, e, "syncIssueMetadata", "createProjects",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+			if isFailedMigrateRecord(item) {
+				return nil
+			}
 			cloudKey := extractField(item, "cloud_project_key")
 			orgKey := extractField(item, "sonarcloud_org_key")
 			serverURL := extractField(item, "server_url")

--- a/go/internal/migrate/tasks_permissions.go
+++ b/go/internal/migrate/tasks_permissions.go
@@ -7,6 +7,7 @@ package migrate
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
@@ -78,6 +79,30 @@ func permissionTasks() []TaskDef {
 	}
 }
 
+// sonarUsersGroupName is the SonarQube Server built-in "everyone on this
+// server" group. Kept as a named constant so the three call sites that
+// guard against the admin-escalation alias (issue #550, see
+// skipAdminForBuiltInAlias) compare against the same literal.
+const sonarUsersGroupName = "sonar-users"
+
+// skipAdminForBuiltInAlias reports whether granting perm to a group would
+// be an accidental privilege escalation introduced by the sonar-users →
+// Members built-in alias (MapGroupNameToCloud, issue #269). That alias
+// remaps SQS's "everyone on this server" group to SQC's "everyone in
+// this org" group with zero awareness of which permission is being
+// carried over: a global admin permission granted to sonar-users on the
+// source would otherwise be faithfully re-granted to Members at org (or
+// resource) scope on the target, making every single org member an
+// administrator (issue #550).
+//
+// originalName MUST be the SOURCE group name, captured before
+// MapGroupNameToCloud runs — comparing the mapped name instead would
+// also catch a legitimately named custom "Members" group, which is not
+// what this guard is for.
+func skipAdminForBuiltInAlias(originalName, perm string) bool {
+	return originalName == sonarUsersGroupName && perm == "admin"
+}
+
 // migrationUserProjectPermissions are the four permissions the
 // migration user grants itself on every project it just created.
 // user=Browse, admin=Administer, issueadmin=Administer Issues,
@@ -114,7 +139,9 @@ func runGrantMigrationUserProjectPermissions(ctx context.Context, e *Executor) e
 			if cloudKey == "" {
 				return nil
 			}
+			var attempted, succeeded int
 			for _, perm := range migrationUserProjectPermissions {
+				attempted++
 				e.Logger.Debug("grantMigrationUserProjectPermissions: POST /api/permissions/add_user",
 					"login", login, "perm", perm, "project", cloudKey, "org", orgKey)
 				err := e.Cloud.Permissions.AddUser(ctx, login, perm, orgKey, cloudKey)
@@ -123,7 +150,19 @@ func runGrantMigrationUserProjectPermissions(ctx context.Context, e *Executor) e
 						"login", login, "project", cloudKey, "perm", perm)
 					continue
 				}
+				succeeded++
 				counter.Success()
+			}
+			// Issue #550: partial failure is expected and swallowed above
+			// so the other permissions still get applied — but if EVERY
+			// grant on this project failed, the migration user very
+			// likely can't administer it at all, and every downstream
+			// per-project task will 403. Surface that as a real task
+			// error so the DAG halts instead of silently proceeding as
+			// if the permissions were granted.
+			if attempted > 0 && succeeded == 0 {
+				return fmt.Errorf("all %d permission grant(s) failed for project %s (org %s)",
+					attempted, cloudKey, orgKey)
 			}
 			return nil
 		})
@@ -242,33 +281,49 @@ func runSetOrgGroupPermissions(ctx context.Context, e *Executor) error {
 			if shouldSkipOrg(orgKey) {
 				return nil
 			}
-			applyOrgPermissions(ctx, e, item.Data, name, orgKey, counter)
+			err := applyOrgPermissions(ctx, e, item.Data, name, orgKey, counter)
 			_ = w.WriteOne(item.Data)
-			return nil
+			return err
 		})
 	return err
 }
 
-func applyOrgPermissions(ctx context.Context, e *Executor, data json.RawMessage, name, orgKey string, counter *TaskCounter) {
+func applyOrgPermissions(ctx context.Context, e *Executor, data json.RawMessage, name, orgKey string, counter *TaskCounter) error {
 	// Issue #269: remap SQS built-in groups to their SQC equivalents
 	// (today: sonar-users → Members). Skip the grant if no equivalent
 	// exists.
 	cloudName, ok := MapGroupNameToCloud(name)
 	if !ok {
-		return
+		return nil
 	}
 	perms := extractPermissions(data)
+	var attempted, succeeded int
 	for _, perm := range perms {
 		if !validPermissions[perm] {
 			continue
 		}
+		// Issue #550: never auto-escalate the sonar-users → Members alias
+		// into an org-wide admin grant. The other permissions in this
+		// same group still get applied normally.
+		if skipAdminForBuiltInAlias(name, perm) {
+			e.Logger.Warn("setOrgGroupPermissions: admin NOT auto-granted to Members — source aliased it from sonar-users; grant manually if genuinely intended",
+				"group", cloudName, "org", orgKey)
+			counter.Fail()
+			continue
+		}
+		attempted++
 		err := e.Cloud.Permissions.AddGroup(ctx, cloudName, perm, orgKey, "")
 		if err != nil {
 			failAPI(counter, e.Logger, "setOrgGroupPermissions failed", err, "group", cloudName, "perm", perm)
-		} else {
-			counter.Success()
+			continue
 		}
+		succeeded++
+		counter.Success()
 	}
+	if attempted > 0 && succeeded == 0 {
+		return fmt.Errorf("all %d permission grant(s) failed for group %s in org %s", attempted, cloudName, orgKey)
+	}
+	return nil
 }
 
 func runSetProfileGroupPermissions(ctx context.Context, e *Executor) error {
@@ -295,16 +350,38 @@ func runSetProfileGroupPermissions(ctx context.Context, e *Executor) error {
 				return nil
 			}
 			refs := profileInfo[profileKey]
+			// api/qualityprofiles/add_group has no separate permission
+			// argument — the grant itself is "this group may edit the
+			// profile", i.e. it IS the admin-equivalent action for this
+			// resource. Issue #550: don't let the sonar-users → Members
+			// alias silently hand every org member edit rights on the
+			// profile; skip the grant entirely and require manual review.
+			if skipAdminForBuiltInAlias(groupName, "admin") {
+				for _, ref := range refs {
+					e.Logger.Warn("setProfileGroupPermissions: edit rights NOT auto-granted to Members — source aliased it from sonar-users; grant manually if genuinely intended",
+						"profile", ref.Name, "group", cloudGroup)
+					counter.Fail()
+				}
+				_ = w.WriteOne(item.Data)
+				return nil
+			}
+			var attempted, succeeded int
 			for _, ref := range refs {
+				attempted++
 				err := e.Cloud.QualityProfiles.AddGroup(ctx, ref.Language, ref.Name, cloudGroup, ref.OrgKey)
 				if err != nil {
 					failAPI(counter, e.Logger, "setProfileGroupPermissions failed", err,
 						"profile", ref.Name, "group", cloudGroup)
-				} else {
-					counter.Success()
+					continue
 				}
+				succeeded++
+				counter.Success()
 			}
 			_ = w.WriteOne(item.Data)
+			if attempted > 0 && succeeded == 0 {
+				return fmt.Errorf("all %d permission grant(s) failed for group %s on profile group %s",
+					attempted, cloudGroup, groupName)
+			}
 			return nil
 		})
 	return err
@@ -384,15 +461,15 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 
 	counter := TaskCounterFromContext(ctx)
 
-	apply := func(ctx context.Context, srvURL string, data json.RawMessage) {
+	apply := func(ctx context.Context, srvURL string, data json.RawMessage) error {
 		srcTemplateID := extractField(data, "templateId")
 		groupName := extractField(data, "name")
 		if srcTemplateID == "" || groupName == "" || skipGroups[groupName] {
-			return
+			return nil
 		}
 		tmpl, ok := templateMap[srvURL+"\x00"+srcTemplateID]
 		if !ok || tmpl.cloudID == "" || tmpl.org == "" {
-			return
+			return nil
 		}
 		// Issue #269: remap SQS built-in groups (sonar-users → Members).
 		// Aliased built-ins exist on SQC by default and won't appear in
@@ -400,15 +477,25 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 		// for them.
 		cloudGroup, mapOK := MapGroupNameToCloud(groupName)
 		if !mapOK {
-			return
+			return nil
 		}
 		aliased := cloudGroup != groupName
 		if !aliased && !groupExists[tmpl.org+"\x00"+groupName] {
-			return
+			return nil
 		}
 		perms := extractStringArray(data, "permissions")
+		var attempted, succeeded int
 		for _, perm := range perms {
 			if perm == "" {
+				continue
+			}
+			// Issue #550: never auto-escalate the sonar-users → Members
+			// alias into an admin grant on the permission template. The
+			// other permissions for this group/template still apply.
+			if skipAdminForBuiltInAlias(groupName, perm) {
+				e.Logger.Warn("setTemplateGroupPermissions: admin NOT auto-granted to Members — source aliased it from sonar-users; grant manually if genuinely intended",
+					"template", tmpl.cloudID, "group", cloudGroup)
+				counter.Fail()
 				continue
 			}
 			k := triple{tmpl.cloudID, cloudGroup, perm}
@@ -419,20 +506,26 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 			}
 			applied[k] = true
 			appliedMu.Unlock()
+			attempted++
 			if err := e.Cloud.Permissions.AddGroupToTemplate(ctx, tmpl.cloudID, cloudGroup, perm, tmpl.org); err != nil {
 				failAPI(counter, e.Logger, "setTemplateGroupPermissions failed", err,
 					"template", tmpl.cloudID, "group", cloudGroup, "perm", perm)
-			} else {
-				counter.Success()
+				continue
 			}
+			succeeded++
+			counter.Success()
 		}
+		if attempted > 0 && succeeded == 0 {
+			return fmt.Errorf("all %d permission grant(s) failed for group %s on template %s",
+				attempted, cloudGroup, tmpl.cloudID)
+		}
+		return nil
 	}
 
 	for _, feed := range []string{"getTemplateGroupsScanners", "getTemplateGroupsViewers"} {
 		if err := forEachExtractItem(ctx, e, feed+":apply", feed,
 			func(ctx context.Context, item structure.ExtractItem, _ *common.ChunkWriter) error {
-				apply(ctx, item.ServerURL, item.Data)
-				return nil
+				return apply(ctx, item.ServerURL, item.Data)
 			}); err != nil {
 			return err
 		}

--- a/go/internal/migrate/tasks_permissions.go
+++ b/go/internal/migrate/tasks_permissions.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
@@ -133,6 +135,17 @@ func runGrantMigrationUserProjectPermissions(ctx context.Context, e *Executor) e
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
 			if shouldSkipOrg(orgKey) {
+				return nil
+			}
+			// createProjects writes an explicit "failed" record (still
+			// carrying a non-empty cloud_project_key — the originally
+			// requested key, not the actual one) when it couldn't create
+			// the project in our org: a cross-org key collision (#525)
+			// or an empty key returned by a fresh create (#550). The
+			// project doesn't exist here, so every grant below would
+			// fail — skip rather than letting that surface as "all
+			// grants failed" and abort every other project in this run.
+			if extractField(item, "status") == "failed" {
 				return nil
 			}
 			cloudKey := extractField(item, "cloud_project_key")
@@ -271,6 +284,15 @@ func runSetOrgGroupPermissions(ctx context.Context, e *Executor) error {
 	orgKeys := buildServerOrgLookup(e)
 
 	counter := TaskCounterFromContext(ctx)
+	// #551: applyOrgPermissions' total-failure error must not be
+	// returned from the per-item closure — forEachExtractItem fans out
+	// over an errgroup, so the first item to return an error cancels
+	// the shared context and aborts every other group/org still being
+	// processed. Accumulate failures instead and report them once,
+	// after every item has run, so one ungrantable group doesn't stop
+	// the rest of the migration.
+	var failMu sync.Mutex
+	var totalFailures []string
 	err := forEachExtractItem(ctx, e, "setOrgGroupPermissions", "getGroups",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			name := extractField(item.Data, "name")
@@ -281,10 +303,19 @@ func runSetOrgGroupPermissions(ctx context.Context, e *Executor) error {
 			if shouldSkipOrg(orgKey) {
 				return nil
 			}
-			err := applyOrgPermissions(ctx, e, item.Data, name, orgKey, counter)
+			if err := applyOrgPermissions(ctx, e, item.Data, name, orgKey, counter); err != nil {
+				failMu.Lock()
+				totalFailures = append(totalFailures, err.Error())
+				failMu.Unlock()
+			}
 			_ = w.WriteOne(item.Data)
-			return err
+			return nil
 		})
+	if err == nil && len(totalFailures) > 0 {
+		sort.Strings(totalFailures)
+		err = fmt.Errorf("setOrgGroupPermissions: %d group(s) received no permissions at all: %s",
+			len(totalFailures), strings.Join(totalFailures, "; "))
+	}
 	return err
 }
 
@@ -306,9 +337,11 @@ func applyOrgPermissions(ctx context.Context, e *Executor, data json.RawMessage,
 		// into an org-wide admin grant. The other permissions in this
 		// same group still get applied normally.
 		if skipAdminForBuiltInAlias(name, perm) {
+			// #551: this is a deliberate security decision, not a
+			// failure — no attempt was made and none should be counted
+			// as failed. Logger.Warn already gives it visibility.
 			e.Logger.Warn("setOrgGroupPermissions: admin NOT auto-granted to Members — source aliased it from sonar-users; grant manually if genuinely intended",
 				"group", cloudName, "org", orgKey)
-			counter.Fail()
 			continue
 		}
 		attempted++
@@ -340,6 +373,12 @@ func runSetProfileGroupPermissions(ctx context.Context, e *Executor) error {
 	}
 
 	counter := TaskCounterFromContext(ctx)
+	// #551: see runSetOrgGroupPermissions — accumulate total-failure
+	// errors instead of returning them from the per-item closure, so
+	// one ungrantable group doesn't cancel the errgroup and abort every
+	// other profile/group still being processed.
+	var failMu sync.Mutex
+	var totalFailures []string
 	err := forEachExtractItem(ctx, e, "setProfileGroupPermissions", "getProfileGroups",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			profileKey := extractField(item.Data, "profileKey")
@@ -357,10 +396,11 @@ func runSetProfileGroupPermissions(ctx context.Context, e *Executor) error {
 			// alias silently hand every org member edit rights on the
 			// profile; skip the grant entirely and require manual review.
 			if skipAdminForBuiltInAlias(groupName, "admin") {
+				// #551: a deliberate security skip, not a failure — no
+				// counter increment (Logger.Warn already surfaces it).
 				for _, ref := range refs {
 					e.Logger.Warn("setProfileGroupPermissions: edit rights NOT auto-granted to Members — source aliased it from sonar-users; grant manually if genuinely intended",
 						"profile", ref.Name, "group", cloudGroup)
-					counter.Fail()
 				}
 				_ = w.WriteOne(item.Data)
 				return nil
@@ -379,11 +419,17 @@ func runSetProfileGroupPermissions(ctx context.Context, e *Executor) error {
 			}
 			_ = w.WriteOne(item.Data)
 			if attempted > 0 && succeeded == 0 {
-				return fmt.Errorf("all %d permission grant(s) failed for group %s on profile group %s",
-					attempted, cloudGroup, groupName)
+				failMu.Lock()
+				totalFailures = append(totalFailures, fmt.Sprintf("group %s on profile group %s", cloudGroup, groupName))
+				failMu.Unlock()
 			}
 			return nil
 		})
+	if err == nil && len(totalFailures) > 0 {
+		sort.Strings(totalFailures)
+		err = fmt.Errorf("setProfileGroupPermissions: %d group(s) received no permissions at all: %s",
+			len(totalFailures), strings.Join(totalFailures, "; "))
+	}
 	return err
 }
 
@@ -459,6 +505,18 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 	applied := make(map[triple]bool)
 	var appliedMu sync.Mutex
 
+	// #551: track attempted/succeeded per (template, group) pair ACROSS
+	// both feeds, not per apply() invocation. Without this, a group
+	// whose scanners-feed row already succeeded on one permission would
+	// still be reported as "all grants failed" if the viewers-feed row
+	// for the SAME pair carries one additional permission that fails —
+	// each feed's row was previously tallied independently, so the
+	// earlier feed's success was invisible to the later one.
+	type pairKey struct{ cloudTemplate, group string }
+	type pairStat struct{ attempted, succeeded int }
+	pairStats := make(map[pairKey]*pairStat)
+	var statsMu sync.Mutex
+
 	counter := TaskCounterFromContext(ctx)
 
 	apply := func(ctx context.Context, srvURL string, data json.RawMessage) error {
@@ -484,7 +542,6 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 			return nil
 		}
 		perms := extractStringArray(data, "permissions")
-		var attempted, succeeded int
 		for _, perm := range perms {
 			if perm == "" {
 				continue
@@ -493,9 +550,10 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 			// alias into an admin grant on the permission template. The
 			// other permissions for this group/template still apply.
 			if skipAdminForBuiltInAlias(groupName, perm) {
+				// #551: a deliberate security skip, not a failure — no
+				// counter increment (Logger.Warn already surfaces it).
 				e.Logger.Warn("setTemplateGroupPermissions: admin NOT auto-granted to Members — source aliased it from sonar-users; grant manually if genuinely intended",
 					"template", tmpl.cloudID, "group", cloudGroup)
-				counter.Fail()
 				continue
 			}
 			k := triple{tmpl.cloudID, cloudGroup, perm}
@@ -506,29 +564,56 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 			}
 			applied[k] = true
 			appliedMu.Unlock()
-			attempted++
+
+			pk := pairKey{tmpl.cloudID, cloudGroup}
+			statsMu.Lock()
+			stat, ok := pairStats[pk]
+			if !ok {
+				stat = &pairStat{}
+				pairStats[pk] = stat
+			}
+			stat.attempted++
+			statsMu.Unlock()
+
 			if err := e.Cloud.Permissions.AddGroupToTemplate(ctx, tmpl.cloudID, cloudGroup, perm, tmpl.org); err != nil {
 				failAPI(counter, e.Logger, "setTemplateGroupPermissions failed", err,
 					"template", tmpl.cloudID, "group", cloudGroup, "perm", perm)
 				continue
 			}
-			succeeded++
+			statsMu.Lock()
+			stat.succeeded++
+			statsMu.Unlock()
 			counter.Success()
-		}
-		if attempted > 0 && succeeded == 0 {
-			return fmt.Errorf("all %d permission grant(s) failed for group %s on template %s",
-				attempted, cloudGroup, tmpl.cloudID)
 		}
 		return nil
 	}
 
+	// #551: run both feeds to completion (don't abort the second on the
+	// first feed's error) and defer the total-failure verdict until
+	// every (template, group) pair's stats are final across both feeds.
+	var feedErrs []string
 	for _, feed := range []string{"getTemplateGroupsScanners", "getTemplateGroupsViewers"} {
 		if err := forEachExtractItem(ctx, e, feed+":apply", feed,
 			func(ctx context.Context, item structure.ExtractItem, _ *common.ChunkWriter) error {
 				return apply(ctx, item.ServerURL, item.Data)
 			}); err != nil {
-			return err
+			feedErrs = append(feedErrs, err.Error())
 		}
+	}
+	if len(feedErrs) > 0 {
+		return fmt.Errorf("setTemplateGroupPermissions: %s", strings.Join(feedErrs, "; "))
+	}
+
+	var totalFailures []string
+	for k, stat := range pairStats {
+		if stat.attempted > 0 && stat.succeeded == 0 {
+			totalFailures = append(totalFailures, fmt.Sprintf("group %s on template %s", k.group, k.cloudTemplate))
+		}
+	}
+	if len(totalFailures) > 0 {
+		sort.Strings(totalFailures)
+		return fmt.Errorf("setTemplateGroupPermissions: %d group(s) received no permissions at all: %s",
+			len(totalFailures), strings.Join(totalFailures, "; "))
 	}
 	return nil
 }

--- a/go/internal/migrate/tasks_permissions.go
+++ b/go/internal/migrate/tasks_permissions.go
@@ -131,6 +131,8 @@ func runGrantMigrationUserProjectPermissions(ctx context.Context, e *Executor) e
 	}
 
 	counter := TaskCounterFromContext(ctx)
+	var failMu sync.Mutex
+	var totalFailures []string
 	err := forEachMigrateItem(ctx, e, "grantMigrationUserProjectPermissions", "createProjects",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -145,7 +147,7 @@ func runGrantMigrationUserProjectPermissions(ctx context.Context, e *Executor) e
 			// project doesn't exist here, so every grant below would
 			// fail — skip rather than letting that surface as "all
 			// grants failed" and abort every other project in this run.
-			if extractField(item, "status") == "failed" {
+			if isFailedMigrateRecord(item) {
 				return nil
 			}
 			cloudKey := extractField(item, "cloud_project_key")
@@ -170,15 +172,25 @@ func runGrantMigrationUserProjectPermissions(ctx context.Context, e *Executor) e
 			// so the other permissions still get applied — but if EVERY
 			// grant on this project failed, the migration user very
 			// likely can't administer it at all, and every downstream
-			// per-project task will 403. Surface that as a real task
-			// error so the DAG halts instead of silently proceeding as
-			// if the permissions were granted.
+			// per-project task will 403. #551: accumulate this rather
+			// than returning it directly — forEachMigrateItem runs items
+			// in an errgroup, so returning an error here would cancel
+			// the shared context and abort every other project still in
+			// flight. Report one aggregated error after all items have
+			// been attempted, same as the sibling permission tasks.
 			if attempted > 0 && succeeded == 0 {
-				return fmt.Errorf("all %d permission grant(s) failed for project %s (org %s)",
-					attempted, cloudKey, orgKey)
+				failMu.Lock()
+				totalFailures = append(totalFailures, fmt.Sprintf("project %s (org %s): all %d grant(s) failed",
+					cloudKey, orgKey, attempted))
+				failMu.Unlock()
 			}
 			return nil
 		})
+	if err == nil && len(totalFailures) > 0 {
+		sort.Strings(totalFailures)
+		err = fmt.Errorf("grantMigrationUserProjectPermissions: %d project(s) received no permissions at all: %s",
+			len(totalFailures), strings.Join(totalFailures, "; "))
+	}
 	return err
 }
 

--- a/go/internal/migrate/tasks_permissions_cov_test.go
+++ b/go/internal/migrate/tasks_permissions_cov_test.go
@@ -172,6 +172,56 @@ func TestRunGrantMigrationUserProjectPermissionsSkipsFailedRecords(t *testing.T)
 	}
 }
 
+// #551 (Gitar round 2): a genuinely-existing project whose four add_user
+// calls all 403 (e.g. the migration token lacks admin on it) used to
+// return that as a hard error straight out of the forEachMigrateItem
+// closure, cancelling the shared errgroup context and aborting every
+// other project still in flight — a cascade of spurious "context
+// canceled" failures burying the one real cause. Confirm the sibling
+// project's grants still complete, and the task still reports the
+// total-failure as an error (just accumulated, not fatal-mid-flight).
+func TestRunGrantMigrationUserProjectPermissionsOneProjectFailureDoesNotAbortSiblings(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		byProj = map[string]int{}
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/permissions/add_user", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		project := r.FormValue("projectKey")
+		mu.Lock()
+		byProj[project]++
+		mu.Unlock()
+		if project == "cloud-proj-forbidden" {
+			http.Error(w, `{"errors":[{"msg":"Insufficient privileges"}]}`, http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newCustomCloudTest(t, mux)
+
+	writeTaskJSONL(t, e, "getMigrationUser", []map[string]any{{"login": "migration-user"}})
+	writeTaskJSONL(t, e, "createProjects", []map[string]any{
+		{"key": "proj1", "cloud_project_key": "cloud-proj-forbidden", "sonarcloud_org_key": "cloud-org"},
+		{"key": "proj2", "cloud_project_key": "cloud-proj-good", "sonarcloud_org_key": "cloud-org"},
+	})
+
+	err := runGrantMigrationUserProjectPermissions(context.Background(), e)
+	if err == nil {
+		t.Fatal("expected an aggregated error reporting the forbidden project's total failure, got nil")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := byProj["cloud-proj-good"], len(migrationUserProjectPermissions); got != want {
+		t.Errorf("cloud-proj-good: got %d add_user calls, want %d — one project's total failure must not abort a sibling's grants",
+			got, want)
+	}
+}
+
 // --- runSetTemplateGroupPermissions (was 0.0%) ---
 
 // setupTemplateGroupExtract writes the two template-group feeds plus the

--- a/go/internal/migrate/tasks_permissions_cov_test.go
+++ b/go/internal/migrate/tasks_permissions_cov_test.go
@@ -124,6 +124,54 @@ func TestRunGrantMigrationUserProjectPermissionsAPIError(t *testing.T) {
 	}
 }
 
+// #551: createProjects writes an explicit "failed" record — still
+// carrying a non-empty cloud_project_key, the originally requested one
+// — when it couldn't create the project in our org (#525 cross-org
+// collision, #550 empty returned key). That project doesn't exist, so
+// every grant on it would fail; before this fix that 100%-failure
+// error propagated out of the errgroup and cancelled every other
+// project's grants too. Confirm a "failed" record is skipped entirely
+// (no add_user calls for it) and does not prevent a genuinely valid
+// project in the same run from getting its grants.
+func TestRunGrantMigrationUserProjectPermissionsSkipsFailedRecords(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		byProj = map[string]int{}
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/permissions/add_user", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		byProj[r.FormValue("projectKey")]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newCustomCloudTest(t, mux)
+
+	writeTaskJSONL(t, e, "getMigrationUser", []map[string]any{{"login": "migration-user"}})
+	writeTaskJSONL(t, e, "createProjects", []map[string]any{
+		{"key": "proj1", "cloud_project_key": "cloud-proj-good", "sonarcloud_org_key": "cloud-org"},
+		{"key": "proj2", "cloud_project_key": "cloud-proj-bad", "sonarcloud_org_key": "cloud-org",
+			"status": "failed", "error": "empty project key"},
+	})
+
+	if err := runGrantMigrationUserProjectPermissions(context.Background(), e); err != nil {
+		t.Fatalf("runGrantMigrationUserProjectPermissions: %v (a failed record must not abort the whole task)", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := byProj["cloud-proj-good"], len(migrationUserProjectPermissions); got != want {
+		t.Errorf("cloud-proj-good: got %d add_user calls, want %d", got, want)
+	}
+	if got := byProj["cloud-proj-bad"]; got != 0 {
+		t.Errorf("cloud-proj-bad (status=failed): got %d add_user calls, want 0 — failed records must be skipped", got)
+	}
+}
+
 // --- runSetTemplateGroupPermissions (was 0.0%) ---
 
 // setupTemplateGroupExtract writes the two template-group feeds plus the

--- a/go/internal/migrate/tasks_permissions_cov_test.go
+++ b/go/internal/migrate/tasks_permissions_cov_test.go
@@ -103,8 +103,9 @@ func TestRunGrantMigrationUserProjectPermissionsBlankLogin(t *testing.T) {
 	}
 }
 
-// add_user failing (403) exercises the counter.Fail()/continue branch without
-// failing the task.
+// add_user failing (403) for every permission on the project means the
+// migration user got nothing on it — issue #550 (Fix B) now surfaces that
+// as a task error instead of silently swallowing a 100% failure.
 func TestRunGrantMigrationUserProjectPermissionsAPIError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/permissions/add_user", func(w http.ResponseWriter, _ *http.Request) {
@@ -118,8 +119,8 @@ func TestRunGrantMigrationUserProjectPermissionsAPIError(t *testing.T) {
 	writeTaskJSONL(t, e, "createProjects", []map[string]any{
 		{"key": "proj1", "cloud_project_key": "cloud-proj", "sonarcloud_org_key": "cloud-org"},
 	})
-	if err := runGrantMigrationUserProjectPermissions(context.Background(), e); err != nil {
-		t.Fatalf("add_user 403 must be swallowed, got err %v", err)
+	if err := runGrantMigrationUserProjectPermissions(context.Background(), e); err == nil {
+		t.Fatal("expected an error when every add_user grant on the project fails (100% failure), got nil")
 	}
 }
 
@@ -222,6 +223,11 @@ func TestRunSetTemplateGroupPermissionsNoTemplates(t *testing.T) {
 
 // --- runSetOrgGroupPermissions error branch (add_group fails) ---
 
+// add_group failing (403) for the only permission on the only group means
+// that group ended up with nothing granted — issue #550 (Fix B) now
+// surfaces that as a task error instead of silently swallowing a 100%
+// failure. Requires a generateOrganizationMappings row so the org isn't
+// treated as skipped (shouldSkipOrg) and the grant is actually attempted.
 func TestRunSetOrgGroupPermissionsAddGroupError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/permissions/add_group", func(w http.ResponseWriter, _ *http.Request) {
@@ -237,13 +243,169 @@ func TestRunSetOrgGroupPermissionsAddGroupError(t *testing.T) {
 	dir := t.TempDir()
 	setupExtractData(dir) // getGroups row: sonar-users (→ Members) with scan perm
 	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
+		{"server_url": testServerURL, "sonarcloud_org_key": "cloud-org"},
+	})
 
-	if err := runSetOrgGroupPermissions(context.Background(), e); err != nil {
-		t.Fatalf("add_group 403 must be swallowed, got %v", err)
+	if err := runSetOrgGroupPermissions(context.Background(), e); err == nil {
+		t.Fatal("expected an error when every add_group grant on the group fails (100% failure), got nil")
 	}
 }
 
 // extractPath returns the extract-run directory path for a feed name.
 func extractPath(e *Executor, feed string) string {
 	return filepath.Join(e.ExportDir, "extract-01", feed)
+}
+
+// --- Fix A (issue #550): sonar-users → Members must never auto-escalate admin ---
+
+// TestRunSetOrgGroupPermissionsSkipsAdminForSonarUsersAlias exercises
+// applyOrgPermissions' org-level guard: when the source sonar-users group
+// (aliased to SQC's Members) held the global admin permission, that grant
+// must be skipped — re-granting it would make every org member an admin —
+// while the group's other permissions are still applied normally.
+func TestRunSetOrgGroupPermissionsSkipsAdminForSonarUsersAlias(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls []string // "<group>:<perm>"
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/permissions/add_group", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		calls = append(calls, r.FormValue("groupName")+":"+r.FormValue("permission"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newCustomCloudTest(t, mux)
+
+	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
+		{"server_url": testServerURL, "sonarcloud_org_key": "cloud-org"},
+	})
+	// sonar-users source group holds both admin (dangerous) and scan (fine).
+	writeJSONL(extractPath(e, "getGroups"), []map[string]any{
+		{"id": "1", "name": testSonarUsers, "permissions": []string{"admin", "scan"},
+			"serverUrl": testServerURL},
+	})
+
+	if err := runSetOrgGroupPermissions(context.Background(), e); err != nil {
+		t.Fatalf("runSetOrgGroupPermissions: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	got := map[string]bool{}
+	for _, c := range calls {
+		got[c] = true
+	}
+	if got["Members:admin"] {
+		t.Errorf("admin must NOT be auto-granted to Members via the sonar-users alias (issue #550), calls=%v", calls)
+	}
+	if !got["Members:scan"] {
+		t.Errorf("expected scan still granted to Members, got %v", calls)
+	}
+}
+
+// TestRunSetProfileGroupPermissionsSkipsSonarUsersAlias exercises the
+// quality-profile call site. api/qualityprofiles/add_group has no separate
+// permission argument — the grant itself hands the group edit rights on
+// the profile, so it is treated as the admin-equivalent action and skipped
+// entirely for the sonar-users → Members alias, while a normal custom
+// group's grant on the same profile still goes through.
+func TestRunSetProfileGroupPermissionsSkipsSonarUsersAlias(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		calls []string // "<group>"
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/qualityprofiles/add_group", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		calls = append(calls, r.FormValue("group"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newCustomCloudTest(t, mux)
+
+	writeTaskJSONL(t, e, "createProfiles", []map[string]any{
+		{"source_profile_key": "prof1", "sonarcloud_org_key": "cloud-org",
+			"name": "Custom", "language": "java"},
+	})
+	writeJSONL(extractPath(e, "getProfileGroups"), []map[string]any{
+		{"profileKey": "prof1", "name": testSonarUsers, "serverUrl": testServerURL},
+		{"profileKey": "prof1", "name": "developers", "serverUrl": testServerURL},
+	})
+
+	if err := runSetProfileGroupPermissions(context.Background(), e); err != nil {
+		t.Fatalf("runSetProfileGroupPermissions: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	got := map[string]bool{}
+	for _, c := range calls {
+		got[c] = true
+	}
+	if got["Members"] {
+		t.Errorf("Members (sonar-users alias) must NOT be auto-granted edit rights on the profile (issue #550), calls=%v", calls)
+	}
+	if !got["developers"] {
+		t.Errorf("expected developers still granted on the profile, got %v", calls)
+	}
+}
+
+// TestRunSetTemplateGroupPermissionsSkipsAdminForSonarUsersAlias exercises
+// the permission-template call site: sonar-users holding admin on the
+// source template must not translate into an admin grant to Members on
+// the target, while its other permission (user) is still applied.
+func TestRunSetTemplateGroupPermissionsSkipsAdminForSonarUsersAlias(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		adds []string // "<group>:<perm>"
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/permissions/add_group_to_template", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		adds = append(adds, r.FormValue("groupName")+":"+r.FormValue("permission"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	e := newCustomCloudTest(t, mux)
+
+	writeTaskJSONL(t, e, "createPermissionTemplates", []map[string]any{
+		{"server_url": testServerURL, "source_template_key": "tpl-src-1",
+			"cloud_template_id": "tpl-cloud-1", "sonarcloud_org_key": "cloud-org"},
+	})
+	writeJSONL(extractPath(e, "getTemplateGroupsScanners"), []map[string]any{
+		{"templateId": "tpl-src-1", "name": testSonarUsers,
+			"permissions": []string{"admin", "user"}, "serverUrl": testServerURL},
+	})
+	writeJSONL(extractPath(e, "getTemplateGroupsViewers"), nil)
+
+	if err := runSetTemplateGroupPermissions(context.Background(), e); err != nil {
+		t.Fatalf("runSetTemplateGroupPermissions: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	got := map[string]bool{}
+	for _, a := range adds {
+		got[a] = true
+	}
+	if got["Members:admin"] {
+		t.Errorf("admin must NOT be auto-granted to Members via the sonar-users alias (issue #550), adds=%v", adds)
+	}
+	if !got["Members:user"] {
+		t.Errorf("expected user still granted to Members, got %v", adds)
+	}
 }

--- a/go/internal/migrate/tasks_portfolios.go
+++ b/go/internal/migrate/tasks_portfolios.go
@@ -193,6 +193,9 @@ func buildProjectCloudKeyIndex(e *Executor) map[string]cloudProjectInfo {
 	projects, _ := e.Store.ReadAll("createProjects")
 	out := make(map[string]cloudProjectInfo, len(projects))
 	for _, p := range projects {
+		if isFailedMigrateRecord(p) {
+			continue
+		}
 		serverURL := extractField(p, "server_url")
 		key := extractField(p, "key")
 		if serverURL == "" || key == "" {

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -58,6 +58,9 @@ func runImportProjectData(ctx context.Context, e *Executor) error {
 	g.SetLimit(cap(e.Sem))
 
 	for _, proj := range projects {
+		if isFailedMigrateRecord(proj) {
+			continue
+		}
 		cloudKey := extractField(proj, "cloud_project_key")
 		orgKey := extractField(proj, "sonarcloud_org_key")
 		serverURL := extractField(proj, "server_url")

--- a/go/internal/migrate/tasks_read.go
+++ b/go/internal/migrate/tasks_read.go
@@ -61,6 +61,9 @@ func readTasks() []TaskDef {
 func runGetProjectIds(ctx context.Context, e *Executor) error {
 	return forEachMigrateItem(ctx, e, "getProjectIds", "createProjects",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+			if isFailedMigrateRecord(item) {
+				return nil
+			}
 			orgKey := extractField(item, "sonarcloud_org_key")
 			projectKey := extractField(item, "cloud_project_key")
 			if shouldSkipOrg(orgKey) || projectKey == "" {
@@ -273,6 +276,9 @@ func runGetCreatedProjects(ctx context.Context, e *Executor) error {
 			continue
 		}
 		for _, item := range items {
+			if isFailedMigrateRecord(item) {
+				continue
+			}
 			cloudKey := extractField(item, "cloud_project_key")
 			if cloudKey == "" || seen[cloudKey] {
 				continue
@@ -331,6 +337,9 @@ func MigrateCreatedProjectCounts(exportDir string) (map[string]int, error) {
 			continue
 		}
 		for _, item := range items {
+			if isFailedMigrateRecord(item) {
+				continue
+			}
 			cloudKey := extractField(item, "cloud_project_key")
 			if cloudKey == "" || seen[cloudKey] {
 				continue

--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -542,6 +542,9 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 	projects, _ := e.Store.ReadAll("createProjects")
 	projectKeyMap := make(map[string]projectMapping, len(projects))
 	for _, p := range projects {
+		if isFailedMigrateRecord(p) {
+			continue
+		}
 		serverURL := extractField(p, "server_url")
 		key := extractField(p, "key")
 		projectKeyMap[serverURL+key] = projectMapping{

--- a/go/internal/migrate/testutil_test.go
+++ b/go/internal/migrate/testutil_test.go
@@ -28,7 +28,17 @@ const (
 	testSonarUsers = "sonar-users"
 )
 
-// newMockCloudServer creates a mock SonarQube Cloud server for testing.
+// newMockCloudServer creates a mock SonarQube Cloud server for testing —
+// the "happy path" server: creates/updates succeed, searches return
+// realistic-but-generic fixtures. Used by newFlowTest/newTestExecutor
+// and most of this package's tests.
+//
+// newAlreadyExistsCloudServer (below) is a SEPARATE, deliberately
+// NOT-shared mock for the different "everything already exists"
+// scenario. The two are not DRY on purpose — before editing a handler
+// in one, check whether the same concern needs the same fix in the
+// other (issue #550 found exactly this: a template-name fixture was
+// only correct in one of the two).
 func newMockCloudServer() *httptest.Server {
 	mux := http.NewServeMux()
 
@@ -293,6 +303,20 @@ func newMockCloudServer() *httptest.Server {
 		json.NewEncoder(w).Encode(map[string]any{"organizations": orgs})
 	})
 
+	// #550: reset's resetPermissionTemplates hard-fails when no template
+	// matches defaultPermissionTemplateName by name (no isBuiltIn flag
+	// exists for permission templates in the real API) — reference the
+	// production constant directly, not a hand-typed copy of the
+	// string, so this fixture can never silently drift out of sync with
+	// what tasks_delete.go actually checks against.
+	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"permissionTemplates": []map[string]any{
+				{"id": "existing-tpl-id", "name": defaultPermissionTemplateName},
+			},
+		})
+	})
+
 	// Catch-all.
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{})
@@ -303,7 +327,9 @@ func newMockCloudServer() *httptest.Server {
 
 // newAlreadyExistsCloudServer creates a mock Cloud server where all POST create
 // endpoints return 400 "already exists", and GET search endpoints return
-// matching resources for lookup.
+// matching resources for lookup. This is a SEPARATE mux from
+// newMockCloudServer (above), not a variant built on top of it — see
+// that function's comment before editing a handler here.
 func newAlreadyExistsCloudServer() *httptest.Server {
 	existsBody := func(name string) string {
 		return fmt.Sprintf(`{"errors":[{"msg":"%s already exists"}]}`, name)
@@ -368,6 +394,11 @@ func newAlreadyExistsCloudServer() *httptest.Server {
 			},
 		})
 	})
+	// NOT the reset built-in — this "Default" is an arbitrary CUSTOM
+	// template name for TestCreatePermissionTemplates_AlreadyExists'
+	// already-exists/lookup scenario. Do not "fix" it to
+	// defaultPermissionTemplateName; that's a different mock
+	// (newMockCloudServer, above) testing a different concern.
 	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"permissionTemplates": []map[string]any{

--- a/go/internal/predict/branch_source_purged_test.go
+++ b/go/internal/predict/branch_source_purged_test.go
@@ -25,7 +25,7 @@ func TestSynthesizeBranchSourcePurged(t *testing.T) {
 		"name,key,server_url,sonarqube_org_key\n"+
 			"App,com.example:app,"+testServerURL+",default\n")
 
-	extractDir := filepath.Join(exportDir, "extract-0001")
+	extractDir := filepath.Join(exportDir, "2026-08-20-0001")
 	writeFile(t, extractDir, "extract.json", `{"url":"`+testServerURL+`"}`)
 
 	// Two LONG branches: main (has source) and release-1.0 (purged).

--- a/go/internal/predict/predict_test.go
+++ b/go/internal/predict/predict_test.go
@@ -79,7 +79,7 @@ func setupPredictiveFixture(t *testing.T) string {
 	// projects.csv row gets no sonarcloud_org_key and is filtered out by
 	// the synthesizer (mirrors migrate's shouldSkipOrg).
 
-	extractID := "extract-0001"
+	extractID := "2026-08-20-0001"
 	extractDir := filepath.Join(exportDir, extractID)
 	writeFile(t, extractDir, "extract.json", `{"url":"`+testServerURL+`"}`)
 
@@ -279,7 +279,7 @@ func TestGeneratePredictiveReport_ConsolidatesSonarAuth(t *testing.T) {
 	writeFile(t, exportDir, "gates.csv",
 		"name,server_url,source_gate_key,is_default,sonarqube_org_key\n")
 
-	extractID := "extract-0001"
+	extractID := "2026-08-20-0001"
 	extractDir := filepath.Join(exportDir, extractID)
 	writeFile(t, extractDir, "extract.json", `{"url":"`+testServerURL+`"}`)
 
@@ -360,7 +360,7 @@ func TestGeneratePredictiveReport_HotspotAcknowledgedDemotion(t *testing.T) {
 	writeFile(t, exportDir, "gates.csv",
 		"name,server_url,source_gate_key,is_default,sonarqube_org_key\n")
 
-	extractID := "extract-0001"
+	extractID := "2026-08-20-0001"
 	extractDir := filepath.Join(exportDir, extractID)
 	writeFile(t, extractDir, "extract.json", `{"url":"`+testServerURL+`"}`)
 

--- a/go/internal/predict/sync_hotspot_metadata_test.go
+++ b/go/internal/predict/sync_hotspot_metadata_test.go
@@ -28,7 +28,7 @@ func TestSynthesizeSyncHotspotMetadataEligibility(t *testing.T) {
 	writeFile(t, exportDir, "gates.csv",
 		"name,server_url,source_gate_key,is_default,sonarqube_org_key\n")
 
-	extractDir := filepath.Join(exportDir, "extract-0001")
+	extractDir := filepath.Join(exportDir, "2026-08-20-0001")
 	writeFile(t, extractDir, "extract.json", `{"url":"`+testServerURL+`"}`)
 
 	writeJSONL(t, filepath.Join(extractDir, "getProjectHotspotsFull", "hotspots.jsonl"),

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -247,7 +247,7 @@ func TestCollectSummaryGateBuiltInAndUnused(t *testing.T) {
 	os.MkdirAll(runDir, 0o755)
 
 	// Extract data: 3 gates — 1 built-in, 1 used, 1 unused.
-	extractDir := filepath.Join(dir, "extract-01")
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
 	writeExtractMeta(t, extractDir, "https://sq.example.com")
 	writeTaskJSONL(t, extractDir, "getGates", []map[string]any{
 		{"name": "Sonar way", "isBuiltIn": true},
@@ -294,7 +294,7 @@ func TestCollectSummaryProfileBuiltInAndUnused(t *testing.T) {
 	runDir := filepath.Join(dir, runID)
 	os.MkdirAll(runDir, 0o755)
 
-	extractDir := filepath.Join(dir, "extract-01")
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
 	writeExtractMeta(t, extractDir, "https://sq.example.com")
 	writeTaskJSONL(t, extractDir, "getProfiles", []map[string]any{
 		{"name": "Sonar way", "language": "java", "isBuiltIn": true},
@@ -442,7 +442,7 @@ func TestCollectSummaryPortfolioHierarchyPartial(t *testing.T) {
 	// Extract describes a top-level portfolio "Top" with one subportfolio
 	// "Mid" which itself has one subportfolio "Leaf"; plus a stand-alone
 	// portfolio "Solo" with no children.
-	extractDir := filepath.Join(dir, "extract-01")
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
 	writeExtractMeta(t, extractDir, "https://sq.example.com")
 	writeTaskJSONL(t, extractDir, "getPortfolioDetails", []map[string]any{
 		{
@@ -550,7 +550,7 @@ func TestCollectSummaryPortfolioApplicationsClassification(t *testing.T) {
 	runDir := filepath.Join(dir, runID)
 	os.MkdirAll(runDir, 0o755)
 
-	extractDir := filepath.Join(dir, "extract-01")
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
 	writeExtractMeta(t, extractDir, "https://sq.example.com")
 	writeTaskJSONL(t, extractDir, "getPortfolioDetails", []map[string]any{
 		{
@@ -634,7 +634,7 @@ func TestCollectSummaryPortfolioEmpty(t *testing.T) {
 	runDir := filepath.Join(dir, runID)
 	os.MkdirAll(runDir, 0o755)
 
-	extractDir := filepath.Join(dir, "extract-01")
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
 	writeExtractMeta(t, extractDir, "https://sq.example.com")
 	// "NonEmpty" has one resolved project, "Empty" has none.
 	writeTaskJSONL(t, extractDir, "getPortfolioProjects", []map[string]any{
@@ -1185,7 +1185,7 @@ func TestCollectSummaryMentionsUnmigratedApplications(t *testing.T) {
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	extractDir := filepath.Join(dir, "extract-01")
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
 	writeExtractMeta(t, extractDir, "https://sq.example.com")
 	writeTaskJSONL(t, extractDir, "getApplications", []map[string]any{
 		{"key": "app1", "name": "Application 1"},
@@ -1235,7 +1235,7 @@ func TestCollectSummaryNCDLimitations(t *testing.T) {
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	extractDir := filepath.Join(dir, "extract-01")
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
 	writeExtractMeta(t, extractDir, "https://sq.example.com")
 	writeTaskJSONL(t, extractDir, "getNewCodePeriods", []map[string]any{
 		// main-branch records carry the project-level NCD. inherited=true
@@ -1305,7 +1305,7 @@ func TestCollectSummaryNCDFallbackMovesProjectToPartial(t *testing.T) {
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	writeExtractMeta(t, filepath.Join(dir, "extract-01"), "https://sq.example.com")
+	writeExtractMeta(t, filepath.Join(dir, "2026-08-20-0001"), "https://sq.example.com")
 
 	writeTaskJSONL(t, runDir, "createProjects", []map[string]any{
 		{"name": "Project A", "sonarcloud_org_key": "org1", "cloud_project_key": "org1_projA"},
@@ -1360,7 +1360,7 @@ func TestCollectSummaryNoApplicationsLimitation(t *testing.T) {
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	extractDir := filepath.Join(dir, "extract-01")
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
 	writeExtractMeta(t, extractDir, "https://sq.example.com")
 	// getApplications dir exists but is empty.
 	writeTaskJSONL(t, extractDir, "getApplications", nil)
@@ -1431,7 +1431,7 @@ func TestCollectSummaryGlobalPermissionsLimitationTruncatesAt10(t *testing.T) {
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	extractDir := filepath.Join(dir, "extract-01")
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
 	writeExtractMeta(t, extractDir, "https://sq.example.com")
 	var items []map[string]any
 	for i := 1; i <= 12; i++ {
@@ -1472,7 +1472,7 @@ func TestCollectSummaryGlobalPermissionsLimitationListsAllBelow10(t *testing.T) 
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	extractDir := filepath.Join(dir, "extract-01")
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
 	writeExtractMeta(t, extractDir, "https://sq.example.com")
 	writeTaskJSONL(t, extractDir, "getUserPermissions", []map[string]any{
 		{"login": "alice"}, {"login": "bob"}, {"login": "carol"}, {"login": "dave"},
@@ -1919,10 +1919,10 @@ func TestCollectSummaryRuntimeTelemetry(t *testing.T) {
 			"process_type": "request_completed",
 			"status":       "failure",
 			"payload": map[string]any{
-				"method": "POST",
-				"url":    "/api/projects/create",
-				"status": float64(400),
-				"data":   map[string]any{"name": "FailProj", "organization": "org1"},
+				"method":   "POST",
+				"url":      "/api/projects/create",
+				"status":   float64(400),
+				"data":     map[string]any{"name": "FailProj", "organization": "org1"},
 				"response": `{"errors":[{"msg":"already exists"}]}`,
 			},
 		},

--- a/go/internal/report/summary/repro_353_test.go
+++ b/go/internal/report/summary/repro_353_test.go
@@ -5,8 +5,8 @@
 package summary
 
 import (
-	"path/filepath"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -24,7 +24,7 @@ func TestCollectSummary_DroppedUserPerms(t *testing.T) {
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		t.Fatalf("mkdir runDir: %v", err)
 	}
-	extractDir := filepath.Join(dir, "extract-01")
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
 	writeExtractMeta(t, extractDir, "https://sq.example.com")
 
 	// ── Quality Gates ───────────────────────────────────────────
@@ -91,10 +91,10 @@ func TestCollectSummary_DroppedUserPerms(t *testing.T) {
 	// extract carries it as `templateId`.
 	writeTaskJSONL(t, runDir, "createPermissionTemplates", []map[string]any{
 		{
-			"name":                 "Banking Template",
-			"source_template_key":  "uuid-banking-tpl",
-			"cloud_template_id":    "cloud_banking_tpl",
-			"sonarcloud_org_key":   "org1",
+			"name":                "Banking Template",
+			"source_template_key": "uuid-banking-tpl",
+			"cloud_template_id":   "cloud_banking_tpl",
+			"sonarcloud_org_key":  "org1",
 		},
 	})
 	writeTaskJSONL(t, runDir, "generateTemplateMappings", []map[string]any{

--- a/go/internal/structure/csv.go
+++ b/go/internal/structure/csv.go
@@ -89,7 +89,7 @@ func LoadCSV(directory, filename string) ([]map[string]any, error) {
 		m := make(map[string]any, len(headers))
 		for i, header := range headers {
 			if i < len(row) {
-				m[header] = coerceCSVValue(row[i])
+				m[header] = coerceCSVValue(header, row[i])
 			}
 		}
 		result = append(result, m)
@@ -167,10 +167,28 @@ func serializeAny(v any) string {
 	}
 }
 
+// isIdentifierColumn reports whether header names a column holding an
+// opaque identifier (e.g. sonarcloud_org_key, cloud_project_key) rather
+// than actual data. These columns must never be numeric-, bool-, or
+// JSON-coerced: a purely-numeric identifier like a SonarCloud org key
+// "12345" would otherwise silently become float64(12345), and downstream
+// code that does `val, _ := row[header].(string)` would then read back
+// "" (Go's zero value for string) instead of the real key — dropping the
+// organization/project from the migration with no error (issue #550).
+//
+// The rule is generic on purpose: any current or future column following
+// the "*_key" naming convention (or the bare "key" column) is covered
+// without needing to enumerate specific column names here.
+func isIdentifierColumn(header string) bool {
+	return header == "key" || strings.HasSuffix(header, "_key")
+}
+
 // coerceCSVValue attempts to parse a CSV string value back into a typed value,
 // JSON arrays/objects/booleans/numbers are parsed back into typed values.
-func coerceCSVValue(s string) any {
-	if s == "" {
+// header is the column name the value came from; identifier columns (see
+// isIdentifierColumn) are always returned as the raw, uncoerced string.
+func coerceCSVValue(header, s string) any {
+	if s == "" || isIdentifierColumn(header) {
 		return s
 	}
 

--- a/go/internal/structure/csv_test.go
+++ b/go/internal/structure/csv_test.go
@@ -114,9 +114,12 @@ func TestCoerceCSVValue(t *testing.T) {
 		{"hello", "hello"},
 		{"", ""},
 		{"null", nil},
+		{"12345", float64(12345)},
 	}
 	for _, tt := range tests {
-		got := coerceCSVValue(tt.input)
+		// "project_count" is a plain data column (not "key"/"*_key"), so
+		// it still gets the normal numeric/JSON coercion behavior.
+		got := coerceCSVValue("project_count", tt.input)
 		switch expected := tt.expected.(type) {
 		case nil:
 			if got != nil {
@@ -130,11 +133,75 @@ func TestCoerceCSVValue(t *testing.T) {
 			if got != expected {
 				t.Errorf("coerceCSVValue(%q) = %v, want %v", tt.input, got, expected)
 			}
+		case float64:
+			if got != expected {
+				t.Errorf("coerceCSVValue(%q) = %v (%T), want %v", tt.input, got, got, expected)
+			}
 		default:
 			// For slices/maps, just check type.
 			if got == nil {
 				t.Errorf("coerceCSVValue(%q) = nil, want %v", tt.input, expected)
 			}
 		}
+	}
+}
+
+// Issue #550: identifier columns (the bare "key" column, and any column
+// whose header ends in "_key") must never be numeric-coerced, even when
+// their value happens to look like a number. Otherwise a purely-numeric
+// sonarcloud_org_key such as "12345" would silently become float64(12345),
+// and downstream code doing `val, _ := row["sonarcloud_org_key"].(string)`
+// would read back "" instead of the real key.
+func TestCoerceCSVValue_IdentifierColumnsNeverCoerced(t *testing.T) {
+	tests := []struct {
+		header string
+		input  string
+	}{
+		{"key", "12345"},
+		{"sonarcloud_org_key", "12345"},
+		{"sonarqube_org_key", "999"},
+		{"cloud_project_key", "42"},
+		{"binding_key", "true"},
+		{"binding_key", `["a","b"]`},
+	}
+	for _, tt := range tests {
+		got := coerceCSVValue(tt.header, tt.input)
+		if got != tt.input {
+			t.Errorf("coerceCSVValue(%q, %q) = %v (%T), want raw string %q", tt.header, tt.input, got, got, tt.input)
+		}
+	}
+}
+
+// Issue #550: LoadCSV must preserve a numeric-looking sonarcloud_org_key
+// as a string, not coerce it to float64, or downstream code relying on a
+// string type assertion silently drops the organization.
+func TestLoadCSV_NumericIdentifierColumnStaysString(t *testing.T) {
+	dir := t.TempDir()
+	contents := "sonarqube_org_key,sonarcloud_org_key,project_count\norg-a,12345,7\n"
+	if err := os.WriteFile(filepath.Join(dir, "organizations.csv"), []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := LoadCSV(dir, "organizations.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+
+	orgKey := rows[0]["sonarcloud_org_key"]
+	s, ok := orgKey.(string)
+	if !ok {
+		t.Fatalf("expected sonarcloud_org_key to be a string, got %v (%T)", orgKey, orgKey)
+	}
+	if s != "12345" {
+		t.Errorf("expected sonarcloud_org_key = %q, got %q", "12345", s)
+	}
+
+	// Non-identifier numeric columns keep their existing coercion.
+	count := rows[0]["project_count"]
+	if f, ok := count.(float64); !ok || f != 7 {
+		t.Errorf("expected project_count = float64(7), got %v (%T)", count, count)
 	}
 }

--- a/go/internal/structure/csv_test.go
+++ b/go/internal/structure/csv_test.go
@@ -7,6 +7,7 @@ package structure
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -120,28 +121,8 @@ func TestCoerceCSVValue(t *testing.T) {
 		// "project_count" is a plain data column (not "key"/"*_key"), so
 		// it still gets the normal numeric/JSON coercion behavior.
 		got := coerceCSVValue("project_count", tt.input)
-		switch expected := tt.expected.(type) {
-		case nil:
-			if got != nil {
-				t.Errorf("coerceCSVValue(%q) = %v, want nil", tt.input, got)
-			}
-		case bool:
-			if got != expected {
-				t.Errorf("coerceCSVValue(%q) = %v, want %v", tt.input, got, expected)
-			}
-		case string:
-			if got != expected {
-				t.Errorf("coerceCSVValue(%q) = %v, want %v", tt.input, got, expected)
-			}
-		case float64:
-			if got != expected {
-				t.Errorf("coerceCSVValue(%q) = %v (%T), want %v", tt.input, got, got, expected)
-			}
-		default:
-			// For slices/maps, just check type.
-			if got == nil {
-				t.Errorf("coerceCSVValue(%q) = nil, want %v", tt.input, expected)
-			}
+		if !reflect.DeepEqual(got, tt.expected) {
+			t.Errorf("coerceCSVValue(%q) = %v (%T), want %v (%T)", tt.input, got, got, tt.expected, tt.expected)
 		}
 	}
 }

--- a/go/internal/structure/extract.go
+++ b/go/internal/structure/extract.go
@@ -51,6 +51,19 @@ func buildURLMappings(directory string, entries []os.DirEntry) map[string]map[st
 		if err := json.Unmarshal(data, &meta); err != nil || meta.URL == "" {
 			continue
 		}
+		if !common.IsValidRunID(entry.Name()) {
+			// A directory name that isn't a well-formed run ID must never
+			// become a candidate: RunIDAfter falls back to a plain string
+			// compare for anything that doesn't parse as "<prefix>-<digits>",
+			// and since real run IDs always start with a digit, a rogue
+			// name (e.g. planted by an attacker who can write to the
+			// export directory) would beat every legitimate dated run in
+			// that string compare (#550). Filtering here keeps
+			// RunIDAfter's fallback intact for its other legitimate
+			// callers/tests while closing this path off entirely.
+			slog.Debug("skipping non-conforming extract directory name", "name", entry.Name())
+			continue
+		}
 		if urlMappings[meta.URL] == nil {
 			urlMappings[meta.URL] = make(map[string]bool)
 		}

--- a/go/internal/structure/extract_test.go
+++ b/go/internal/structure/extract_test.go
@@ -29,3 +29,25 @@ func TestGetUniqueExtracts_PicksNumericallyLatestPast99(t *testing.T) {
 		t.Errorf("GetUniqueExtracts picked %q, want %q (numeric, not lexicographic, ordering)", got, want)
 	}
 }
+
+// TestGetUniqueExtracts_RejectsNonConformingDirectoryName closes #550: a
+// rogue directory whose name doesn't match the "YYYY-MM-DD-N" run-ID
+// shape (e.g. one an attacker could plant in the export directory) must
+// never be picked as "latest", even though a plain string compare would
+// rank it above every legitimately dated run (any letter sorts above
+// any digit in ASCII).
+func TestGetUniqueExtracts_RejectsNonConformingDirectoryName(t *testing.T) {
+	dir := t.TempDir()
+	writeTestJSON(t, filepath.Join(dir, "2026-08-20-0001", "extract.json"),
+		map[string]any{"url": testSQURL})
+	writeTestJSON(t, filepath.Join(dir, "zzz-evil", "extract.json"),
+		map[string]any{"url": testSQURL})
+
+	mapping, err := GetUniqueExtracts(dir)
+	if err != nil {
+		t.Fatalf("GetUniqueExtracts: %v", err)
+	}
+	if got, want := mapping[testSQURL], "2026-08-20-0001"; got != want {
+		t.Errorf("GetUniqueExtracts picked %q, want %q (rogue non-conforming directory name must be rejected)", got, want)
+	}
+}

--- a/go/internal/structure/extract_test.go
+++ b/go/internal/structure/extract_test.go
@@ -51,3 +51,23 @@ func TestGetUniqueExtracts_RejectsNonConformingDirectoryName(t *testing.T) {
 		t.Errorf("GetUniqueExtracts picked %q, want %q (rogue non-conforming directory name must be rejected)", got, want)
 	}
 }
+
+// TestGetUniqueExtracts_AcceptsLegacyDateFormat guards against a
+// regression in the #550 IsValidRunID hardening: the legacy pre-#108
+// "MM-DD-YYYY-N" directory naming (still present in export directories
+// on users' disks — see internal/gui/history.go and
+// internal/regtest/suite.go, which accept the same two shapes) must
+// still be recognised as a legitimate extract, not silently dropped.
+func TestGetUniqueExtracts_AcceptsLegacyDateFormat(t *testing.T) {
+	dir := t.TempDir()
+	writeTestJSON(t, filepath.Join(dir, "08-20-2026-0001", "extract.json"),
+		map[string]any{"url": testSQURL})
+
+	mapping, err := GetUniqueExtracts(dir)
+	if err != nil {
+		t.Fatalf("GetUniqueExtracts: %v", err)
+	}
+	if got, want := mapping[testSQURL], "08-20-2026-0001"; got != want {
+		t.Errorf("GetUniqueExtracts picked %q, want %q (legacy MM-DD-YYYY-N directory must not be dropped)", got, want)
+	}
+}

--- a/go/internal/structure/projects_test.go
+++ b/go/internal/structure/projects_test.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	testSQURL      = "https://sq.example.com/"
-	testExtractID  = "extract-01"
+	testExtractID  = "2026-08-20-0001"
 	testCustomGate = "Custom Gate"
 	testSonarWay   = "Sonar way"
 	testProjOrgKey = "https://sq.example.com/proj1"

--- a/go/internal/structure/structure_test.go
+++ b/go/internal/structure/structure_test.go
@@ -102,7 +102,7 @@ func TestMapProfiles(t *testing.T) {
 
 	// Build project org mapping from test data.
 	projectOrgMapping := map[string]string{
-		testProjOrgKey: "org1",
+		testProjOrgKey:                 "org1",
 		"https://sq.example.com/proj2": "org1",
 	}
 
@@ -126,7 +126,7 @@ func TestMapGates(t *testing.T) {
 	dir := setupTestExtract(t)
 	mapping := ExtractMapping{testSQURL: testExtractID}
 	projectOrgMapping := map[string]string{
-		testProjOrgKey: "org1",
+		testProjOrgKey:                 "org1",
 		"https://sq.example.com/proj2": "org1",
 	}
 
@@ -230,7 +230,7 @@ func TestGetUniqueExtracts(t *testing.T) {
 		t.Fatalf("expected 1 extract, got %d", len(mapping))
 	}
 	if mapping[testSQURL] != testExtractID {
-		t.Errorf("expected extract-01, got %q", mapping[testSQURL])
+		t.Errorf("expected %q, got %q", testExtractID, mapping[testSQURL])
 	}
 }
 

--- a/go/internal/wizard/wizard.go
+++ b/go/internal/wizard/wizard.go
@@ -160,6 +160,49 @@ func determineStartingPhase(p Prompter, state *WizardState, exportDir string) (W
 	return state.Phase, true
 }
 
+// structureOutputFiles are the CSVs phaseStructure is responsible for
+// producing (see displayStructureSummary / phaseOrgMapping's
+// mapAllOrganizations, which both read them). Any phase reached after
+// Structure requires these to exist.
+var structureOutputFiles = []string{fileOrganizations, fileProjects}
+
+// verifyPhasePrerequisites checks that the real, on-disk artifacts an
+// earlier phase is supposed to have produced actually exist before
+// dispatching into the given phase. It does not re-derive trust from
+// state.Phase itself (that's the value under attack, whether by
+// tampering or corruption) — it independently verifies the filesystem.
+//
+// This is deliberately NOT a tamper-evidence / integrity-signing
+// mechanism for .wizard_state.json (no HMAC, no checksum): a local,
+// single-user CLI tool gains nothing from proving the JSON wasn't
+// hand-edited, since an attacker with write access to the export
+// directory could simply invoke `migrate` directly. The actual gap is
+// that runPhaseHandler previously trusted state.Phase to dispatch
+// straight into a phase's handler without confirming that phase's real
+// prerequisites — the files earlier phases actually produced — exist.
+// Checking those artifacts closes that gap for tampering AND ordinary
+// corruption/bad manual edits alike.
+func verifyPhasePrerequisites(state *WizardState, exportDir string, phase WizardPhase) error {
+	switch phase {
+	case PhaseOrgMapping, PhaseMappings, PhaseValidate, PhaseMigrate:
+		if ptrStr(state.ExtractID) == "" {
+			return fmt.Errorf("no extraction has been recorded (extract_id is empty) — run the Extract phase first")
+		}
+		if missing := checkRequiredFiles(exportDir, structureOutputFiles); len(missing) > 0 {
+			return fmt.Errorf("structure output missing: %v — run the Structure phase first", missing)
+		}
+	}
+
+	switch phase {
+	case PhaseValidate, PhaseMigrate:
+		if missing := checkRequiredFiles(exportDir, requiredMappingFiles); len(missing) > 0 {
+			return fmt.Errorf("missing required files: %v — run the Mappings phase first", missing)
+		}
+	}
+
+	return nil
+}
+
 // runPhaseLoop executes phases sequentially from startPhase to completion.
 func runPhaseLoop(ctx context.Context, p Prompter, state *WizardState, exportDir string, startPhase WizardPhase) error {
 	currentPhase := startPhase
@@ -200,7 +243,22 @@ func runPhaseLoop(ctx context.Context, p Prompter, state *WizardState, exportDir
 }
 
 // runPhaseHandler dispatches to the correct phase function.
+//
+// Before dispatching into any phase other than Extract (the entry point,
+// which has no prior-phase prerequisites), it calls verifyPhasePrerequisites
+// to make sure the artifacts earlier phases are supposed to have produced
+// genuinely exist on disk. state.Phase is trusted verbatim by
+// determineStartingPhase — a .wizard_state.json that claims phase "migrate"
+// (whether from tampering or ordinary corruption/a bad manual edit) would
+// otherwise dispatch straight into phaseMigrate against whatever TargetURL
+// happens to be set, skipping every real prerequisite check (issue #550).
 func runPhaseHandler(ctx context.Context, p Prompter, state *WizardState, exportDir string, phase WizardPhase) error {
+	if phase != PhaseExtract {
+		if err := verifyPhasePrerequisites(state, exportDir, phase); err != nil {
+			return fmt.Errorf("cannot enter phase %s: %w", phase, err)
+		}
+	}
+
 	switch phase {
 	case PhaseExtract:
 		return phaseExtract(ctx, p, state, exportDir)

--- a/go/internal/wizard/wizard_test.go
+++ b/go/internal/wizard/wizard_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sonar-solutions/sonar-migration-tool/internal/extract"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 )
 
@@ -302,7 +304,10 @@ func TestRunPhaseHandlerValidate(t *testing.T) {
 	dir := t.TempDir()
 	writeMinimalCSVs(t, dir)
 
-	state := &WizardState{Phase: PhaseValidate}
+	// A legitimate resume always has ExtractID set (phaseExtract sets it
+	// before advancing past PhaseStructure) — verifyPhasePrerequisites
+	// (#550) requires it for any phase after Extract.
+	state := &WizardState{Phase: PhaseValidate, ExtractID: strPtr("test-extract-01")}
 	p := &MockPrompter{}
 
 	err := runPhaseHandler(context.Background(), p, state, dir, PhaseValidate)
@@ -316,7 +321,12 @@ func TestRunPhaseHandlerValidate(t *testing.T) {
 
 func TestRunPhaseHandlerMigrateCancel(t *testing.T) {
 	dir := t.TempDir()
-	state := &WizardState{Phase: PhaseMigrate, TargetURL: strPtr(testSQCloudURL)}
+	writeMinimalCSVs(t, dir)
+
+	// Real prerequisites present (ExtractID + the mapping CSVs) so this
+	// exercises the decline-to-retry path inside phaseMigrate itself,
+	// not verifyPhasePrerequisites (#550) rejecting the phase outright.
+	state := &WizardState{Phase: PhaseMigrate, TargetURL: strPtr(testSQCloudURL), ExtractID: strPtr("test-extract-01")}
 	p := &MockPrompter{ConfirmResponses: []bool{false}}
 
 	err := runPhaseHandler(context.Background(), p, state, dir, PhaseMigrate)
@@ -331,6 +341,149 @@ func TestRunPhaseHandlerUnknownPhase(t *testing.T) {
 	err := runPhaseHandler(context.Background(), p, state, t.TempDir(), WizardPhase("bogus"))
 	if err == nil {
 		t.Fatal("expected error for unknown phase")
+	}
+}
+
+// --- verifyPhasePrerequisites (#550): a .wizard_state.json claiming a
+// downstream phase — whether from tampering or ordinary corruption/a bad
+// manual edit — must not let runPhaseHandler dispatch into that phase
+// unless the artifacts earlier phases are supposed to have produced
+// genuinely exist on disk. ---
+
+func TestVerifyPhasePrerequisitesExtractIDMissing(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalCSVs(t, dir) // structure + mapping files present...
+
+	for _, phase := range []WizardPhase{PhaseOrgMapping, PhaseMappings, PhaseValidate, PhaseMigrate} {
+		state := &WizardState{Phase: phase} // ...but ExtractID is not set.
+		if err := verifyPhasePrerequisites(state, dir, phase); err == nil {
+			t.Errorf("phase %s: expected error when ExtractID is unset, got nil", phase)
+		}
+	}
+}
+
+func TestVerifyPhasePrerequisitesStructureOutputMissing(t *testing.T) {
+	dir := t.TempDir() // no organizations.csv / projects.csv at all
+
+	for _, phase := range []WizardPhase{PhaseOrgMapping, PhaseMappings, PhaseValidate, PhaseMigrate} {
+		state := &WizardState{Phase: phase, ExtractID: strPtr("fake-id")}
+		if err := verifyPhasePrerequisites(state, dir, phase); err == nil {
+			t.Errorf("phase %s: expected error when structure output is missing, got nil", phase)
+		}
+	}
+}
+
+func TestVerifyPhasePrerequisitesMappingFilesMissing(t *testing.T) {
+	dir := t.TempDir()
+	// Structure output present, but none of the mapping CSVs
+	// (templates/profiles/gates/groups) that phaseMappings produces.
+	orgHeaders := []string{"sonarqube_org_key", "sonarcloud_org_key"}
+	writeCSV(t, dir, fileOrganizations, orgHeaders, [][]string{{"org-1", "cloud-1"}})
+	writeCSV(t, dir, fileProjects, []string{"key"}, [][]string{{"p1"}})
+
+	for _, phase := range []WizardPhase{PhaseValidate, PhaseMigrate} {
+		state := &WizardState{Phase: phase, ExtractID: strPtr("fake-id")}
+		if err := verifyPhasePrerequisites(state, dir, phase); err == nil {
+			t.Errorf("phase %s: expected error when mapping files are missing, got nil", phase)
+		}
+	}
+
+	// OrgMapping only needs the structure output, not the mapping CSVs.
+	if err := verifyPhasePrerequisites(&WizardState{Phase: PhaseOrgMapping, ExtractID: strPtr("fake-id")}, dir, PhaseOrgMapping); err != nil {
+		t.Errorf("PhaseOrgMapping: unexpected error with structure output present: %v", err)
+	}
+}
+
+func TestVerifyPhasePrerequisitesLegitimateResumePasses(t *testing.T) {
+	dir := t.TempDir()
+	writeMinimalCSVs(t, dir)
+
+	for _, phase := range []WizardPhase{PhaseOrgMapping, PhaseMappings, PhaseValidate, PhaseMigrate} {
+		state := &WizardState{Phase: phase, ExtractID: strPtr("real-extract-01")}
+		if err := verifyPhasePrerequisites(state, dir, phase); err != nil {
+			t.Errorf("phase %s: unexpected error for legitimate resume: %v", phase, err)
+		}
+	}
+}
+
+func TestVerifyPhasePrerequisitesExtractHasNone(t *testing.T) {
+	// PhaseExtract is the entry point and is never passed to
+	// verifyPhasePrerequisites by runPhaseHandler, but the function
+	// itself must be a no-op for it regardless (defensive — no case
+	// matches PhaseExtract in either switch).
+	if err := verifyPhasePrerequisites(&WizardState{Phase: PhaseExtract}, t.TempDir(), PhaseExtract); err != nil {
+		t.Errorf("PhaseExtract: expected no prerequisites, got %v", err)
+	}
+}
+
+// TestRunRejectsFabricatedMigrateState reproduces the exact scenario
+// from issue #550: a .wizard_state.json claiming phase "migrate" against
+// an arbitrary target, with none of the real prerequisites (extraction,
+// structure, org mapping, generated mapping CSVs) ever having run. This
+// could arise from tampering or from ordinary file corruption / a bad
+// manual edit — either way, runPhaseHandler must refuse to dispatch into
+// phaseMigrate rather than proceeding to prompt for migrate credentials
+// or invoke runMigrateFn against the fabricated target.
+func TestRunRejectsFabricatedMigrateState(t *testing.T) {
+	dir := t.TempDir() // fresh export dir: no CSVs, no extract output
+
+	origMigrate := runMigrateFn
+	migrateCalled := false
+	runMigrateFn = func(_ context.Context, _ migrate.MigrateConfig) (string, error) {
+		migrateCalled = true
+		return "should-not-run", nil
+	}
+	defer func() { runMigrateFn = origMigrate }()
+
+	// Defense in depth: even though verifyPhasePrerequisites should stop
+	// the wizard before it ever reaches phaseExtract again, also stub
+	// out real extraction so a bug in the restart-offer plumbing can
+	// never make this test perform a live network call / retry loop.
+	origExtract := runExtractFn
+	extractCalled := false
+	runExtractFn = func(_ context.Context, _ extract.ExtractConfig) ([]string, error) {
+		extractCalled = true
+		return nil, fmt.Errorf("extraction must not run in this test")
+	}
+	defer func() { runExtractFn = origExtract }()
+
+	state := &WizardState{
+		Phase:     PhaseMigrate,
+		TargetURL: strPtr("https://evil.example.com"),
+		ExtractID: strPtr("fake-id"),
+	}
+	if err := state.Save(dir); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	p := &MockPrompter{
+		// resume=yes (so determineStartingPhase is reached at all);
+		// restart-from-earlier-phase=no (so runPhaseLoop reports the
+		// verifyPhasePrerequisites error instead of looping into
+		// offerPhaseRestart's default-choice fallback).
+		ConfirmResponses: []bool{true, false},
+	}
+
+	err := Run(context.Background(), p, dir)
+	if err == nil {
+		t.Fatal("expected Run to return an error instead of dispatching into phaseMigrate")
+	}
+	if migrateCalled {
+		t.Error("runMigrateFn must never be called against a fabricated/corrupted state")
+	}
+	if extractCalled {
+		t.Error("runExtractFn must never be called from this fabricated-migrate-state scenario")
+	}
+
+	// The persisted state's phase must not have been silently accepted
+	// and advanced past — it stays at PhaseMigrate (or is untouched)
+	// rather than reaching PhaseComplete.
+	loaded, loadErr := Load(dir)
+	if loadErr != nil {
+		t.Fatalf("Load: %v", loadErr)
+	}
+	if loaded.Phase == PhaseComplete {
+		t.Error("wizard must not reach PhaseComplete from a fabricated migrate state")
 	}
 }
 
@@ -493,6 +646,7 @@ func TestRunWithSeedReturnsStateOnSuccess(t *testing.T) {
 		Phase:         PhaseValidate,
 		TargetURL:     strPtr(testSQCloudURL),
 		EnterpriseKey: strPtr(testEntKey),
+		ExtractID:     strPtr("test-extract-01"),
 	}
 	state.Save(dir)
 
@@ -598,6 +752,7 @@ func TestRunWithSkippedProjects(t *testing.T) {
 		TargetURL:       strPtr(testSQCloudURL),
 		EnterpriseKey:   strPtr(testEntKey),
 		SkippedProjects: []string{"proj-a", "proj-b"},
+		ExtractID:       strPtr("test-extract-01"),
 	}
 	state.Save(dir)
 


### PR DESCRIPTION
## Summary
Closes #550. Resolves all 13 SonarCloud "hunter-agent" business-logic/security findings, previously marked WONTFIX/ACCEPTED, per the issue's explicit request to resolve them.

- **Reset command hardening**: `--organization` scoping (anchored regex, mirrors `transfer`'s `--project_key`), `--dry-run`, and a fail-closed default for `ConfirmedOrgs` (an empty scope now errors instead of wiping every mapped org). Config-file-driven callers can supply `confirmed_orgs` directly.
- **Permission-template safety nets**: `resetPermissionTemplates` hard-fails when the built-in "Default Template" can't be found by name instead of silently proceeding; `deleteTemplates` also refuses to delete anything that's currently an org's default template, independent of name.
- **Privilege escalation blocked**: the `sonar-users`→`Members` alias can no longer auto-grant `admin` org-wide. Permission-grant tasks now surface an error when every attempted grant failed, instead of always reporting success.
- **Silent data-loss fixes**: `--default_organization` is validated against the live API before being persisted to `organizations.csv` (closes a bug where a bad first attempt permanently locked out a corrected retry — also fixed in the `sync-issues` entry point, which had the same bug). Numeric-looking org/identifier keys no longer get silently coerced to `float64` and dropped from the migration. Fresh project creation treats an empty returned key as a failure rather than propagating it.
- **Trust-boundary fixes**: extract run directories must match the real date-shaped ID format before being treated as "latest" (closes a directory-poisoning path). The wizard now verifies each phase's real on-disk prerequisites before dispatching into it, rather than trusting a resumed state file's phase field verbatim.
- Also hardens the shared `migrate` test fixtures (a hand-typed template-name literal had silently drifted out of sync with production code during review; replaced with a direct reference to the real constant, plus clarifying docs on two easily-confused mock server constructors).

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./... -count=1` — all packages pass
- [x] Each fix has dedicated regression tests reproducing its finding's exact scenario (renamed built-in template still-default not deleted, corrected `--default_organization` applies after a failed first attempt, numeric org key survives as a string, rogue run-ID directory excluded from "latest", total permission-grant failure surfaces an error, fabricated wizard state rejected before entering migrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
