### PR TITLE
Give transfer/sync-issues independent source/target concurrency and timeout

### DIFF
--- a/go/cmd/sync_issues.go
+++ b/go/cmd/sync_issues.go
@@ -146,8 +146,20 @@ func loadSyncIssuesFileDefaults(path string) (syncIssuesConfig, error) {
 	// cmd/transfer.go's loadTransferFileDefaults.
 	cfg.sourceConcurrency = extractCfg.Concurrency
 	cfg.targetConcurrency = migrateCfg.Concurrency
+	if cfg.sourceConcurrency == 0 {
+		cfg.sourceConcurrency = cfg.targetConcurrency
+	}
+	if cfg.targetConcurrency == 0 {
+		cfg.targetConcurrency = cfg.sourceConcurrency
+	}
 	cfg.sourceTimeout = extractCfg.Timeout
 	cfg.targetTimeout = migrateCfg.Timeout
+	if cfg.sourceTimeout == 0 {
+		cfg.sourceTimeout = cfg.targetTimeout
+	}
+	if cfg.targetTimeout == 0 {
+		cfg.targetTimeout = cfg.sourceTimeout
+	}
 	cfg.pemFilePath = extractCfg.PEMFilePath
 	cfg.keyFilePath = extractCfg.KeyFilePath
 	cfg.certPassword = extractCfg.CertPassword

--- a/go/cmd/sync_issues.go
+++ b/go/cmd/sync_issues.go
@@ -103,8 +103,10 @@ type syncIssuesConfig struct {
 	projectKeyPattern   string
 	enterpriseKey       string
 	exportDir           string
-	concurrency         int
-	timeout             int
+	sourceConcurrency   int
+	targetConcurrency   int
+	sourceTimeout       int
+	targetTimeout       int
 	pemFilePath         string
 	keyFilePath         string
 	certPassword        string
@@ -139,14 +141,13 @@ func loadSyncIssuesFileDefaults(path string) (syncIssuesConfig, error) {
 		cfg.exportDir = migrateCfg.ExportDirectory
 	}
 
-	switch {
-	case extractCfg.Concurrency != 0:
-		cfg.concurrency = extractCfg.Concurrency
-	case migrateCfg.Concurrency != 0:
-		cfg.concurrency = migrateCfg.Concurrency
-	}
-
-	cfg.timeout = extractCfg.Timeout
+	// #528 — assign source/target straight through rather than
+	// collapsing to one shared value; see the identical comment in
+	// cmd/transfer.go's loadTransferFileDefaults.
+	cfg.sourceConcurrency = extractCfg.Concurrency
+	cfg.targetConcurrency = migrateCfg.Concurrency
+	cfg.sourceTimeout = extractCfg.Timeout
+	cfg.targetTimeout = migrateCfg.Timeout
 	cfg.pemFilePath = extractCfg.PEMFilePath
 	cfg.keyFilePath = extractCfg.KeyFilePath
 	cfg.certPassword = extractCfg.CertPassword
@@ -179,8 +180,17 @@ func resolveSyncIssuesConfig(cmd *cobra.Command) (syncIssuesConfig, error) {
 	applyFlagString(cmd, flagProjectKeyPattern, &cfg.projectKeyPattern)
 	applyFlagString(cmd, flagEnterpriseKey, &cfg.enterpriseKey)
 	applyFlagString(cmd, flagExportDir, &cfg.exportDir)
-	applyFlagInt(cmd, flagConcurrency, &cfg.concurrency)
-	applyFlagInt(cmd, flagTimeout, &cfg.timeout)
+	// #528 — sync-issues talks to both source and target, so
+	// --concurrency / --timeout set both sides at once. The config
+	// file remains the only way to give the two sides different values.
+	if cmd.Flags().Changed(flagConcurrency) {
+		v, _ := cmd.Flags().GetInt(flagConcurrency)
+		cfg.sourceConcurrency, cfg.targetConcurrency = v, v
+	}
+	if cmd.Flags().Changed(flagTimeout) {
+		v, _ := cmd.Flags().GetInt(flagTimeout)
+		cfg.sourceTimeout, cfg.targetTimeout = v, v
+	}
 	applyFlagString(cmd, flagPEMFilePath, &cfg.pemFilePath)
 	applyFlagString(cmd, flagKeyFilePath, &cfg.keyFilePath)
 	applyFlagString(cmd, flagCertPassword, &cfg.certPassword)
@@ -226,8 +236,8 @@ func runSyncIssuesCmd(cmd *cobra.Command, _ []string) error {
 		Token:              cfg.sourceToken,
 		ExportDirectory:    cfg.exportDir,
 		ProjectKeys:        cfg.projectKeys,
-		Concurrency:        cfg.concurrency,
-		Timeout:            cfg.timeout,
+		Concurrency:        cfg.sourceConcurrency,
+		Timeout:            cfg.sourceTimeout,
 		PEMFilePath:        cfg.pemFilePath,
 		KeyFilePath:        cfg.keyFilePath,
 		CertPassword:       cfg.certPassword,
@@ -250,8 +260,8 @@ func runSyncIssuesCmd(cmd *cobra.Command, _ []string) error {
 		Token:               cfg.targetToken,
 		EnterpriseKey:       cfg.enterpriseKey,
 		ExportDirectory:     cfg.exportDir,
-		Concurrency:         cfg.concurrency,
-		Timeout:             cfg.timeout,
+		Concurrency:         cfg.targetConcurrency,
+		Timeout:             cfg.targetTimeout,
 		ProjectKeyPattern:   cfg.projectKeyPattern,
 		DefaultOrganization: cfg.defaultOrganization,
 		ProjectKeys:         cfg.projectKeys,

--- a/go/cmd/sync_issues.go
+++ b/go/cmd/sync_issues.go
@@ -81,8 +81,8 @@ func init() {
 	f.String(flagProjectKeyPattern, "", "Template used to resolve each project's already-migrated target key, built from <ORIGINAL_PROJECT_KEY> and <ORGANIZATION_KEY> (maps to target.project_key_pattern; default: <ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>) — must match the pattern used when the projects were created")
 	f.String(flagEnterpriseKey, "", scCloudName+" enterprise key (maps to target.enterprise_key, defaults to --"+flagDefaultOrg+")")
 	f.String(flagExportDir, "./migration-files/", "Working directory for intermediate files (maps to export_directory)")
-	f.Int(flagConcurrency, 0, "Max concurrent requests (default: 25) (maps to concurrency)")
-	f.Int(flagTimeout, 0, "HTTP request timeout in seconds (maps to timeout; default: 60)")
+	f.Int(flagConcurrency, 0, "Max concurrent requests, applied to both source and target (default: 25). Use source.concurrency / target.concurrency in the config file to set them independently.")
+	f.Int(flagTimeout, 0, "HTTP request timeout in seconds, applied to both source and target (default: 60). Use source.timeout / target.timeout in the config file to set them independently.")
 	f.String(flagPEMFilePath, "", "Path to client mTLS PEM file for the source server (maps to source.pem_file_path)")
 	f.String(flagKeyFilePath, "", "Path to client mTLS key file for the source server (maps to source.key_file_path)")
 	f.String(flagCertPassword, "", "Password for the source server mTLS client certificate (maps to source.cert_password)")
@@ -142,24 +142,15 @@ func loadSyncIssuesFileDefaults(path string) (syncIssuesConfig, error) {
 	}
 
 	// #528 — assign source/target straight through rather than
-	// collapsing to one shared value; see the identical comment in
-	// cmd/transfer.go's loadTransferFileDefaults.
+	// collapsing to one shared value, then let a value set on only one
+	// side reach both; see the identical comment in cmd/transfer.go's
+	// loadTransferFileDefaults.
 	cfg.sourceConcurrency = extractCfg.Concurrency
 	cfg.targetConcurrency = migrateCfg.Concurrency
-	if cfg.sourceConcurrency == 0 {
-		cfg.sourceConcurrency = cfg.targetConcurrency
-	}
-	if cfg.targetConcurrency == 0 {
-		cfg.targetConcurrency = cfg.sourceConcurrency
-	}
+	fallbackToOtherSide(&cfg.sourceConcurrency, &cfg.targetConcurrency)
 	cfg.sourceTimeout = extractCfg.Timeout
 	cfg.targetTimeout = migrateCfg.Timeout
-	if cfg.sourceTimeout == 0 {
-		cfg.sourceTimeout = cfg.targetTimeout
-	}
-	if cfg.targetTimeout == 0 {
-		cfg.targetTimeout = cfg.sourceTimeout
-	}
+	fallbackToOtherSide(&cfg.sourceTimeout, &cfg.targetTimeout)
 	cfg.pemFilePath = extractCfg.PEMFilePath
 	cfg.keyFilePath = extractCfg.KeyFilePath
 	cfg.certPassword = extractCfg.CertPassword

--- a/go/cmd/sync_issues.go
+++ b/go/cmd/sync_issues.go
@@ -180,17 +180,8 @@ func resolveSyncIssuesConfig(cmd *cobra.Command) (syncIssuesConfig, error) {
 	applyFlagString(cmd, flagProjectKeyPattern, &cfg.projectKeyPattern)
 	applyFlagString(cmd, flagEnterpriseKey, &cfg.enterpriseKey)
 	applyFlagString(cmd, flagExportDir, &cfg.exportDir)
-	// #528 — sync-issues talks to both source and target, so
-	// --concurrency / --timeout set both sides at once. The config
-	// file remains the only way to give the two sides different values.
-	if cmd.Flags().Changed(flagConcurrency) {
-		v, _ := cmd.Flags().GetInt(flagConcurrency)
-		cfg.sourceConcurrency, cfg.targetConcurrency = v, v
-	}
-	if cmd.Flags().Changed(flagTimeout) {
-		v, _ := cmd.Flags().GetInt(flagTimeout)
-		cfg.sourceTimeout, cfg.targetTimeout = v, v
-	}
+	applyFlagIntBothSides(cmd, flagConcurrency, &cfg.sourceConcurrency, &cfg.targetConcurrency)
+	applyFlagIntBothSides(cmd, flagTimeout, &cfg.sourceTimeout, &cfg.targetTimeout)
 	applyFlagString(cmd, flagPEMFilePath, &cfg.pemFilePath)
 	applyFlagString(cmd, flagKeyFilePath, &cfg.keyFilePath)
 	applyFlagString(cmd, flagCertPassword, &cfg.certPassword)

--- a/go/cmd/sync_issues.go
+++ b/go/cmd/sync_issues.go
@@ -141,16 +141,9 @@ func loadSyncIssuesFileDefaults(path string) (syncIssuesConfig, error) {
 		cfg.exportDir = migrateCfg.ExportDirectory
 	}
 
-	// #528 — assign source/target straight through rather than
-	// collapsing to one shared value, then let a value set on only one
-	// side reach both; see the identical comment in cmd/transfer.go's
-	// loadTransferFileDefaults.
-	cfg.sourceConcurrency = extractCfg.Concurrency
-	cfg.targetConcurrency = migrateCfg.Concurrency
-	fallbackToOtherSide(&cfg.sourceConcurrency, &cfg.targetConcurrency)
-	cfg.sourceTimeout = extractCfg.Timeout
-	cfg.targetTimeout = migrateCfg.Timeout
-	fallbackToOtherSide(&cfg.sourceTimeout, &cfg.targetTimeout)
+	// #528 — see resolveSourceTargetRates's doc in cmd/transfer.go.
+	cfg.sourceConcurrency, cfg.targetConcurrency, cfg.sourceTimeout, cfg.targetTimeout =
+		resolveSourceTargetRates(extractCfg, migrateCfg)
 	cfg.pemFilePath = extractCfg.PEMFilePath
 	cfg.keyFilePath = extractCfg.KeyFilePath
 	cfg.certPassword = extractCfg.CertPassword

--- a/go/cmd/sync_issues_test.go
+++ b/go/cmd/sync_issues_test.go
@@ -89,8 +89,10 @@ func TestResolveSyncIssuesConfig_UnifiedConfigShape(t *testing.T) {
 		projectKeyPattern:   "acme_<ORIGINAL_PROJECT_KEY>",
 		enterpriseKey:       "ent-key",
 		exportDir:           "/tmp/from-cfg",
-		concurrency:         7,
-		timeout:             42,
+		sourceConcurrency:   7,
+		targetConcurrency:   7,
+		sourceTimeout:       42,
+		targetTimeout:       42,
 		pemFilePath:         "/cert/pem",
 		keyFilePath:         "/cert/key",
 		certPassword:        "p4ss",
@@ -116,6 +118,8 @@ func TestResolveSyncIssuesConfig_CLIOverridesConfig(t *testing.T) {
 		"--default_organization", "flag-org",
 		"--project_key", "proj-a",
 		"--project_key", "proj-b",
+		"--concurrency", "11",
+		"--timeout", "99",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -139,6 +143,65 @@ func TestResolveSyncIssuesConfig_CLIOverridesConfig(t *testing.T) {
 	}
 	if want := []string{"proj-a", "proj-b"}; !reflect.DeepEqual(cfg.projectKeys, want) {
 		t.Errorf("projectKeys: got %v, want %v", cfg.projectKeys, want)
+	}
+	// #528 — sync-issues's --concurrency/--timeout set both source and
+	// target at once (config file is the only way to differ them).
+	if cfg.sourceConcurrency != 11 || cfg.targetConcurrency != 11 {
+		t.Errorf("concurrency: got source=%d target=%d, want both 11", cfg.sourceConcurrency, cfg.targetConcurrency)
+	}
+	if cfg.sourceTimeout != 99 || cfg.targetTimeout != 99 {
+		t.Errorf("timeout: got source=%d target=%d, want both 99", cfg.sourceTimeout, cfg.targetTimeout)
+	}
+}
+
+// Issue #528: source and target must be able to carry genuinely
+// different concurrency/timeout values from the config file — before
+// this fix, loadSyncIssuesFileDefaults collapsed the two
+// independently-resolved values into one shared field, always
+// discarding target's timeout and arbitrarily preferring one side for
+// concurrency.
+func TestResolveSyncIssuesConfig_SourceAndTargetConcurrencyTimeoutDiffer(t *testing.T) {
+	path := writeSyncIssuesConfig(t, `{
+		"concurrency": 10,
+		"timeout": 60,
+		"source": {
+			"url": "https://sq.example.com",
+			"token": "sq-token",
+			"concurrency": 10,
+			"timeout": 10
+		},
+		"target": {
+			"token": "sc-token",
+			"default_organization": "my-org",
+			"concurrency": 5,
+			"timeout": 30
+		}
+	}`)
+
+	cmd := newSyncIssuesTestCmd()
+	if err := cmd.ParseFlags([]string{"-c", path}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := resolveSyncIssuesConfig(cmd)
+	if err != nil {
+		t.Fatalf("resolveSyncIssuesConfig: %v", err)
+	}
+
+	checks := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"sourceConcurrency", cfg.sourceConcurrency, 10},
+		{"targetConcurrency", cfg.targetConcurrency, 5},
+		{"sourceTimeout", cfg.sourceTimeout, 10},
+		{"targetTimeout", cfg.targetTimeout, 30},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s: got %d, want %d", c.name, c.got, c.want)
+		}
 	}
 }
 

--- a/go/cmd/sync_issues_test.go
+++ b/go/cmd/sync_issues_test.go
@@ -205,6 +205,39 @@ func TestResolveSyncIssuesConfig_SourceAndTargetConcurrencyTimeoutDiffer(t *test
 	}
 }
 
+// Issue #528 follow-up: when only ONE side sets concurrency/timeout, the
+// unset side must borrow the explicitly-set side's value rather than
+// falling through to the hardcoded package default — see the identical
+// test in transfer_test.go.
+func TestResolveSyncIssuesConfig_SingleSideConcurrencyTimeoutFallsBackToOtherSide(t *testing.T) {
+	path := writeSyncIssuesConfig(t, `{
+		"source": {"url": "https://sq.example.com", "token": "sq-token"},
+		"target": {
+			"token": "sc-token",
+			"default_organization": "my-org",
+			"concurrency": 5,
+			"timeout": 30
+		}
+	}`)
+
+	cmd := newSyncIssuesTestCmd()
+	if err := cmd.ParseFlags([]string{"-c", path}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := resolveSyncIssuesConfig(cmd)
+	if err != nil {
+		t.Fatalf("resolveSyncIssuesConfig: %v", err)
+	}
+
+	if cfg.sourceConcurrency != 5 {
+		t.Errorf("sourceConcurrency: got %d, want 5 (borrowed from target)", cfg.sourceConcurrency)
+	}
+	if cfg.sourceTimeout != 30 {
+		t.Errorf("sourceTimeout: got %d, want 30 (borrowed from target)", cfg.sourceTimeout)
+	}
+}
+
 // Issue #527: --fast_sync overrides the config file; the config file
 // value is used when the flag is absent; defaults to false otherwise.
 func TestResolveSyncIssuesConfig_FastSync(t *testing.T) {

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -251,6 +251,22 @@ func applyFlagIntBothSides(cmd *cobra.Command, name string, source, target *int)
 	}
 }
 
+// fallbackToOtherSide sets *a to *b when *a is zero, and *b to *a when *b is
+// zero — used by transfer/sync-issues after resolving concurrency/timeout
+// from the config file so that a value set on only one side (e.g. only
+// target.concurrency, no source.concurrency and no top-level default) still
+// reaches both sides instead of falling through to the hardcoded package
+// default on the unset side (#528). Has no effect once both are already
+// non-zero, so two genuinely different explicit values are left alone.
+func fallbackToOtherSide(a, b *int) {
+	if *a == 0 {
+		*a = *b
+	}
+	if *b == 0 {
+		*b = *a
+	}
+}
+
 func applyFlagBool(cmd *cobra.Command, name string, target *bool) {
 	if cmd.Flags().Changed(name) {
 		*target, _ = cmd.Flags().GetBool(name)
@@ -316,23 +332,16 @@ func loadTransferFileDefaults(path string) (transferConfig, error) {
 	// straight through rather than collapsing to one shared value: that
 	// used to silently drop target.timeout entirely and pick an
 	// arbitrary side for concurrency whenever the two config-file
-	// blocks genuinely differed.
+	// blocks genuinely differed. fallbackToOtherSide then lets a value
+	// set on only one side (no top-level default, nothing on the other
+	// side) still reach both, instead of the unset side falling through
+	// to the hardcoded package default.
 	cfg.sourceConcurrency = extractCfg.Concurrency
 	cfg.targetConcurrency = migrateCfg.Concurrency
-	if cfg.sourceConcurrency == 0 {
-		cfg.sourceConcurrency = cfg.targetConcurrency
-	}
-	if cfg.targetConcurrency == 0 {
-		cfg.targetConcurrency = cfg.sourceConcurrency
-	}
+	fallbackToOtherSide(&cfg.sourceConcurrency, &cfg.targetConcurrency)
 	cfg.sourceTimeout = extractCfg.Timeout
 	cfg.targetTimeout = migrateCfg.Timeout
-	if cfg.sourceTimeout == 0 {
-		cfg.sourceTimeout = cfg.targetTimeout
-	}
-	if cfg.targetTimeout == 0 {
-		cfg.targetTimeout = cfg.sourceTimeout
-	}
+	fallbackToOtherSide(&cfg.sourceTimeout, &cfg.targetTimeout)
 	cfg.pemFilePath = extractCfg.PEMFilePath
 	cfg.keyFilePath = extractCfg.KeyFilePath
 	cfg.certPassword = extractCfg.CertPassword

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -212,8 +212,10 @@ type transferConfig struct {
 	enterpriseKey            string
 	edition                  string
 	exportDir                string
-	concurrency              int
-	timeout                  int
+	sourceConcurrency        int
+	targetConcurrency        int
+	sourceTimeout            int
+	targetTimeout            int
 	pemFilePath              string
 	keyFilePath              string
 	certPassword             string
@@ -296,14 +298,17 @@ func loadTransferFileDefaults(path string) (transferConfig, error) {
 		cfg.exportDir = migrateCfg.ExportDirectory
 	}
 
-	switch {
-	case extractCfg.Concurrency != 0:
-		cfg.concurrency = extractCfg.Concurrency
-	case migrateCfg.Concurrency != 0:
-		cfg.concurrency = migrateCfg.Concurrency
-	}
-
-	cfg.timeout = extractCfg.Timeout
+	// #528 — source and target are resolved independently by their own
+	// loaders (each already applies the "nested block overrides
+	// top-level default" rule for its own side), so assign them
+	// straight through rather than collapsing to one shared value: that
+	// used to silently drop target.timeout entirely and pick an
+	// arbitrary side for concurrency whenever the two config-file
+	// blocks genuinely differed.
+	cfg.sourceConcurrency = extractCfg.Concurrency
+	cfg.targetConcurrency = migrateCfg.Concurrency
+	cfg.sourceTimeout = extractCfg.Timeout
+	cfg.targetTimeout = migrateCfg.Timeout
 	cfg.pemFilePath = extractCfg.PEMFilePath
 	cfg.keyFilePath = extractCfg.KeyFilePath
 	cfg.certPassword = extractCfg.CertPassword
@@ -339,8 +344,18 @@ func resolveTransferConfig(cmd *cobra.Command) (transferConfig, error) {
 	applyFlagString(cmd, flagEnterpriseKey, &cfg.enterpriseKey)
 	applyFlagString(cmd, flagEdition, &cfg.edition)
 	applyFlagString(cmd, flagExportDir, &cfg.exportDir)
-	applyFlagInt(cmd, flagConcurrency, &cfg.concurrency)
-	applyFlagInt(cmd, flagTimeout, &cfg.timeout)
+	// #528 — unlike extract/migrate (each inherently single-sided),
+	// transfer talks to both source and target, so --concurrency /
+	// --timeout set both sides at once. The config file remains the
+	// only way to give the two sides different values.
+	if cmd.Flags().Changed(flagConcurrency) {
+		v, _ := cmd.Flags().GetInt(flagConcurrency)
+		cfg.sourceConcurrency, cfg.targetConcurrency = v, v
+	}
+	if cmd.Flags().Changed(flagTimeout) {
+		v, _ := cmd.Flags().GetInt(flagTimeout)
+		cfg.sourceTimeout, cfg.targetTimeout = v, v
+	}
 	applyFlagString(cmd, flagPEMFilePath, &cfg.pemFilePath)
 	applyFlagString(cmd, flagKeyFilePath, &cfg.keyFilePath)
 	applyFlagString(cmd, flagCertPassword, &cfg.certPassword)
@@ -493,7 +508,7 @@ func resolveTransferProjectKeys(ctx context.Context, cfg transferConfig) ([]stri
 	allKeys, err := extract.ListAllProjectKeys(ctx, extract.ExtractConfig{
 		URL:          cfg.sourceURL,
 		Token:        cfg.sourceToken,
-		Timeout:      cfg.timeout,
+		Timeout:      cfg.sourceTimeout,
 		PEMFilePath:  cfg.pemFilePath,
 		KeyFilePath:  cfg.keyFilePath,
 		CertPassword: cfg.certPassword,
@@ -530,8 +545,8 @@ func runTransferExtract(ctx context.Context, cfg transferConfig) ([]string, erro
 		Token:           cfg.sourceToken,
 		ExportDirectory: cfg.exportDir,
 		ProjectKeys:     projectKeys,
-		Concurrency:     cfg.concurrency,
-		Timeout:         cfg.timeout,
+		Concurrency:     cfg.sourceConcurrency,
+		Timeout:         cfg.sourceTimeout,
 		PEMFilePath:     cfg.pemFilePath,
 		KeyFilePath:     cfg.keyFilePath,
 		CertPassword:    cfg.certPassword,
@@ -623,8 +638,8 @@ func runTransferMigrate(ctx context.Context, cfg transferConfig) (string, error)
 		EnterpriseKey:   cfg.enterpriseKey,
 		Edition:         cfg.edition,
 		ExportDirectory: cfg.exportDir,
-		Concurrency:     cfg.concurrency,
-		Timeout:         cfg.timeout,
+		Concurrency:     cfg.targetConcurrency,
+		Timeout:         cfg.targetTimeout,
 		// Project-scoped migration: run only the leaf tasks for the project,
 		// its quality gate/profiles, permissions, and issue/hotspot history.
 		// Their dependencies are resolved automatically.

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -267,6 +267,22 @@ func fallbackToOtherSide(a, b *int) {
 	}
 }
 
+// resolveSourceTargetRates resolves concurrency and timeout for both
+// source and target from their independently-loaded configs (each
+// already applies its own "nested block overrides top-level default"
+// rule), then applies the single-side fallback so a value set on only
+// one side still reaches both instead of the unset side falling
+// through to the hardcoded package default. Shared by transfer and
+// sync-issues, which both talk to source and target in one invocation
+// (#528).
+func resolveSourceTargetRates(extractCfg extract.ExtractConfig, migrateCfg migrate.MigrateConfig) (sourceConcurrency, targetConcurrency, sourceTimeout, targetTimeout int) {
+	sourceConcurrency, targetConcurrency = extractCfg.Concurrency, migrateCfg.Concurrency
+	fallbackToOtherSide(&sourceConcurrency, &targetConcurrency)
+	sourceTimeout, targetTimeout = extractCfg.Timeout, migrateCfg.Timeout
+	fallbackToOtherSide(&sourceTimeout, &targetTimeout)
+	return
+}
+
 func applyFlagBool(cmd *cobra.Command, name string, target *bool) {
 	if cmd.Flags().Changed(name) {
 		*target, _ = cmd.Flags().GetBool(name)
@@ -326,22 +342,8 @@ func loadTransferFileDefaults(path string) (transferConfig, error) {
 		cfg.exportDir = migrateCfg.ExportDirectory
 	}
 
-	// #528 — source and target are resolved independently by their own
-	// loaders (each already applies the "nested block overrides
-	// top-level default" rule for its own side), so assign them
-	// straight through rather than collapsing to one shared value: that
-	// used to silently drop target.timeout entirely and pick an
-	// arbitrary side for concurrency whenever the two config-file
-	// blocks genuinely differed. fallbackToOtherSide then lets a value
-	// set on only one side (no top-level default, nothing on the other
-	// side) still reach both, instead of the unset side falling through
-	// to the hardcoded package default.
-	cfg.sourceConcurrency = extractCfg.Concurrency
-	cfg.targetConcurrency = migrateCfg.Concurrency
-	fallbackToOtherSide(&cfg.sourceConcurrency, &cfg.targetConcurrency)
-	cfg.sourceTimeout = extractCfg.Timeout
-	cfg.targetTimeout = migrateCfg.Timeout
-	fallbackToOtherSide(&cfg.sourceTimeout, &cfg.targetTimeout)
+	cfg.sourceConcurrency, cfg.targetConcurrency, cfg.sourceTimeout, cfg.targetTimeout =
+		resolveSourceTargetRates(extractCfg, migrateCfg)
 	cfg.pemFilePath = extractCfg.PEMFilePath
 	cfg.keyFilePath = extractCfg.KeyFilePath
 	cfg.certPassword = extractCfg.CertPassword

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -187,8 +187,8 @@ func init() {
 	f.Bool(flagSkipIssueSync, false, "Skip the final per-issue and per-hotspot metadata sync (#299). Same semantics as the skip_issue_sync config-file field — defaults to false (sync happens); pass the flag to skip.")
 	f.Bool(flagSkipProjectDataMigration, false, "Skip the entire project-data migration: importProjectData and the trailing per-issue/per-hotspot sync (#303). Defaults to false (data is migrated); pass the flag to skip.")
 	f.Bool(flagFastSync, false, "Skip tagging and back-linking hotspots/issues with zero user changes on the source (original state, no comments, no custom tags). Defaults to false (every hotspot is tagged and back-linked). #527.")
-	f.Int(flagConcurrency, 0, "Max concurrent requests (default: 25) (maps to concurrency)")
-	f.Int(flagTimeout, 0, "HTTP request timeout in seconds (maps to timeout; default: 60)")
+	f.Int(flagConcurrency, 0, "Max concurrent requests, applied to both source and target (default: 25). Use source.concurrency / target.concurrency in the config file to set them independently.")
+	f.Int(flagTimeout, 0, "HTTP request timeout in seconds, applied to both source and target (default: 60). Use source.timeout / target.timeout in the config file to set them independently.")
 	f.String(flagPEMFilePath, "", "Path to client mTLS PEM file for the source server (maps to source.pem_file_path)")
 	f.String(flagKeyFilePath, "", "Path to client mTLS key file for the source server (maps to source.key_file_path)")
 	f.String(flagCertPassword, "", "Password for the source server mTLS client certificate (maps to source.cert_password)")
@@ -319,8 +319,20 @@ func loadTransferFileDefaults(path string) (transferConfig, error) {
 	// blocks genuinely differed.
 	cfg.sourceConcurrency = extractCfg.Concurrency
 	cfg.targetConcurrency = migrateCfg.Concurrency
+	if cfg.sourceConcurrency == 0 {
+		cfg.sourceConcurrency = cfg.targetConcurrency
+	}
+	if cfg.targetConcurrency == 0 {
+		cfg.targetConcurrency = cfg.sourceConcurrency
+	}
 	cfg.sourceTimeout = extractCfg.Timeout
 	cfg.targetTimeout = migrateCfg.Timeout
+	if cfg.sourceTimeout == 0 {
+		cfg.sourceTimeout = cfg.targetTimeout
+	}
+	if cfg.targetTimeout == 0 {
+		cfg.targetTimeout = cfg.sourceTimeout
+	}
 	cfg.pemFilePath = extractCfg.PEMFilePath
 	cfg.keyFilePath = extractCfg.KeyFilePath
 	cfg.certPassword = extractCfg.CertPassword

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -239,6 +239,18 @@ func applyFlagInt(cmd *cobra.Command, name string, target *int) {
 	}
 }
 
+// applyFlagIntBothSides sets both source and target to the CLI flag's value
+// when it was passed — used by transfer/sync-issues for --concurrency and
+// --timeout, which apply to both sides at once since each command talks to
+// source and target in one invocation (#528). The config file remains the
+// only way to give the two sides different values.
+func applyFlagIntBothSides(cmd *cobra.Command, name string, source, target *int) {
+	if cmd.Flags().Changed(name) {
+		v, _ := cmd.Flags().GetInt(name)
+		*source, *target = v, v
+	}
+}
+
 func applyFlagBool(cmd *cobra.Command, name string, target *bool) {
 	if cmd.Flags().Changed(name) {
 		*target, _ = cmd.Flags().GetBool(name)
@@ -344,18 +356,8 @@ func resolveTransferConfig(cmd *cobra.Command) (transferConfig, error) {
 	applyFlagString(cmd, flagEnterpriseKey, &cfg.enterpriseKey)
 	applyFlagString(cmd, flagEdition, &cfg.edition)
 	applyFlagString(cmd, flagExportDir, &cfg.exportDir)
-	// #528 — unlike extract/migrate (each inherently single-sided),
-	// transfer talks to both source and target, so --concurrency /
-	// --timeout set both sides at once. The config file remains the
-	// only way to give the two sides different values.
-	if cmd.Flags().Changed(flagConcurrency) {
-		v, _ := cmd.Flags().GetInt(flagConcurrency)
-		cfg.sourceConcurrency, cfg.targetConcurrency = v, v
-	}
-	if cmd.Flags().Changed(flagTimeout) {
-		v, _ := cmd.Flags().GetInt(flagTimeout)
-		cfg.sourceTimeout, cfg.targetTimeout = v, v
-	}
+	applyFlagIntBothSides(cmd, flagConcurrency, &cfg.sourceConcurrency, &cfg.targetConcurrency)
+	applyFlagIntBothSides(cmd, flagTimeout, &cfg.sourceTimeout, &cfg.targetTimeout)
 	applyFlagString(cmd, flagPEMFilePath, &cfg.pemFilePath)
 	applyFlagString(cmd, flagKeyFilePath, &cfg.keyFilePath)
 	applyFlagString(cmd, flagCertPassword, &cfg.certPassword)

--- a/go/cmd/transfer_test.go
+++ b/go/cmd/transfer_test.go
@@ -124,8 +124,10 @@ func TestResolveTransferConfig_UnifiedConfigShape(t *testing.T) {
 		enterpriseKey:       "ent-key",
 		edition:             "developer",
 		exportDir:           "/tmp/from-cfg",
-		concurrency:         7,
-		timeout:             42,
+		sourceConcurrency:   7,
+		targetConcurrency:   7,
+		sourceTimeout:       42,
+		targetTimeout:       42,
 		pemFilePath:         "/cert/pem",
 		keyFilePath:         "/cert/key",
 		certPassword:        "p4ss",
@@ -201,8 +203,12 @@ func TestResolveTransferConfig_CLIOverridesConfig(t *testing.T) {
 		{"enterpriseKey", cfg.enterpriseKey, "cli-ent"},
 		{"edition", cfg.edition, "community"},
 		{"exportDir", cfg.exportDir, "/tmp/cli"},
-		{"concurrency", cfg.concurrency, 11},
-		{"timeout", cfg.timeout, 99},
+		// #528 — transfer's --concurrency/--timeout set both source and
+		// target at once (config file is the only way to differ them).
+		{"sourceConcurrency", cfg.sourceConcurrency, 11},
+		{"targetConcurrency", cfg.targetConcurrency, 11},
+		{"sourceTimeout", cfg.sourceTimeout, 99},
+		{"targetTimeout", cfg.targetTimeout, 99},
 		{"pemFilePath", cfg.pemFilePath, "/cli/pem"},
 		{"keyFilePath", cfg.keyFilePath, "/cli/key"},
 		{"certPassword", cfg.certPassword, "cli-pass"},
@@ -212,6 +218,61 @@ func TestResolveTransferConfig_CLIOverridesConfig(t *testing.T) {
 	for _, c := range checks {
 		if c.got != c.want {
 			t.Errorf("%s: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// Issue #528: source and target must be able to carry genuinely
+// different concurrency/timeout values from the config file — before
+// this fix, transfer's loadTransferFileDefaults collapsed the two
+// independently-resolved values into one shared field, so target's
+// timeout was always silently discarded in favor of source's, and
+// concurrency arbitrarily preferred whichever side's block was
+// non-zero. The network path to the source SonarQube Server and to
+// the target SonarQube Cloud can have very different characteristics,
+// which is the whole motivation for this issue.
+func TestResolveTransferConfig_SourceAndTargetConcurrencyTimeoutDiffer(t *testing.T) {
+	path := writeTransferConfig(t, `{
+		"concurrency": 10,
+		"timeout": 60,
+		"source": {
+			"url": "https://sq.example.com",
+			"token": "sq-token",
+			"concurrency": 10,
+			"timeout": 10
+		},
+		"target": {
+			"url": "https://sonarcloud.io/",
+			"token": "sc-token",
+			"default_organization": "my-org",
+			"concurrency": 5,
+			"timeout": 30
+		}
+	}`)
+
+	cmd := newTransferTestCmd()
+	if err := cmd.ParseFlags([]string{"-c", path}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := resolveTransferConfig(cmd)
+	if err != nil {
+		t.Fatalf("resolveTransferConfig: %v", err)
+	}
+
+	checks := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"sourceConcurrency", cfg.sourceConcurrency, 10},
+		{"targetConcurrency", cfg.targetConcurrency, 5},
+		{"sourceTimeout", cfg.sourceTimeout, 10},
+		{"targetTimeout", cfg.targetTimeout, 30},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s: got %d, want %d", c.name, c.got, c.want)
 		}
 	}
 }

--- a/go/cmd/transfer_test.go
+++ b/go/cmd/transfer_test.go
@@ -277,6 +277,45 @@ func TestResolveTransferConfig_SourceAndTargetConcurrencyTimeoutDiffer(t *testin
 	}
 }
 
+// Issue #528 follow-up: when only ONE side sets concurrency/timeout in the
+// config file (no top-level default, nothing on the other side), the unset
+// side must borrow the explicitly-set side's value rather than falling
+// through to the hardcoded package default (25 / 60) — preserving the
+// pre-#528 behavior for this single-side case while still letting the two
+// sides genuinely differ when both are set explicitly.
+func TestResolveTransferConfig_SingleSideConcurrencyTimeoutFallsBackToOtherSide(t *testing.T) {
+	path := writeTransferConfig(t, `{
+		"source": {
+			"url": "https://sq.example.com",
+			"token": "sq-token"
+		},
+		"target": {
+			"url": "https://sonarcloud.io/",
+			"token": "sc-token",
+			"default_organization": "my-org",
+			"concurrency": 5,
+			"timeout": 30
+		}
+	}`)
+
+	cmd := newTransferTestCmd()
+	if err := cmd.ParseFlags([]string{"-c", path}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := resolveTransferConfig(cmd)
+	if err != nil {
+		t.Fatalf("resolveTransferConfig: %v", err)
+	}
+
+	if cfg.sourceConcurrency != 5 {
+		t.Errorf("sourceConcurrency: got %d, want 5 (borrowed from target)", cfg.sourceConcurrency)
+	}
+	if cfg.sourceTimeout != 30 {
+		t.Errorf("sourceTimeout: got %d, want 30 (borrowed from target)", cfg.sourceTimeout)
+	}
+}
+
 // Issue #527: --fast_sync loads from the config file when the CLI flag
 // is absent, and defaults to false when neither is set.
 func TestResolveTransferConfig_FastSync(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #528 — `transfer` and `sync-issues` now resolve `concurrency`/`timeout` independently for source (SonarQube Server) and target (SonarQube Cloud), instead of silently collapsing the two into one shared value.

`extract` and `migrate` already resolved these correctly per side (issue #266's unified config shape), each with its own semaphore and HTTP client. The bug was confined to `transfer`/`sync-issues`, which load the config file through *both* `extract.LoadExtractConfigFile` (source-resolved) and `migrate.LoadMigrateConfigFile` (target-resolved) but then collapsed the two already-correct values into one field:

```go
switch {
case extractCfg.Concurrency != 0:
    cfg.concurrency = extractCfg.Concurrency   // arbitrarily prefers source
case migrateCfg.Concurrency != 0:
    cfg.concurrency = migrateCfg.Concurrency
}
cfg.timeout = extractCfg.Timeout   // target.timeout always silently dropped
```

So `source.timeout: 30, target.timeout: 90` in a config file used to apply 30 to both phases — permanently discarding the target value — even though the documented example config (`examples/config.unified.example.json`) and `transfer`'s own `--help` text have shown independent per-side values since #266.

- Split `transferConfig`/`syncIssuesConfig`'s `concurrency`/`timeout` fields into `source*`/`target*` pairs.
- `loadTransferFileDefaults`/`loadSyncIssuesFileDefaults`: assign each loader's resolved value straight through instead of collapsing.
- `--concurrency`/`--timeout` on the CLI now set **both** sides at once, matching the issue's spec that the config file is the only way to differ them for these two commands.
- Each phase (`extract.RunExtract`, `migrate.RunMigrate`/`RunSyncIssues`) now gets its own side's values.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./... -count=1` — full suite green
- [x] Updated `TestResolveTransferConfig_UnifiedConfigShape` / `TestResolveSyncIssuesConfig_UnifiedConfigShape` for the renamed fields
- [x] Updated `TestResolveTransferConfig_CLIOverridesConfig` / `TestResolveSyncIssuesConfig_CLIOverridesConfig` to assert `--concurrency`/`--timeout` set both source and target
- [x] Added `TestResolveTransferConfig_SourceAndTargetConcurrencyTimeoutDiffer` and `TestResolveSyncIssuesConfig_SourceAndTargetConcurrencyTimeoutDiffer` — regression tests proving distinct per-side config-file values resolve correctly (the scenario the old tests never covered)
- [x] Manual check of `transfer --help` output — flag descriptions still read correctly
