### PR TITLE
Take hotspots sync into account in the migration ETA estimation

### DIFF
--- a/go/internal/common/progress_tracker.go
+++ b/go/internal/common/progress_tracker.go
@@ -23,6 +23,7 @@ const (
 	CategoryProjectConfig
 	CategoryProjectData
 	CategoryIssueSync
+	CategoryHotspotSync
 )
 
 // CategoryWeights are the percentage points (summing to 100) assigned to
@@ -37,14 +38,32 @@ type CategoryWeights struct {
 	ProjectConfig float64
 	ProjectData   float64
 	IssueSync     float64
+	HotspotSync   float64
 }
 
-// DefaultCategoryWeights is the split mandated by issue #520.
+// DefaultCategoryWeights is the split mandated by issue #520. Used as-is by
+// extract, which has no separate trailing hotspot-sync task (HotspotSync
+// stays 0 and CategoryHotspotSync is never emitted by extract's
+// CategorizeTask, so it simply drops out of Tracker.snapshot's denominator).
 var DefaultCategoryWeights = CategoryWeights{
 	General:       5,
 	ProjectConfig: 20,
 	ProjectData:   25,
 	IssueSync:     50,
+}
+
+// DefaultMigrateCategoryWeights is the migrate/transfer-only split mandated
+// by issue #526: syncHotspotMetadata and syncIssueMetadata are separate,
+// sequential trailing tasks, so hotspot sync gets its own 5-point weight
+// carved out of what was previously a single 50-point IssueSync bucket —
+// otherwise the overall percentage sticks at ~100% (and ETA collapses to
+// near-zero) once issue sync finishes while hotspot sync is still running.
+var DefaultMigrateCategoryWeights = CategoryWeights{
+	General:       5,
+	ProjectConfig: 20,
+	ProjectData:   25,
+	IssueSync:     45,
+	HotspotSync:   5,
 }
 
 func (w CategoryWeights) forCategory(cat TaskCategory) float64 {
@@ -55,6 +74,8 @@ func (w CategoryWeights) forCategory(cat TaskCategory) float64 {
 		return w.ProjectData
 	case CategoryIssueSync:
 		return w.IssueSync
+	case CategoryHotspotSync:
+		return w.HotspotSync
 	default:
 		return w.General
 	}

--- a/go/internal/common/progress_tracker_test.go
+++ b/go/internal/common/progress_tracker_test.go
@@ -16,14 +16,16 @@ import (
 )
 
 // categorizeByPrefix buckets synthetic test task names by a "general-",
-// "config-", "data-", or "sync-" prefix — lets each example below spell
-// out task names that read like the issue's own bullet points.
+// "config-", "data-", "sync-", or "hotspot-" prefix — lets each example
+// below spell out task names that read like the issue's own bullet points.
 func categorizeByPrefix(name string) TaskCategory {
 	switch {
 	case len(name) >= 7 && name[:7] == "config-":
 		return CategoryProjectConfig
 	case len(name) >= 5 && name[:5] == "data-":
 		return CategoryProjectData
+	case len(name) >= 8 && name[:8] == "hotspot-":
+		return CategoryHotspotSync
 	case len(name) >= 5 && name[:5] == "sync-":
 		return CategoryIssueSync
 	default:
@@ -132,6 +134,60 @@ func TestTrackerSnapshotWorkedExamples(t *testing.T) {
 		percent, _, _ := tr.snapshot()
 		if !almostEqual(percent, 24.4, 0.1) {
 			t.Errorf("percent = %v, want ~24.4", percent)
+		}
+	})
+}
+
+// TestTrackerSnapshotHotspotSyncWeight pins the #526 fix: with
+// DefaultMigrateCategoryWeights, issue sync finishing no longer reports the
+// overall run as ~100% while hotspot sync (its own 5-point bucket) is still
+// in progress or hasn't started — previously the two shared one IssueSync
+// bucket, so completing syncIssueMetadata alone reported that whole 50%
+// share as done.
+func TestTrackerSnapshotHotspotSyncWeight(t *testing.T) {
+	t.Run("issue sync done, hotspot sync not started", func(t *testing.T) {
+		plan := [][]string{{"general-1", "config-1", "data-1", "sync-1", "hotspot-1"}}
+		tr := NewTracker(testLogger(), plan, categorizeByPrefix, DefaultMigrateCategoryWeights)
+		tr.MarkTaskComplete("general-1")
+		tr.MarkTaskComplete("config-1")
+		tr.MarkTaskComplete("data-1")
+		tr.MarkTaskComplete("sync-1")
+		// hotspot-1 stays unregistered — not started.
+
+		percent, _, _ := tr.snapshot()
+		if !almostEqual(percent, 95, 0.1) {
+			t.Errorf("percent = %v, want ~95 (100 - the unstarted 5%% hotspot-sync weight)", percent)
+		}
+	})
+
+	t.Run("issue sync done, hotspot sync in progress", func(t *testing.T) {
+		plan := [][]string{{"general-1", "config-1", "data-1", "sync-1", "hotspot-1"}}
+		tr := NewTracker(testLogger(), plan, categorizeByPrefix, DefaultMigrateCategoryWeights)
+		tr.MarkTaskComplete("general-1")
+		tr.MarkTaskComplete("config-1")
+		tr.MarkTaskComplete("data-1")
+		tr.MarkTaskComplete("sync-1")
+		registerPartial(tr, "hotspot-1", 50, 200)
+
+		percent, _, _ := tr.snapshot()
+		if !almostEqual(percent, 96.25, 0.1) {
+			t.Errorf("percent = %v, want ~96.25", percent)
+		}
+		if percent >= 100 {
+			t.Errorf("percent = %v, want < 100 while hotspot sync is still in progress", percent)
+		}
+	})
+
+	t.Run("issue sync and hotspot sync both done", func(t *testing.T) {
+		plan := [][]string{{"general-1", "config-1", "data-1", "sync-1", "hotspot-1"}}
+		tr := NewTracker(testLogger(), plan, categorizeByPrefix, DefaultMigrateCategoryWeights)
+		for _, n := range []string{"general-1", "config-1", "data-1", "sync-1", "hotspot-1"} {
+			tr.MarkTaskComplete(n)
+		}
+
+		percent, _, _ := tr.snapshot()
+		if !almostEqual(percent, 100, 0.01) {
+			t.Errorf("percent = %v, want 100", percent)
 		}
 	})
 }

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -314,7 +314,7 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 
 	// Overall progress/ETA logging (#520) — every 10s for the duration of
 	// the run, stopped once phases finish (success or error).
-	executor.Progress = common.NewTracker(logger, phases, CategorizeTask, common.DefaultCategoryWeights)
+	executor.Progress = common.NewTracker(logger, phases, CategorizeTask, common.DefaultMigrateCategoryWeights)
 	executor.Progress.OnUpdate(cfg.ProgressCallback)
 	executor.Progress.Start(ctx, 10*time.Second)
 	defer executor.Progress.Stop()

--- a/go/internal/migrate/progress_categories.go
+++ b/go/internal/migrate/progress_categories.go
@@ -8,8 +8,12 @@ import "github.com/sonar-solutions/sonar-migration-tool/internal/common"
 
 // migrateProjectDataOnlyTasks is the ProjectData bucket for progress
 // weighting (#520) — just importProjectData. migrateIssueSyncTasks
-// (planner.go) already lists exactly {syncHotspotMetadata,
-// syncIssueMetadata} and is reused directly as the IssueSync bucket.
+// (planner.go) lists exactly {syncHotspotMetadata, syncIssueMetadata}; for
+// progress weighting the two are split (#526) — syncHotspotMetadata gets
+// its own CategoryHotspotSync bucket, syncIssueMetadata stays IssueSync —
+// since they run as separate, sequential trailing tasks and lumping them
+// together made overall progress stick at ~100% while hotspot sync was
+// still running.
 var migrateProjectDataOnlyTasks = map[string]bool{
 	"importProjectData": true,
 }
@@ -47,6 +51,8 @@ func CategorizeTask(name string) common.TaskCategory {
 	switch {
 	case migrateProjectDataOnlyTasks[name]:
 		return common.CategoryProjectData
+	case name == "syncHotspotMetadata":
+		return common.CategoryHotspotSync
 	case migrateIssueSyncTasks[name]:
 		return common.CategoryIssueSync
 	case migrateProjectConfigTasks[name]:

--- a/go/internal/migrate/progress_categories_test.go
+++ b/go/internal/migrate/progress_categories_test.go
@@ -15,9 +15,9 @@ func TestCategorizeTask(t *testing.T) {
 		task string
 		want common.TaskCategory
 	}{
-		// Project data / issue sync (#520).
+		// Project data / issue sync (#520); hotspot sync split out (#526).
 		{"importProjectData", common.CategoryProjectData},
-		{"syncHotspotMetadata", common.CategoryIssueSync},
+		{"syncHotspotMetadata", common.CategoryHotspotSync},
 		{"syncIssueMetadata", common.CategoryIssueSync},
 		// Project config: per-project provisioning/configuration.
 		{"createProjects", common.CategoryProjectConfig},
@@ -50,20 +50,23 @@ func TestCategorizeTask(t *testing.T) {
 }
 
 // migrateIssueSyncTasks (planner.go's gating map for --skip_issue_sync)
-// must map to CategoryIssueSync here, and migrateProjectDataTasks (the
-// wider --skip_project_data_migration gate) must map to ProjectData or
-// IssueSync — never General or ProjectConfig — since #520's weighting
-// relies on these categories dropping to 0 together with the gates.
+// must map to CategoryIssueSync or CategoryHotspotSync here (#526 splits
+// syncHotspotMetadata out of the IssueSync bucket), and
+// migrateProjectDataTasks (the wider --skip_project_data_migration gate)
+// must map to ProjectData, IssueSync, or HotspotSync — never General or
+// ProjectConfig — since #520's weighting relies on these categories
+// dropping to 0 together with the gates.
 func TestGatingMapsFullyCategorized(t *testing.T) {
 	for name := range migrateIssueSyncTasks {
-		if cat := CategorizeTask(name); cat != common.CategoryIssueSync {
-			t.Errorf("%s: gated by --skip_issue_sync but categorized as %v, want IssueSync", name, cat)
+		cat := CategorizeTask(name)
+		if cat != common.CategoryIssueSync && cat != common.CategoryHotspotSync {
+			t.Errorf("%s: gated by --skip_issue_sync but categorized as %v, want IssueSync or HotspotSync", name, cat)
 		}
 	}
 	for name := range migrateProjectDataTasks {
 		cat := CategorizeTask(name)
-		if cat != common.CategoryProjectData && cat != common.CategoryIssueSync {
-			t.Errorf("%s: gated by --skip_project_data_migration but categorized as %v, want ProjectData or IssueSync", name, cat)
+		if cat != common.CategoryProjectData && cat != common.CategoryIssueSync && cat != common.CategoryHotspotSync {
+			t.Errorf("%s: gated by --skip_project_data_migration but categorized as %v, want ProjectData, IssueSync, or HotspotSync", name, cat)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- `syncHotspotMetadata` and `syncIssueMetadata` are separate, sequential trailing tasks in migrate/transfer, but the progress tracker lumped both into a single `CategoryIssueSync` bucket — once issue sync finished, overall progress stuck at ~100% (and ETA collapsed to near-zero) while hotspot sync was still running.
- Carves out a dedicated `CategoryHotspotSync` bucket with its own 5-point weight for migrate/transfer: 5% general + 20% project config + 25% project data + 45% issue sync + 5% hotspot sync (was 50% issue sync), total still 100%.
- Extract keeps its existing weights (`DefaultCategoryWeights`) unchanged — it has no equivalent trailing hotspot task, so this is scoped to transfer/migrate only, matching the issue's ask.

## Changes
- `internal/common/progress_tracker.go`: new `CategoryHotspotSync` category, `HotspotSync` weight field, and `DefaultMigrateCategoryWeights`.
- `internal/migrate/migrate.go`: tracker now uses `DefaultMigrateCategoryWeights` (transfer reuses this same construction site).
- `internal/migrate/progress_categories.go`: `syncHotspotMetadata` now categorizes as `CategoryHotspotSync` instead of `CategoryIssueSync`.
- Updated tests in `internal/common` and `internal/migrate`, including a new `TestTrackerSnapshotHotspotSyncWeight` reproducing the reported bug.

Fixes #526

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/common/... ./internal/migrate/... ./internal/extract/...` — all pass
- [x] Confirmed extract's weighting behavior is untouched (no source changes, existing tests pass unchanged)