### PR TITLE
Fix double "v" in version output (e.g. "sonar-migration-tool vv1.2.0-…

### DIFF
--- a/go/internal/extract/extract.go
+++ b/go/internal/extract/extract.go
@@ -174,7 +174,7 @@ func RunExtract(ctx context.Context, cfg ExtractConfig) ([]string, error) {
 	executor.Progress.Stop() // silence the ticker before the closing line
 	executor.Progress.LogFinal()
 
-	fmt.Printf("%s v%s - Extract Complete: %s\n", smtver.ToolName, smtver.Version, extractID)
+	fmt.Printf("%s %s - Extract Complete: %s\n", smtver.ToolName, smtver.Version, extractID)
 	return executor.SkippedProjectKeys(), nil
 }
 

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -331,7 +331,7 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 	}
 	executor.Progress.LogFinal()
 
-	fmt.Printf("%s v%s - Migration Complete: %s\n", version.ToolName, version.Version, runIDOut)
+	fmt.Printf("%s %s - Migration Complete: %s\n", version.ToolName, version.Version, runIDOut)
 	return runIDOut, nil
 }
 

--- a/go/internal/migrate/reset.go
+++ b/go/internal/migrate/reset.go
@@ -164,7 +164,7 @@ func RunReset(ctx context.Context, cfg ResetConfig) error {
 		}
 	}
 
-	fmt.Printf("%s v%s - Reset Complete: %s\n", version.ToolName, version.Version, runID)
+	fmt.Printf("%s %s - Reset Complete: %s\n", version.ToolName, version.Version, runID)
 	return nil
 }
 


### PR DESCRIPTION
…SNAPSHOT")

version.Version already includes a leading "v" (e.g. "v1.2.0-SNAPSHOT"), but three completion-line Printfs formatted it with an extra "%s v%s", producing a doubled "vv" prefix.