### PR TITLE
Log Cloud-indexing retry waits instead of running silently

### DIFF
--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -560,7 +560,7 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 
 	// 2. Wait for Cloud indexing — proves the CE task is done. Counted over
 	// issues, not hotspots: the imported findings are issues on the target.
-	_ = waitForCloudIndexing(ctx, func() (int, error) {
+	_ = waitForCloudIndexing(ctx, e.Logger, "syncHotspotMetadata", input.CloudKey, func() (int, error) {
 		params := url.Values{}
 		params.Set("componentKeys", input.CloudKey)
 		params.Set("organization", input.OrgKey)

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"slices"
 	"strings"
@@ -387,7 +388,13 @@ func countDistinctBranches(issues []matchableIssue) int {
 // exhausted without results the function returns nil (non-fatal) so the
 // sync proceeds with zero matches — the alternative would be a hard
 // failure that blocks later projects unnecessarily.
-func waitForCloudIndexing(ctx context.Context, fetchFn func() (int, error)) error {
+//
+// Retries are logged (task/project-scoped) because the backoff can run up
+// to ~8 minutes (10+20+40+60*7s) with no other activity for this project:
+// without a log line here, that wait is indistinguishable from a hang —
+// the run-wide progress percentage can't move either, since it only
+// advances once this project's whole sync completes.
+func waitForCloudIndexing(ctx context.Context, logger *slog.Logger, task, projectKey string, fetchFn func() (int, error)) error {
 	const (
 		initialDelay = 10 * time.Second
 		maxDelay     = 60 * time.Second
@@ -403,6 +410,8 @@ func waitForCloudIndexing(ctx context.Context, fetchFn func() (int, error)) erro
 		if total > 0 {
 			return nil
 		}
+		logger.Info(fmt.Sprintf("%s: waiting for Cloud indexing to catch up", task),
+			"project", projectKey, "attempt", attempt+1, "max_attempts", maxRetries, "retry_in", delay)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -538,7 +547,7 @@ func syncProjectIssues(ctx context.Context, e *Executor, cloudKey, orgKey, serve
 
 	// 2. Wait for Cloud indexing — proves the CE task is done so per-
 	// issue searches return real data.
-	if err := waitForCloudIndexing(ctx, func() (int, error) {
+	if err := waitForCloudIndexing(ctx, e.Logger, "syncIssueMetadata", cloudKey, func() (int, error) {
 		params := url.Values{}
 		params.Set("componentKeys", cloudKey)
 		params.Set("organization", orgKey)

--- a/go/internal/migrate/tasks_issuesync_test.go
+++ b/go/internal/migrate/tasks_issuesync_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -1215,5 +1216,73 @@ func TestLoadMatchableIssuesCarriesScorerFields(t *testing.T) {
 	iss := got[0]
 	if iss.Message != "Do not do this" || iss.Type != "BUG" || iss.Severity != "MAJOR" || iss.Author != "dev@example.com" {
 		t.Errorf("loadMatchableIssues: scorer fields not carried through, got %+v", iss)
+	}
+}
+
+// waitForCloudIndexing must return immediately, without logging anything,
+// when the first fetch already reports a non-zero total — the common case
+// (Cloud already indexed) must not pay for a retry log line.
+func TestWaitForCloudIndexingSucceedsImmediatelyWithoutLogging(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	calls := 0
+	err := waitForCloudIndexing(context.Background(), logger, "syncIssueMetadata", "proj-a", func() (int, error) {
+		calls++
+		return 5, nil
+	})
+	if err != nil {
+		t.Fatalf("waitForCloudIndexing: unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("fetchFn calls = %d, want 1", calls)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no log output on immediate success, got: %s", buf.String())
+	}
+}
+
+// A fetchFn error must propagate immediately without any retry-wait log
+// line — the loop's error path returns before ever reaching the log call.
+func TestWaitForCloudIndexingPropagatesFetchError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+	wantErr := errors.New("boom")
+
+	err := waitForCloudIndexing(context.Background(), logger, "syncIssueMetadata", "proj-a", func() (int, error) {
+		return 0, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want %v", err, wantErr)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no log output when fetchFn errors, got: %s", buf.String())
+	}
+}
+
+// #526-adjacent fix: when Cloud hasn't indexed yet (total == 0), the retry
+// wait must be logged — task/project-scoped — rather than silent, since the
+// backoff can otherwise run for minutes with zero visible activity. Uses an
+// already-canceled context so the test doesn't pay for the real 10s delay:
+// the log line fires before the select on ctx.Done()/time.After(delay).
+func TestWaitForCloudIndexingLogsBeforeRetrying(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := waitForCloudIndexing(ctx, logger, "syncHotspotMetadata", "proj-b", func() (int, error) {
+		return 0, nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "syncHotspotMetadata: waiting for Cloud indexing to catch up") {
+		t.Errorf("expected a waiting-for-indexing log line, got: %s", out)
+	}
+	if !strings.Contains(out, "project=proj-b") {
+		t.Errorf("expected the log line to be project-scoped, got: %s", out)
 	}
 }


### PR DESCRIPTION
waitForCloudIndexing polls with exponential backoff (10s/20s/40s/60s, up to 10 attempts, worst case ~8 minutes) before syncIssueMetadata or syncHotspotMetadata process a project's issues/hotspots, but emitted no log output while waiting. Combined with the per-project (not per-item) progress registration, this made a slow-to-index project look exactly like a hang: overall progress frozen at 99% with a near-flat ETA for minutes at a time, with nothing in the log to explain why.

Log each retry attempt, scoped to the task and project key, so the wait is visible instead of silent.