### PR TITLE
Report source/target rule diff for built-in QPs (#309)

### DIFF
--- a/go/internal/common/object_task_names.go
+++ b/go/internal/common/object_task_names.go
@@ -117,6 +117,7 @@ var objectCategoryTaskNames = map[string]struct {
 			"createProfiles", "setProfileParent", "restoreProfiles", "analyzeProfileRules",
 			"setDefaultProfiles", "setProfileGroupPermissions",
 			"updateRuleTags", "updateRuleDescriptions",
+			"compareBuiltInProfiles",
 		},
 	},
 	ObjectQualityGates: {

--- a/go/internal/migrate/planner.go
+++ b/go/internal/migrate/planner.go
@@ -85,6 +85,7 @@ func RegisterAll() []TaskDef {
 	all = append(all, almTasks()...)
 	all = append(all, portfolioTasks()...)
 	all = append(all, ruleTasks()...)
+	all = append(all, compareTasks()...)
 	all = append(all, deleteTasks()...)
 	all = append(all, projectDataTasks()...)
 	all = append(all, hotspotMetadataSyncTasks()...)

--- a/go/internal/migrate/tasks_compare_profiles.go
+++ b/go/internal/migrate/tasks_compare_profiles.go
@@ -1,0 +1,192 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strings"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
+)
+
+// BuiltInProfileDiff is the JSONL record compareBuiltInProfiles emits for
+// each source built-in quality profile it was able to match against a
+// target built-in profile. The summary report joins these back onto the
+// existing "Built-in, not migrated" skip row (issue #309) by
+// (ServerURL, Name, Language) — the same key it already dedups extract
+// data on for the Quality Profiles section.
+type BuiltInProfileDiff struct {
+	ServerURL    string `json:"server_url"`
+	Name         string `json:"name"`
+	Language     string `json:"language"`
+	RulesAdded   int    `json:"rules_added"`
+	RulesRemoved int    `json:"rules_removed"`
+}
+
+// compareTasks returns the task that diffs source vs target built-in
+// quality profiles' active rule sets (#309).
+func compareTasks() []TaskDef {
+	return []TaskDef{
+		{
+			Name:         "compareBuiltInProfiles",
+			Dependencies: []string{"generateOrganizationMappings"},
+			Run:          runCompareBuiltInProfiles,
+		},
+	}
+}
+
+// runCompareBuiltInProfiles walks every source built-in quality profile
+// (e.g. "Sonar way") and, for each one, live-fetches the matching
+// built-in profile's active rules on the target organization to compute
+// how many rules were added/removed on SQC relative to the source. Built-
+// in profiles are never migrated (structure.addProfile drops them before
+// profiles.csv is generated), so this is the only place that ever looks
+// at their target-side rule set.
+//
+// Unlike runAnalyzeProfileRules, this task DOES call the live Cloud API —
+// it needs the target's actual rule set, which extract data can't provide.
+// That also means it only ever runs during a real migrate: the predictive
+// report's synthetic run directory never synthesizes this task's output,
+// so collectExtractSkipped simply finds no sidecar and keeps the static
+// "Built-in, not migrated" text for predictive runs.
+func runCompareBuiltInProfiles(ctx context.Context, e *Executor) error {
+	orgKeys := firstValidOrgPerServer(e)
+	activeByProfile := indexExtractByServerAndField(e, "getActiveProfileRules", "profileKey")
+
+	counter := TaskCounterFromContext(ctx)
+	return forEachExtractItem(ctx, e, "compareBuiltInProfiles", "getProfiles",
+		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
+			if !extractBool(item.Data, "isBuiltIn") {
+				return nil
+			}
+			name := extractField(item.Data, "name")
+			language := extractField(item.Data, "language")
+			profileKey := extractField(item.Data, "key")
+			orgKey := orgKeys[item.ServerURL]
+			if name == "" || language == "" || profileKey == "" || orgKey == "" {
+				return nil
+			}
+
+			targetProfiles, err := e.Cloud.QualityProfiles.Search(ctx, orgKey)
+			if err != nil {
+				failAPI(counter, e.Logger, "compareBuiltInProfiles: searching target profiles failed", err,
+					"organization", orgKey, "language", language)
+				return nil
+			}
+			targetKey := ""
+			for _, p := range targetProfiles {
+				// Match on name AND language, not language alone: a
+				// platform can ship more than one built-in profile per
+				// language (e.g. "Sonar way" and "Sonar agentic AI"
+				// both built-in for java). Matching by language only
+				// would pair every source built-in of that language
+				// against whichever built-in profile happened to come
+				// first in the target's search results.
+				if isBuiltInProfile(p) && strings.EqualFold(p.Language, language) && strings.EqualFold(p.Name, name) {
+					targetKey = p.Key
+					break
+				}
+			}
+			if targetKey == "" {
+				// No matching built-in profile on the target with this
+				// exact name — leave the row on its default text.
+				return nil
+			}
+
+			targetItems, err := e.Raw.GetPaginated(ctx, common.PaginatedOpts{
+				// SonarQube Cloud's api/rules/search responds with a
+				// top-level "total" field and no "paging" object at all
+				// (unlike SonarQube Server, which nests it under
+				// "paging.total" too — the default TotalKey). Without
+				// this override, ExtractTotal silently reads 0 from the
+				// Cloud response, TotalPages then also returns 0, and
+				// GetPaginated stops after page 1 — truncating any
+				// profile with more active rules than one page (500).
+				Path: "api/rules/search", ResultKey: "rules", TotalKey: "total", MaxPageSize: 500,
+				Params: url.Values{
+					"inheritance": {"NONE"},
+					"qprofile":    {targetKey},
+					"activation":  {"true"},
+				},
+			})
+			if err != nil {
+				failAPI(counter, e.Logger, "compareBuiltInProfiles: fetching target rules failed", err,
+					"organization", orgKey, "language", language)
+				return nil
+			}
+
+			sourceRules := ruleKeySet(activeByProfile[item.ServerURL+"\x00"+profileKey])
+			targetRules := ruleKeySet(targetItems)
+			added, removed := diffRuleKeySets(sourceRules, targetRules)
+
+			b, mErr := json.Marshal(BuiltInProfileDiff{
+				ServerURL:    item.ServerURL,
+				Name:         name,
+				Language:     language,
+				RulesAdded:   added,
+				RulesRemoved: removed,
+			})
+			if mErr != nil {
+				return nil
+			}
+			counter.Success()
+			return w.WriteOne(b)
+		})
+}
+
+// firstValidOrgPerServer maps each source server URL to the first target
+// organization it's bound to that actually has a SonarQube Cloud
+// counterpart. Unlike buildServerOrgLookup — which blindly keeps the LAST
+// generateOrganizationMappings row per server, including rows with an
+// empty or "SKIPPED" sonarcloud_org_key from an unbound ALM binding — this
+// is safe when one source server fans out into several target
+// organizations (a common consolidation setup): the built-in profile's
+// rule content is identical across every org on the same target
+// platform/edition, so any one bound org is representative for the diff.
+func firstValidOrgPerServer(e *Executor) map[string]string {
+	orgItems, _ := e.Store.ReadAll("generateOrganizationMappings")
+	out := make(map[string]string, len(orgItems))
+	for _, o := range orgItems {
+		serverURL := extractField(o, "server_url")
+		cloudKey := extractField(o, "sonarcloud_org_key")
+		if serverURL == "" || cloudKey == "" || shouldSkipOrg(cloudKey) {
+			continue
+		}
+		if _, ok := out[serverURL]; !ok {
+			out[serverURL] = cloudKey
+		}
+	}
+	return out
+}
+
+// ruleKeySet extracts the "key" field of each raw rule record into a set.
+func ruleKeySet(items []json.RawMessage) map[string]bool {
+	set := make(map[string]bool, len(items))
+	for _, item := range items {
+		if key := extractField(item, "key"); key != "" {
+			set[key] = true
+		}
+	}
+	return set
+}
+
+// diffRuleKeySets returns how many keys are present in target but not in
+// source (added) and present in source but not in target (removed).
+func diffRuleKeySets(source, target map[string]bool) (added, removed int) {
+	for key := range target {
+		if !source[key] {
+			added++
+		}
+	}
+	for key := range source {
+		if !target[key] {
+			removed++
+		}
+	}
+	return added, removed
+}

--- a/go/internal/migrate/tasks_compare_profiles.go
+++ b/go/internal/migrate/tasks_compare_profiles.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
@@ -59,6 +60,10 @@ func runCompareBuiltInProfiles(ctx context.Context, e *Executor) error {
 	activeByProfile := indexExtractByServerAndField(e, "getActiveProfileRules", "profileKey")
 
 	counter := TaskCounterFromContext(ctx)
+	// One Search per target org, not one per source built-in profile.
+	builtInKeys := map[string]string{} // orgKey\x00lang\x00name -> target profile key
+	searched := map[string]bool{}
+	var mu sync.Mutex
 	return forEachExtractItem(ctx, e, "compareBuiltInProfiles", "getProfiles",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			if !extractBool(item.Data, "isBuiltIn") {
@@ -72,26 +77,29 @@ func runCompareBuiltInProfiles(ctx context.Context, e *Executor) error {
 				return nil
 			}
 
-			targetProfiles, err := e.Cloud.QualityProfiles.Search(ctx, orgKey)
-			if err != nil {
-				failAPI(counter, e.Logger, "compareBuiltInProfiles: searching target profiles failed", err,
-					"organization", orgKey, "language", language)
-				return nil
-			}
-			targetKey := ""
-			for _, p := range targetProfiles {
-				// Match on name AND language, not language alone: a
-				// platform can ship more than one built-in profile per
-				// language (e.g. "Sonar way" and "Sonar agentic AI"
-				// both built-in for java). Matching by language only
-				// would pair every source built-in of that language
-				// against whichever built-in profile happened to come
-				// first in the target's search results.
-				if isBuiltInProfile(p) && strings.EqualFold(p.Language, language) && strings.EqualFold(p.Name, name) {
-					targetKey = p.Key
-					break
+			mu.Lock()
+			if !searched[orgKey] {
+				searched[orgKey] = true
+				if targetProfiles, err := e.Cloud.QualityProfiles.Search(ctx, orgKey); err != nil {
+					failAPI(counter, e.Logger, "compareBuiltInProfiles: searching target profiles failed", err,
+						"organization", orgKey)
+				} else {
+					for _, p := range targetProfiles {
+						// Match on name AND language, not language alone: a
+						// platform can ship more than one built-in profile per
+						// language (e.g. "Sonar way" and "Sonar agentic AI"
+						// both built-in for java). Matching by language only
+						// would pair every source built-in of that language
+						// against whichever built-in profile happened to come
+						// first in the target's search results.
+						if isBuiltInProfile(p) {
+							builtInKeys[orgKey+"\x00"+strings.ToLower(p.Language)+"\x00"+strings.ToLower(p.Name)] = p.Key
+						}
+					}
 				}
 			}
+			targetKey := builtInKeys[orgKey+"\x00"+strings.ToLower(language)+"\x00"+strings.ToLower(name)]
+			mu.Unlock()
 			if targetKey == "" {
 				// No matching built-in profile on the target with this
 				// exact name — leave the row on its default text.

--- a/go/internal/migrate/tasks_compare_profiles_test.go
+++ b/go/internal/migrate/tasks_compare_profiles_test.go
@@ -1,0 +1,424 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// TestRunCompareBuiltInProfiles exercises issue #309: the source built-in
+// "Sonar way"/java profile has active rules {S1, S2, S3}; the target
+// built-in profile on Cloud has {S2, S4}. Expect 1 rule added (S4) and
+// 2 rules removed (S1, S3), reported under the source server/profile key.
+func TestRunCompareBuiltInProfiles(t *testing.T) {
+	dir := t.TempDir()
+	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+
+	writeJSONL(filepath.Join(dir, "extract-01", "getProfiles"), []map[string]any{
+		{"key": "srcprof1", "name": "Sonar way", "language": "java", "isBuiltIn": true},
+		{"key": "srcprof2", "name": "Custom Java", "language": "java", "isBuiltIn": false},
+	})
+	writeJSONL(filepath.Join(dir, "extract-01", "getActiveProfileRules"), []map[string]any{
+		{"key": "java:S1", "profileKey": "srcprof1"},
+		{"key": "java:S2", "profileKey": "srcprof1"},
+		{"key": "java:S3", "profileKey": "srcprof1"},
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualityprofiles/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"profiles": []map[string]any{
+				{"key": "tgtprof1", "name": "Sonar way", "language": "java", "isBuiltIn": true},
+			},
+		})
+	})
+	mux.HandleFunc("GET /api/rules/search", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("qprofile"); got != "tgtprof1" {
+			t.Errorf("expected qprofile=tgtprof1, got %q", got)
+		}
+		// SonarQube Cloud's real shape: flat top-level "total", no
+		// "paging" object (see TestRunCompareBuiltInProfilesPaginatesTargetRules).
+		json.NewEncoder(w).Encode(map[string]any{
+			"total": 2,
+			"rules": []map[string]any{
+				{"key": "java:S2"},
+				{"key": "java:S4"},
+			},
+		})
+	})
+	addDefaultCloudHandler(mux)
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
+		{"server_url": testServerURL, "sonarcloud_org_key": testCloudOrg},
+	})
+
+	if err := runCompareBuiltInProfiles(context.Background(), e); err != nil {
+		t.Fatalf("runCompareBuiltInProfiles: %v", err)
+	}
+
+	items, err := e.Store.ReadAll("compareBuiltInProfiles")
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected exactly 1 diff record (built-in only), got %d: %v", len(items), items)
+	}
+
+	var got BuiltInProfileDiff
+	if err := json.Unmarshal(items[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Name != "Sonar way" || got.Language != "java" {
+		t.Errorf("unexpected identity: %+v", got)
+	}
+	if got.RulesAdded != 1 {
+		t.Errorf("RulesAdded: got %d want 1", got.RulesAdded)
+	}
+	if got.RulesRemoved != 2 {
+		t.Errorf("RulesRemoved: got %d want 2", got.RulesRemoved)
+	}
+	if got.ServerURL != testServerURL {
+		t.Errorf("ServerURL: got %q want %q", got.ServerURL, testServerURL)
+	}
+}
+
+// TestRunCompareBuiltInProfilesNoTargetMatch: when the target org has no
+// built-in profile for the source's language, no diff record is emitted —
+// the report row keeps its default "Built-in, not migrated" text.
+func TestRunCompareBuiltInProfilesNoTargetMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+
+	writeJSONL(filepath.Join(dir, "extract-01", "getProfiles"), []map[string]any{
+		{"key": "srcprof1", "name": "Sonar way", "language": "python", "isBuiltIn": true},
+	})
+	writeJSONL(filepath.Join(dir, "extract-01", "getActiveProfileRules"), []map[string]any{
+		{"key": "python:S1", "profileKey": "srcprof1"},
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualityprofiles/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"profiles": []map[string]any{
+				{"key": "tgtprof1", "name": "Sonar way", "language": "java", "isBuiltIn": true},
+			},
+		})
+	})
+	addDefaultCloudHandler(mux)
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
+		{"server_url": testServerURL, "sonarcloud_org_key": testCloudOrg},
+	})
+
+	if err := runCompareBuiltInProfiles(context.Background(), e); err != nil {
+		t.Fatalf("runCompareBuiltInProfiles: %v", err)
+	}
+
+	items, err := e.Store.ReadAll("compareBuiltInProfiles")
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected no diff record when no target language match, got %d: %v", len(items), items)
+	}
+}
+
+// TestRunCompareBuiltInProfilesMultiOrgFanOut reproduces the real-world
+// setup that made compareBuiltInProfiles emit nothing: one source SQS
+// server bound to several target orgs (GitHub, GitLab, a consolidated
+// "others" org) PLUS a trailing organizations.csv row for an unbound ALM
+// (no sonarcloud_org_key at all, e.g. an unbound Bitbucket Server). Naively
+// keeping the LAST generateOrganizationMappings row per server_url (as
+// buildServerOrgLookup does) picks that empty-org row and the whole
+// comparison silently no-ops. firstValidOrgPerServer must skip the empty
+// row and use one of the bound orgs instead.
+func TestRunCompareBuiltInProfilesMultiOrgFanOut(t *testing.T) {
+	dir := t.TempDir()
+	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+
+	writeJSONL(filepath.Join(dir, "extract-01", "getProfiles"), []map[string]any{
+		{"key": "srcprof1", "name": "Sonar way", "language": "python", "isBuiltIn": true},
+	})
+	writeJSONL(filepath.Join(dir, "extract-01", "getActiveProfileRules"), []map[string]any{
+		{"key": "python:S1", "profileKey": "srcprof1"},
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualityprofiles/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"profiles": []map[string]any{
+				{"key": "tgtprof1", "name": "Sonar way", "language": "python", "isBuiltIn": true},
+			},
+		})
+	})
+	mux.HandleFunc("GET /api/rules/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"total": 2,
+			"rules": []map[string]any{
+				{"key": "python:S1"},
+				{"key": "python:S2"},
+			},
+		})
+	})
+	addDefaultCloudHandler(mux)
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	// Mirrors a real organizations.csv fan-out: several bound orgs from the
+	// same source server, then a trailing unbound-ALM row with no target
+	// org at all — the exact shape that made buildServerOrgLookup pick "".
+	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
+		{"server_url": testServerURL, "sonarcloud_org_key": "latest-gh"},
+		{"server_url": testServerURL, "sonarcloud_org_key": "latest-others"},
+		{"server_url": testServerURL, "sonarcloud_org_key": ""},
+	})
+
+	if err := runCompareBuiltInProfiles(context.Background(), e); err != nil {
+		t.Fatalf("runCompareBuiltInProfiles: %v", err)
+	}
+
+	items, err := e.Store.ReadAll("compareBuiltInProfiles")
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected exactly 1 diff record despite multi-org fan-out, got %d: %v", len(items), items)
+	}
+	var got BuiltInProfileDiff
+	if err := json.Unmarshal(items[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.RulesAdded != 1 {
+		t.Errorf("RulesAdded: got %d want 1", got.RulesAdded)
+	}
+}
+
+// TestRunCompareBuiltInProfilesMultipleBuiltInsSameLanguage reproduces a
+// real-world report bug: a platform can ship more than one built-in
+// profile for the same language (e.g. "Sonar way" and "Sonar agentic AI",
+// both isBuiltIn=true for java). Matching the target profile by language
+// alone pairs every source built-in of that language against whichever
+// target built-in happens to come first in the search results — here,
+// asserting each source profile is diffed against its OWN like-named
+// target counterpart, not a shared/wrong one.
+func TestRunCompareBuiltInProfilesMultipleBuiltInsSameLanguage(t *testing.T) {
+	dir := t.TempDir()
+	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+
+	writeJSONL(filepath.Join(dir, "extract-01", "getProfiles"), []map[string]any{
+		{"key": "srcway", "name": "Sonar way", "language": "java", "isBuiltIn": true},
+		{"key": "srcai", "name": "Sonar agentic AI", "language": "java", "isBuiltIn": true},
+	})
+	writeJSONL(filepath.Join(dir, "extract-01", "getActiveProfileRules"), []map[string]any{
+		{"key": "java:S1", "profileKey": "srcway"},
+		{"key": "java:S2", "profileKey": "srcway"},
+		{"key": "java:S3", "profileKey": "srcway"},
+		{"key": "java:S1", "profileKey": "srcai"},
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualityprofiles/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"profiles": []map[string]any{
+				// "Sonar agentic AI" listed FIRST on purpose — a
+				// language-only match would wrongly latch onto this one
+				// for the "Sonar way" source profile too.
+				{"key": "tgtai", "name": "Sonar agentic AI", "language": "java", "isBuiltIn": true},
+				{"key": "tgtway", "name": "Sonar way", "language": "java", "isBuiltIn": true},
+			},
+		})
+	})
+	mux.HandleFunc("GET /api/rules/search", func(w http.ResponseWriter, r *http.Request) {
+		var rules []map[string]any
+		switch r.URL.Query().Get("qprofile") {
+		case "tgtway":
+			rules = []map[string]any{{"key": "java:S1"}, {"key": "java:S2"}, {"key": "java:S4"}}
+		case "tgtai":
+			rules = []map[string]any{{"key": "java:S1"}}
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"total": len(rules),
+			"rules": rules,
+		})
+	})
+	addDefaultCloudHandler(mux)
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
+		{"server_url": testServerURL, "sonarcloud_org_key": testCloudOrg},
+	})
+
+	if err := runCompareBuiltInProfiles(context.Background(), e); err != nil {
+		t.Fatalf("runCompareBuiltInProfiles: %v", err)
+	}
+
+	items, err := e.Store.ReadAll("compareBuiltInProfiles")
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 diff records, got %d: %v", len(items), items)
+	}
+	byName := map[string]BuiltInProfileDiff{}
+	for _, raw := range items {
+		var d BuiltInProfileDiff
+		if err := json.Unmarshal(raw, &d); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		byName[d.Name] = d
+	}
+	way := byName["Sonar way"]
+	// source {S1,S2,S3} vs target {S1,S2,S4}: 1 added (S4), 1 removed (S3).
+	if way.RulesAdded != 1 || way.RulesRemoved != 1 {
+		t.Errorf("Sonar way: got added=%d removed=%d, want added=1 removed=1", way.RulesAdded, way.RulesRemoved)
+	}
+	ai := byName["Sonar agentic AI"]
+	// source {S1} vs target {S1}: identical.
+	if ai.RulesAdded != 0 || ai.RulesRemoved != 0 {
+		t.Errorf("Sonar agentic AI: got added=%d removed=%d, want added=0 removed=0", ai.RulesAdded, ai.RulesRemoved)
+	}
+}
+
+// TestRunCompareBuiltInProfilesPaginatesTargetRules reproduces the bug
+// behind wrong added/removed counts on large built-in profiles (e.g. java
+// "Sonar way", 600+ rules): SonarQube Cloud's api/rules/search responds
+// with a flat top-level "total" and no "paging" object at all — unlike
+// SonarQube Server, which nests it under "paging.total" (the
+// PaginatedOpts default). Without TotalKey:"total", ExtractTotal reads 0
+// from the Cloud response, GetPaginated computes 0 pages, and silently
+// stops after page 1 (capped at ps=500) — undercounting any profile with
+// more than 500 active rules. This profile has 3 pages of 500/500/1.
+func TestRunCompareBuiltInProfilesPaginatesTargetRules(t *testing.T) {
+	dir := t.TempDir()
+	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+
+	writeJSONL(filepath.Join(dir, "extract-01", "getProfiles"), []map[string]any{
+		{"key": "srcprof1", "name": "Sonar way", "language": "java", "isBuiltIn": true},
+	})
+	// Source has 500 of the target's rules plus one the target dropped.
+	var sourceRules []map[string]any
+	for i := 0; i < 500; i++ {
+		sourceRules = append(sourceRules, map[string]any{"key": fmt.Sprintf("java:S%d", i), "profileKey": "srcprof1"})
+	}
+	sourceRules = append(sourceRules, map[string]any{"key": "java:REMOVED", "profileKey": "srcprof1"})
+	writeJSONL(filepath.Join(dir, "extract-01", "getActiveProfileRules"), sourceRules)
+
+	// Target has the same 500 plus 501 new ones, spread across 3 pages of
+	// up to 500 each (1001 rules total) to exercise real multi-page fetch.
+	const targetTotal = 1001
+	var targetRules []map[string]any
+	for i := 0; i < 500; i++ {
+		targetRules = append(targetRules, map[string]any{"key": fmt.Sprintf("java:S%d", i)})
+	}
+	for i := 0; i < targetTotal-500; i++ {
+		targetRules = append(targetRules, map[string]any{"key": fmt.Sprintf("java:NEW%d", i)})
+	}
+	if len(targetRules) != targetTotal {
+		t.Fatalf("test setup: built %d target rules, want %d", len(targetRules), targetTotal)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualityprofiles/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"profiles": []map[string]any{
+				{"key": "tgtprof1", "name": "Sonar way", "language": "java", "isBuiltIn": true},
+			},
+		})
+	})
+	mux.HandleFunc("GET /api/rules/search", func(w http.ResponseWriter, r *http.Request) {
+		page, _ := strconv.Atoi(r.URL.Query().Get("p"))
+		if page < 1 {
+			page = 1
+		}
+		const pageSize = 500
+		start := (page - 1) * pageSize
+		end := start + pageSize
+		if end > len(targetRules) {
+			end = len(targetRules)
+		}
+		var pageRules []map[string]any
+		if start < len(targetRules) {
+			pageRules = targetRules[start:end]
+		}
+		// Real SonarQube Cloud shape: flat "total", NO "paging" wrapper.
+		json.NewEncoder(w).Encode(map[string]any{
+			"total": targetTotal,
+			"p":     page,
+			"ps":    pageSize,
+			"rules": pageRules,
+		})
+	})
+	addDefaultCloudHandler(mux)
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
+		{"server_url": testServerURL, "sonarcloud_org_key": testCloudOrg},
+	})
+
+	if err := runCompareBuiltInProfiles(context.Background(), e); err != nil {
+		t.Fatalf("runCompareBuiltInProfiles: %v", err)
+	}
+
+	items, err := e.Store.ReadAll("compareBuiltInProfiles")
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 diff record, got %d: %v", len(items), items)
+	}
+	var got BuiltInProfileDiff
+	if err := json.Unmarshal(items[0], &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// source={S0..S499, REMOVED} (501), target={S0..S499, NEW0..NEW500} (1001).
+	// added = 501 (NEW0..NEW500), removed = 1 (REMOVED).
+	if got.RulesAdded != 501 {
+		t.Errorf("RulesAdded: got %d want 501 (pagination truncation would report far fewer)", got.RulesAdded)
+	}
+	if got.RulesRemoved != 1 {
+		t.Errorf("RulesRemoved: got %d want 1", got.RulesRemoved)
+	}
+}
+
+func TestDiffRuleKeySets(t *testing.T) {
+	source := map[string]bool{"a": true, "b": true, "c": true}
+	target := map[string]bool{"b": true, "d": true}
+
+	added, removed := diffRuleKeySets(source, target)
+	if added != 1 {
+		t.Errorf("added: got %d want 1", added)
+	}
+	if removed != 2 {
+		t.Errorf("removed: got %d want 2", removed)
+	}
+}

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -888,7 +888,12 @@ func dropFailuresAlreadySucceeded(failed, succeeded []EntityItem) []EntityItem {
 	}
 	out := failed[:0:0]
 	for _, f := range failed {
-		if ok[f.Name+"\x00"+f.Organization] {
+		// Only a create that recovered from an "already exists" 400 is safe
+		// to drop. Any other error is a genuine failure that may belong to a
+		// different entity sharing the name (requests.log rows carry no
+		// language, so "All rules"/java collides with "All rules"/php).
+		if ok[f.Name+"\x00"+f.Organization] &&
+			strings.Contains(strings.ToLower(f.ErrorMessage), "already exists") {
 			continue
 		}
 		out = append(out, f)

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -591,6 +591,7 @@ func collectSection(store *common.DataStore, def sectionDef,
 	succeeded := collectSucceeded(store, def)
 	skipped := collectSkipped(store, def)
 	failed := collectFailed(failuresByType, def)
+	failed = dropFailuresAlreadySucceeded(failed, succeeded)
 	attachFailedSourceKeys(failed, store, def)
 
 	// #525: createProjects can diagnose some failures precisely (a target
@@ -773,6 +774,11 @@ func collectExtractSkipped(def sectionDef, exportDir string,
 	}
 
 	mappedKeys := buildMappedKeys(def, store)
+	// Only ever populated for the Quality Profiles section, and only by a
+	// real migrate run — the predictive report's synthetic run directory
+	// never writes this sidecar (#309), so builtInDiffs is nil there and
+	// every built-in row keeps the static text below.
+	builtInDiffs := readBuiltInProfileDiffs(store)
 
 	var result []EntityItem
 	seen := make(map[string]bool)
@@ -790,10 +796,14 @@ func collectExtractSkipped(def sectionDef, exportDir string,
 		seen[key] = true
 
 		if isBuiltIn {
+			detail := "Built-in, not migrated"
+			if d, ok := builtInDiffs[item.ServerURL+"|"+name+"|"+language]; ok {
+				detail = formatBuiltInProfileDiff(d.RulesAdded, d.RulesRemoved)
+			}
 			result = append(result, EntityItem{
 				Name:       name,
 				Language:   language,
-				Detail:     "Built-in, not migrated",
+				Detail:     detail,
 				SkipReason: SkipReasonBuiltIn,
 			})
 			continue
@@ -857,6 +867,33 @@ func collectFailed(failuresByType map[string][]analysis.ReportRow, def sectionDe
 		})
 	}
 	return result
+}
+
+// dropFailuresAlreadySucceeded removes requests.log-derived failure rows
+// for an entity (matched by Name+Organization) that also has a row in
+// Succeeded. The generic requests.log scan (collectFailed) has no idea a
+// create task recovered from a 400 — either via its own lookup-and-reuse
+// fallback (createProfiles' "already exists" handling) or because #165's
+// fan-in de-dup already collapsed several source-org attempts targeting
+// the same cloud entity onto one successful row — so without this it
+// reports one Failed row per recovered attempt for an entity that is, in
+// the end, correctly migrated and already listed as Succeeded.
+func dropFailuresAlreadySucceeded(failed, succeeded []EntityItem) []EntityItem {
+	if len(failed) == 0 || len(succeeded) == 0 {
+		return failed
+	}
+	ok := make(map[string]bool, len(succeeded))
+	for _, s := range succeeded {
+		ok[s.Name+"\x00"+s.Organization] = true
+	}
+	out := failed[:0:0]
+	for _, f := range failed {
+		if ok[f.Name+"\x00"+f.Organization] {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
 }
 
 // collectExplicitFailures reads def.OutputTask for records the task itself

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -129,6 +129,73 @@ func TestCollectSummaryDedupesDuplicateCreates(t *testing.T) {
 	}
 }
 
+// TestCollectSummaryDropsFailuresAlreadySucceeded reproduces the report
+// bug found alongside #309: a source server fanning three source orgs
+// into one target org ("latest-others") makes createProfiles attempt the
+// same (org, name, language) create three times. The first POST succeeds;
+// the other two get a 400 "already exists", which createProfiles recovers
+// from via lookup-and-reuse — all three end up as ONE deduped Succeeded
+// row (#165). But requests.log's generic HTTP-status scan has no idea
+// that happened, so without a fix it renders 2 spurious duplicate Failed
+// rows for an entity that is, in fact, migrated and already listed as
+// Succeeded.
+func TestCollectSummaryDropsFailuresAlreadySucceeded(t *testing.T) {
+	dir := t.TempDir()
+
+	writeTaskJSONL(t, dir, "createProfiles", []map[string]any{
+		{"name": "All rules", "language": "php", "sonarcloud_org_key": "latest-others", "cloud_profile_key": "cp-1"},
+	})
+
+	logLine := func(status int, respFailure bool) map[string]any {
+		entry := map[string]any{
+			"process_type": "request_completed",
+			"payload": map[string]any{
+				"method": "POST",
+				"url":    "/api/qualityprofiles/create",
+				"status": float64(status),
+				"data": map[string]any{
+					"name": "All rules", "language": "php", "organization": "latest-others",
+				},
+			},
+		}
+		if respFailure {
+			entry["status"] = "failure"
+			entry["payload"].(map[string]any)["response"] = `{"errors":[{"msg":"Quality profile already exists: php/All rules"}]}`
+		} else {
+			entry["status"] = "success"
+		}
+		return entry
+	}
+
+	var lines []string
+	for _, e := range []map[string]any{
+		logLine(200, false),
+		logLine(400, true),
+		logLine(400, true),
+	} {
+		b, _ := json.Marshal(e)
+		lines = append(lines, string(b))
+	}
+	if err := os.WriteFile(filepath.Join(dir, "requests.log"), []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+		t.Fatalf("write requests.log: %v", err)
+	}
+
+	summary, err := CollectSummary(dir, "")
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	profiles := findSection(summary, "Quality Profiles")
+	if profiles == nil {
+		t.Fatal("missing Quality Profiles section")
+	}
+	if len(profiles.Succeeded) != 1 {
+		t.Errorf("expected 1 succeeded profile, got %d: %+v", len(profiles.Succeeded), profiles.Succeeded)
+	}
+	if len(profiles.Failed) != 0 {
+		t.Errorf("expected 0 failed rows once the entity is confirmed Succeeded, got %d: %+v", len(profiles.Failed), profiles.Failed)
+	}
+}
+
 func TestCollectSummaryWithProjectData(t *testing.T) {
 	dir := t.TempDir()
 
@@ -327,6 +394,89 @@ func TestCollectSummaryProfileBuiltInAndUnused(t *testing.T) {
 	// Custom/js and Unused/java are both unused.
 	if counts[SkipReasonUnused] != 2 {
 		t.Errorf("expected 2 unused profiles skipped, got %d", counts[SkipReasonUnused])
+	}
+	for _, item := range profiles.Skipped {
+		if item.SkipReason == SkipReasonBuiltIn && item.Detail != "Built-in, not migrated" {
+			t.Errorf("expected default built-in text with no compareBuiltInProfiles sidecar, got %q", item.Detail)
+		}
+	}
+}
+
+// TestCollectSummaryProfileBuiltInRuleDiff covers issue #309: when a real
+// migrate run's compareBuiltInProfiles sidecar reports a rule delta for a
+// built-in profile, the skipped row's Detail carries the human-readable
+// added/removed counts instead of the static default text.
+func TestCollectSummaryProfileBuiltInRuleDiff(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	os.MkdirAll(runDir, 0o755)
+
+	serverURL := "https://sq.example.com"
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
+	writeExtractMeta(t, extractDir, serverURL)
+	writeTaskJSONL(t, extractDir, "getProfiles", []map[string]any{
+		{"name": "Sonar way", "language": "java", "isBuiltIn": true},
+	})
+	writeTaskJSONL(t, runDir, "compareBuiltInProfiles", []map[string]any{
+		{"server_url": serverURL, "name": "Sonar way", "language": "java",
+			"rules_added": 3, "rules_removed": 0},
+	})
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+
+	profiles := findSection(summary, "Quality Profiles")
+	if profiles == nil {
+		t.Fatal("missing Quality Profiles section")
+	}
+	if len(profiles.Skipped) != 1 {
+		t.Fatalf("expected 1 skipped row, got %d: %+v", len(profiles.Skipped), profiles.Skipped)
+	}
+	// Added-only must never mention "0 removed".
+	if want := "3 rule(s) added"; profiles.Skipped[0].Detail != want {
+		t.Errorf("Detail: got %q want %q", profiles.Skipped[0].Detail, want)
+	}
+	if profiles.Skipped[0].SkipReason != SkipReasonBuiltIn {
+		t.Errorf("expected SkipReasonBuiltIn, got %q", profiles.Skipped[0].SkipReason)
+	}
+}
+
+// TestCollectSummaryProfileBuiltInIdenticalHasEmptyDetail: identical
+// source/target built-in rule sets must render an empty Detail (#309),
+// not the old static "Built-in, not migrated" text.
+func TestCollectSummaryProfileBuiltInIdenticalHasEmptyDetail(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	os.MkdirAll(runDir, 0o755)
+
+	serverURL := "https://sq.example.com"
+	extractDir := filepath.Join(dir, "2026-08-20-0001")
+	writeExtractMeta(t, extractDir, serverURL)
+	writeTaskJSONL(t, extractDir, "getProfiles", []map[string]any{
+		{"name": "Sonar way", "language": "java", "isBuiltIn": true},
+	})
+	writeTaskJSONL(t, runDir, "compareBuiltInProfiles", []map[string]any{
+		{"server_url": serverURL, "name": "Sonar way", "language": "java",
+			"rules_added": 0, "rules_removed": 0},
+	})
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	profiles := findSection(summary, "Quality Profiles")
+	if profiles == nil {
+		t.Fatal("missing Quality Profiles section")
+	}
+	if len(profiles.Skipped) != 1 {
+		t.Fatalf("expected 1 skipped row, got %d: %+v", len(profiles.Skipped), profiles.Skipped)
+	}
+	if profiles.Skipped[0].Detail != "" {
+		t.Errorf("expected empty Detail for identical built-in profiles, got %q", profiles.Skipped[0].Detail)
 	}
 }
 

--- a/go/internal/report/summary/profile_notes.go
+++ b/go/internal/report/summary/profile_notes.go
@@ -239,6 +239,56 @@ func applyProfileFindings(succeeded, nearPerfect, partial []EntityItem, findings
 	return keep, nearPerfect, partial
 }
 
+// builtInProfileDiff mirrors migrate.BuiltInProfileDiff for the read-side
+// (#309). Keeping a separate copy avoids a summary → migrate import flip,
+// same rationale as profileFinding above.
+type builtInProfileDiff struct {
+	ServerURL    string `json:"server_url"`
+	Name         string `json:"name"`
+	Language     string `json:"language"`
+	RulesAdded   int    `json:"rules_added"`
+	RulesRemoved int    `json:"rules_removed"`
+}
+
+// readBuiltInProfileDiffs reads the compareBuiltInProfiles JSONL sidecar
+// (only ever written by a real migrate run — never by the predictive
+// report's synthetic run directory) and keys each record the same way
+// collectExtractSkipped's own dedup key is built: serverURL+"|"+name+"|"+language.
+func readBuiltInProfileDiffs(store *common.DataStore) map[string]builtInProfileDiff {
+	items, err := store.ReadAll("compareBuiltInProfiles")
+	if err != nil || len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]builtInProfileDiff, len(items))
+	for _, raw := range items {
+		var d builtInProfileDiff
+		if err := json.Unmarshal(raw, &d); err != nil {
+			continue
+		}
+		if d.Name == "" || d.Language == "" {
+			continue
+		}
+		out[d.ServerURL+"|"+d.Name+"|"+d.Language] = d
+	}
+	return out
+}
+
+// formatBuiltInProfileDiff renders the rules-added/removed counts for a
+// built-in quality profile's Detail column (#309): empty when the source
+// and target rule sets are identical, and never mentions a zero count.
+func formatBuiltInProfileDiff(added, removed int) string {
+	switch {
+	case added == 0 && removed == 0:
+		return ""
+	case removed == 0:
+		return fmt.Sprintf("%d rule(s) added", added)
+	case added == 0:
+		return fmt.Sprintf("%d rule(s) removed", removed)
+	default:
+		return fmt.Sprintf("%d rule(s) added, %d rule(s) removed", added, removed)
+	}
+}
+
 // Profile finding kind constants used throughout profile_notes.go.
 const (
 	kindTemplateInstance  = "template-instance"

--- a/go/internal/report/summary/profile_notes_builtin_test.go
+++ b/go/internal/report/summary/profile_notes_builtin_test.go
@@ -1,0 +1,27 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package summary
+
+import "testing"
+
+func TestFormatBuiltInProfileDiff(t *testing.T) {
+	cases := []struct {
+		name           string
+		added, removed int
+		want           string
+	}{
+		{"identical", 0, 0, ""},
+		{"added only", 5, 0, "5 rule(s) added"},
+		{"removed only", 0, 3, "3 rule(s) removed"},
+		{"both", 5, 3, "5 rule(s) added, 3 rule(s) removed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatBuiltInProfileDiff(tc.added, tc.removed); got != tc.want {
+				t.Errorf("formatBuiltInProfileDiff(%d, %d) = %q, want %q", tc.added, tc.removed, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Closes #309: during `migrate`, compare each source built-in quality profile against its matching target built-in profile and report the rules added/removed in the Quality Profiles section's Skipped `Detail` column (empty when identical, no "0 removed" when only additions exist, status stays Skipped). The predictive report is unaffected since the comparison needs live target-side data it doesn't have.
- Fixes three additional bugs surfaced while testing this against a real multi-org migration (`config-ee.json`):
  - **Org lookup picked the wrong/empty org**: the live-comparison org lookup kept whatever `generateOrganizationMappings` row came last for a given source server, including unbound/empty ones, silently dropping every comparison when one source server fans out to several target orgs.
  - **Duplicate "Failed" QP rows**: the `requests.log`-derived Failed bucket had no dedup and no awareness that `createProfiles` already recovers from an "already exists" 400 (the #165 fan-in case), so it rendered one duplicate Failed row per recovered attempt for entities that were, in fact, successfully migrated and already listed as Succeeded.
  - **Wrong target profile matched**: matching only checked `isBuiltIn` + `language`, so a platform shipping more than one built-in profile per language (e.g. "Sonar way" and "Sonar agentic AI" for java) paired every source built-in of that language against whichever target one happened to come first in the search results.
  - **Silent truncation past 500 rules**: SonarQube Cloud's `api/rules/search` responds with a flat top-level `total` field, not the `paging.total` the pagination helper defaults to (SonarQube Server nests it under `paging.total` too), so any built-in profile with more than 500 active rules was silently truncated to its first page.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (full module, no regressions)
- [x] New regression tests: multi-org fan-out org lookup, requests.log Failed-vs-Succeeded dedup, multiple-built-ins-per-language matching, and target rule-fetch pagination (verified this last one fails without the fix, then passes with it)
- [x] Verified end-to-end against a real migrate run (`config-ee.json`): re-ran `--target_task compareBuiltInProfiles`, confirmed correct added/removed counts for java "Sonar way" and cross-checked against the live SonarQube Cloud API directly
